### PR TITLE
Dependabot の PR 運用とインストール失敗時の CI の扱いを直す

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,9 +17,22 @@ updates:
         dependency-type: production
         update-types:
           - patch
+    ignore:
+      # typescript 7 は typescript-eslint の peer 依存（>=4.8.4 <6.1.0）を満たさず、
+      # npm ci が ERESOLVE で必ず失敗する。毎週赤い PR が来ると
+      # 「Dependabot の PR は赤いもの」と学習してしまうので止めておく。
+      # **解除の条件と手順は #25 に書いた。上げるときはこの ignore も消す。**
+      - dependency-name: typescript
+        update-types:
+          - version-update:semver-major
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
       day: monday
+    # actions ごとに PR が立つと数が増えるため、1本にまとめる
+    groups:
+      github-actions:
+        patterns:
+          - '*'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,28 +20,33 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v7
         with:
           # .node-version を唯一の情報源にする。ここに数字を書かない
           node-version-file: .node-version
           cache: npm
 
-      - run: npm ci
+      - name: install
+        id: install
+        run: npm ci
 
-      # 1つ落ちても残りを実行する。全部の失敗を1回の実行で把握できるようにするため
+      # チェックは1つ落ちても残りを実行する。全部の失敗を1回の実行で把握できるようにするため
       # （ジョブを分けると依存のインストールが回数分かかる）。
+      #
+      # ただし install が失敗した実行では skip する。依存が入っていない状態の結果は
+      # 信号として無意味で、読む側を混乱させる（#26）。
       - name: typecheck
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.install.outcome == 'success' }}
         run: npm run typecheck
 
       - name: lint
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.install.outcome == 'success' }}
         run: npm run lint
 
       - name: format
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.install.outcome == 'success' }}
         run: npm run format:check
 
       - name: test
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.install.outcome == 'success' }}
         run: npm test


### PR DESCRIPTION
Closes #26 / Refs #22 #23 #25

#12 で CI と Dependabot を入れた直後に届いた実際の PR 3本（#21 #22 #23）から出た問題への対応。

## 1. インストールが失敗した実行で `typecheck` が緑になっていた

`npm ci` が ERESOLVE で落ちた実行（run `31063937983`）の結果:

```
failure  npm ci
success  typecheck   ← 依存が入っていないのに緑
failure  lint        （eslint: not found）
failure  format      （prettier: not found）
success  test
```

ジョブ全体は failure なので事故には至っていないが、この緑は信号として無意味。
`if: ${{ !cancelled() }}` を付けた狙いは「lint と test の失敗を同時に見る」ことで、
インストール失敗後も走らせることではなかった。

`npm ci` に `id: install` を付け、後続のチェックを `steps.install.outcome == 'success'` で条件付けた。

## 2. `actions/setup-node` を v7 に上げた（#22 の取り込み）

#22 を単体でマージできなかった理由:

- ルールセットで strict なステータスチェックを必須にしているため `main` への追随が必要
- #21 のマージで `main` の `ci.yml` が変わり、追随が workflow ファイルの更新を伴うようになった
- そのため `gh pr update-branch` が **`workflow` scope 不足**で拒否された

```
GraphQL: refusing to allow an OAuth App to create or update workflow `.github/workflows/ci.yml` without `workflow` scope
```

`ci.yml` はこの PR でどちらにしても触るので、一緒に上げた。

## 3. `github-actions` の更新を1本の PR にまとめた

`actions/checkout` と `actions/setup-node` で別々に PR が立った（#21 #22）。
数が増えると見なくなるため `patterns: ['*']` でグループ化した。

## 4. `typescript` の major を無視する

#23 は `typescript-eslint@8.66.0` の peer 依存（`>=4.8.4 <6.1.0`）を満たさないため、
**何度出しても必ず ERESOLVE で落ちる。** 毎週赤い PR が来ると
「Dependabot の PR は赤いもの」と学習してしまうので止めた。

**解除の条件と手順は #25 に記録した**（`ignore` を消すことも手順に含めた。忘れると通知が来なくなる）。

## 補足: TypeScript 6.0.3 は事故ではない

`npm install -D typescript` で `latest` の 7.0.2 ではなく 6.0.3 が入ったのは、
npm が typescript-eslint の peer 制約を守って落としていたため。**正しい解決結果**。
