### PR TITLE
依存関係を触るときの注意を workflow.md に追加する

### DIFF
--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -89,6 +89,19 @@ push 直後に叩いたときは、`gh run list --branch <branch> --limit 1` で
 - **テストを書かずに機能を入れない。** 特に認可（§6）
 - 1 PR が大きくなりすぎたら、途中で切ってサブイシューを増やす
 
+### 依存関係を触るとき
+
+**`package-lock.json` を作り直さない。** 削除して `npm install` し直すと、
+**この環境では大量の `resolved` / `integrity` が失われる**（実測: 3120行削除・553行追加、
+解決されるバージョンは同一）。integrity が無い lock は供給元の検証ができなくなるので、
+作り直してしまったら `git checkout package-lock.json` で戻して `npm ci` する。
+
+依存を足すときは `npm install --workspace <名前> <パッケージ>` を使う（lock は差分更新される）。
+
+**`overrides` は効かない。** npm 11.3.0 では、`overrides` を書き換えても再解決の理由として
+検出されない（あり得ないバージョンを指定しても `up to date` で通過する）。
+lock を作り直しても honor されなかった。**推移的な依存のバージョンを強制する手段は無いものとして扱う**（#29）。
+
 **例外はない。ドキュメントのみの変更も PR を通す。**
 `main` にはルールセットが設定されており（`docs/console-settings.md`）、
 PR 必須・CI 必須・force push 禁止で、**bypass できるアクターもいない**。


### PR DESCRIPTION
Refs #29

#29（`npm audit` の high を `overrides` で解消する）を試した結果、**解消できなかった。**
代わりに、試す過程で見つけた2つの罠を手順書に残す。コードの変更はない。

## 1. `overrides` が効かない

npm 11.3.0 は **`overrides` の変更を再解決の理由として検出しない。**
切り分けとして、あり得ないバージョンを指定してみたところエラーにもならなかった:

```
$ npm pkg set 'overrides.undici=^99.0.0' && npm install --package-lock-only --dry-run
up to date in 161ms
```

`package-lock.json` を削除して作り直しても `overrides` は lock に記録されず、
`npm explain undici` にも痕跡が出ず、`undici` は 7.28.0 のままだった。

## 2. `package-lock.json` を作り直すと integrity が失われる

上記の切り分けで lock を作り直した結果:

```
package-lock.json | 3673 +++++-------------------------
1 file changed, 553 insertions(+), 3120 deletions(-)
```

**解決されるバージョンは主要な依存すべてで同一**（vitest / vite / wrangler / miniflare /
hono / drizzle / typescript / eslint / prettier / zod）。減った 3120 行の大半は
`resolved` と `integrity` で、この環境のレジストリ経路ではメタデータが落ちるらしい。

**integrity の無い lock は供給元の検証ができなくなる**ため、`git checkout package-lock.json` で
戻して `npm ci` し直した。この PR の差分に lock は含まれていない。

## #29 の扱い

`undici` の high は残る。イシュー側に結論を書いてクローズする:

- 影響範囲は**開発依存のみ**（`undici` ← `miniflare` ← `wrangler`）。
  miniflare はローカルの Workers 実行環境で、**デプロイされる Worker のバンドルには入らない**
- `miniflare@5.20260801.0-alpha` が `undici@7.28.0` を**完全固定**しているため、
  upstream が上げるまで動かせない
- `npm audit fix` の提案は wrangler の 4.119.0 → 4.35.0 への**ダウングレード**で、採れない

Dependabot が wrangler を上げた時点で自然に解消する見込み。
