### PR TITLE
Deno Deploy 側のディレクトリ名を apps/image から apps/render にする

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,15 @@
 ```
 apps/
   web/        Cloudflare Workers（Hono + React SPA + D1）
-  image/      Deno Deploy（Satori による画像生成）  ← 未作成
+  render/     Deno Deploy（Satori による画像生成）  ← 未作成
 packages/
   shared/     型・Zod スキーマ・定数
 ```
 
-`apps/image` は OGP 画像に着手する時点で作る
+`apps/render` は OGP 画像に着手する時点で作る
 （Deno なので、npm workspaces に含めるかは `TECH_STACK.md` §12-2 の結論次第）。
+**ディレクトリ名は Deno Deploy のアプリ名 `yaritai100list-render` に合わせている**
+（`docs/console-settings.md`）。`image` にしないのは、PNG 以外の出力が来たときに名前がズレるため。
 
 デプロイ先は2つだが、**リポジトリは1つ**にする。
 分けると、どのリポジトリが生きているのかを追えなくなる。


### PR DESCRIPTION
Deno Deploy のアプリ名は **`yaritai100list-render`** に決めてある（#1、`docs/console-settings.md`）のに、
README の構成図だけ `apps/image` のままだった。

`image` を避ける理由はアプリ名を決めたときと同じで、**PNG 以外の出力が来たときに名前がズレる**から。
OGP 画像（#8）とダウンロード画像（#9）を同じパイプラインに載せる方針なので、
フォーマットに縛られない名前にしておきたい。

ディレクトリはまだ存在しないため、**作る前に揃えておく**のが一番安い。

あわせて、ディレクトリ名がアプリ名に由来することを README に明記した。
理由が書いていないと、次のセッションで「`image` の方が分かりやすい」と戻されうるため。

🤖 Generated with [Claude Code](https://claude.com/claude-code)