### PR TITLE
React + Vite の SPA 配信と Hono RPC の型連携を追加する

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,17 +35,21 @@ Cloudflare のアカウントもログインも不要。すべてローカルで
 ```sh
 npm install
 npm run db:migrate --workspace @yaritai100list/web   # ローカル D1 にマイグレーションを当てる
-npm run dev                                          # http://localhost:8787
+npm run dev                                          # http://localhost:5173
 
 npm run typecheck && npm run lint && npm test        # PR を出す前に緑にする
 ```
 
 | コマンド | 内容 |
 |---|---|
-| `npm run dev` | `wrangler dev`。ローカルの D1 を使う |
+| `npm run dev` | Vite。**SPA と Worker の両方**が1プロセスで動く（Worker は workerd で実行される） |
 | `npm test` | Vitest + Miniflare。workerd の中で走り、D1 はインメモリ |
+| `npm run build --workspace @yaritai100list/web` | `dist/client`（SPA）と `dist/yaritai100list`（Worker）を出す |
 | `npm run db:generate --workspace @yaritai100list/web -- --name <名前>` | スキーマからマイグレーションを生成（**名前は必ず付ける**） |
 | `npm run db:migrate --workspace @yaritai100list/web` | ローカル D1 に適用 |
+
+**Vite の dev サーバーは IPv6（`[::1]`）でだけ listen する。**
+`curl http://127.0.0.1:5173` は接続できないので `localhost` を使う。
 
 **`no such table` が出たら `db:migrate` を忘れている。**
 ローカル D1 の保存先は `wrangler.jsonc` の `database_id` ごとに分かれるため、

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>やりたいことリスト100</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/client/main.tsx"></script>
+  </body>
+</html>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,24 +4,33 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "wrangler dev",
+    "dev": "vite",
     "pretypecheck": "wrangler types",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit && tsc -p src/client --noEmit",
     "cf-typegen": "wrangler types",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "wrangler d1 migrations apply DB --local",
     "db:migrate:remote": "wrangler d1 migrations apply DB --remote",
-    "test": "vitest run"
+    "test": "vitest run",
+    "build": "vite build",
+    "preview": "vite preview"
   },
   "devDependencies": {
+    "@cloudflare/vite-plugin": "^1.51.0",
     "@cloudflare/vitest-pool-workers": "^0.20.2",
+    "@types/react": "^19.2.18",
+    "@types/react-dom": "^19.2.4",
+    "@vitejs/plugin-react": "^6.0.5",
     "drizzle-kit": "^0.31.10",
+    "vite": "^8.2.0",
     "vitest": "^4.1.10",
     "wrangler": "^4.119.0"
   },
   "dependencies": {
     "@yaritai100list/shared": "^0.0.0",
     "drizzle-orm": "^0.45.2",
-    "hono": "^4.13.0"
+    "hono": "^4.13.0",
+    "react": "^19.2.8",
+    "react-dom": "^19.2.8"
   }
 }

--- a/apps/web/src/client/App.tsx
+++ b/apps/web/src/client/App.tsx
@@ -1,0 +1,36 @@
+import { SERVICE_NAME } from '@yaritai100list/shared'
+import { useEffect, useState } from 'react'
+
+import { api } from './api'
+
+/**
+ * 土台の確認用の画面。リストの UI は #4 で作る。
+ *
+ * ここで確かめているのは3つ:
+ * - SPA が Workers から配信されること
+ * - 同一オリジンで API を呼べること（CORS の設定が要らないこと）
+ * - **Hono RPC でサーバーの型がクライアントに流れること**
+ */
+export function App() {
+  const [health, setHealth] = useState<string>('確認中')
+
+  useEffect(() => {
+    const check = async () => {
+      const res = await api.api.health.$get()
+      const data = await res.json()
+
+      // data.status は サーバーの `c.json({ status: 'ok' } as const)` から
+      // 型が流れてきている。サーバー側を変えるとここが型エラーになる
+      setHealth(data.status)
+    }
+
+    void check()
+  }, [])
+
+  return (
+    <main>
+      <h1>{SERVICE_NAME}</h1>
+      <p>API: {health}</p>
+    </main>
+  )
+}

--- a/apps/web/src/client/api.ts
+++ b/apps/web/src/client/api.ts
@@ -1,0 +1,14 @@
+import { hc } from 'hono/client'
+
+import type { AppType } from '../index'
+
+/**
+ * サーバーの型からクライアントを作る（Hono RPC）。
+ *
+ * `AppType` は **`import type` で読む。** `verbatimModuleSyntax` が有効なので
+ * この import はビルド時に消え、**Worker のコードがブラウザのバンドルに入らない。**
+ * `import { type AppType }` ではなく `import type { ... }` と書くこと。
+ *
+ * 同一オリジンで配信されるため、ベース URL は相対でよい（CORS の設定が要らない）。
+ */
+export const api = hc<AppType>('/')

--- a/apps/web/src/client/main.tsx
+++ b/apps/web/src/client/main.tsx
@@ -1,0 +1,13 @@
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+
+import { App } from './App'
+
+const root = document.getElementById('root')
+if (!root) throw new Error('#root が見つからない')
+
+createRoot(root).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+)

--- a/apps/web/src/client/tsconfig.json
+++ b/apps/web/src/client/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx",
+    "types": []
+  },
+
+  // worker-configuration.d.ts を含めている理由:
+  // Hono RPC の `AppType` は `Hono<{ Bindings: Env }, ...>` なので、
+  // 型を辿ると Workers の `Env` に到達する。これを解決できないと
+  // クライアント側の型チェックが通らない。
+  //
+  // 副作用として、クライアントのコードからも Workers のグローバル API が
+  // 型として見えてしまう。逆方向（Worker から DOM が見える）の方が事故が重いので、
+  // Worker 側の tsconfig には DOM を入れていない。
+  "include": [".", "../../worker-configuration.d.ts"]
+}

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -10,5 +10,17 @@
     // 設定用の API なので、これとは別）。
     "types": ["@cloudflare/vitest-pool-workers/types"]
   },
-  "include": ["src", "test", "drizzle.config.ts", "vitest.config.ts", "worker-configuration.d.ts"]
+  "include": [
+    "src",
+    "test",
+    "drizzle.config.ts",
+    "vite.config.ts",
+    "vitest.config.ts",
+    "worker-configuration.d.ts"
+  ],
+
+  // クライアントは別の tsconfig（src/client/tsconfig.json）で見る。
+  // **こちらには DOM を入れていない**ので、Worker のコードで document や window を
+  // 触ると型エラーになる。lib を分けることがその保証になっている。
+  "exclude": ["src/client"]
 }

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,0 +1,15 @@
+import { cloudflare } from '@cloudflare/vite-plugin'
+import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vite'
+
+/**
+ * `vite dev` 一発で **Worker と SPA の両方**が動く。
+ *
+ * Worker のコードは Vite の中で workerd で実行されるため、`wrangler dev` と同じ
+ * ランタイムで確認できる。SPA は HMR が効く。起動するプロセスは1つ。
+ *
+ * バインディング（D1 など）は wrangler.jsonc から読まれる。
+ */
+export default defineConfig({
+  plugins: [react(), cloudflare()],
+})

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -14,6 +14,29 @@
     "enabled": true,
   },
 
+  // SPA を Workers から配信する。ビルド出力のディレクトリは
+  // @cloudflare/vite-plugin が設定するため、ここには書かない。
+  //
+  // not_found_handling: single-page-application は、静的ファイルに当たらない
+  // パスで index.html を返す。これで SPA のクライアントルーティングが動く。
+  //
+  // 🔴 run_worker_first に書いたパスだけが Worker のコードに届く。
+  // **サーバー側で処理するルートを増やすときは、ここにも足すこと。**
+  // 足し忘れると Worker には届かず、SPA の index.html が返る（404 にならないので気づきにくい）。
+  //
+  // 予定しているサーバー側のルート（PRODUCT_SPEC.md §7 の URL 表）:
+  // - /api/*            JSON API・認証のコールバック（このコミットで有効）
+  // - /share/:shareId   共有公開ページの SSR（#7）
+  // - /og/:shareId      OGP 画像（#8）
+  // - /export/:listId   ダウンロード画像（#9）
+  //
+  // 全部を Worker に通す（run_worker_first: true）ことはしない。
+  // 静的ファイルの配信まで Worker の実行回数を消費するため、無料枠に効く。
+  "assets": {
+    "not_found_handling": "single-page-application",
+    "run_worker_first": ["/api/*"],
+  },
+
   "d1_databases": [
     {
       "binding": "DB",

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,11 +29,18 @@
       "dependencies": {
         "@yaritai100list/shared": "^0.0.0",
         "drizzle-orm": "^0.45.2",
-        "hono": "^4.13.0"
+        "hono": "^4.13.0",
+        "react": "^19.2.8",
+        "react-dom": "^19.2.8"
       },
       "devDependencies": {
+        "@cloudflare/vite-plugin": "^1.51.0",
         "@cloudflare/vitest-pool-workers": "^0.20.2",
+        "@types/react": "^19.2.18",
+        "@types/react-dom": "^19.2.4",
+        "@vitejs/plugin-react": "^6.0.5",
         "drizzle-kit": "^0.31.10",
+        "vite": "^8.2.0",
         "vitest": "^4.1.10",
         "wrangler": "^4.119.0"
       }
@@ -62,6 +69,28 @@
         "workerd": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@cloudflare/vite-plugin": {
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/vite-plugin/-/vite-plugin-1.51.0.tgz",
+      "integrity": "sha512-8ltb2RA6U1i7KGDzVsRBDa7+GvWRBNGBx0mjTxdsHh/6zgCcUPLT3I8Kwp/xUkIbInojnwh8GAtnbuLJPfcK6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cloudflare/unenv-preset": "2.16.1",
+        "miniflare": "5.20260801.0-alpha",
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260801.1",
+        "wrangler": "4.119.0",
+        "ws": "8.21.0"
+      },
+      "bin": {
+        "cf-vite": "bin/cf-vite"
+      },
+      "peerDependencies": {
+        "vite": "^6.1.0 || ^7.0.0 || ^8.0.0",
+        "wrangler": "^4.119.0"
       }
     },
     "node_modules/@cloudflare/vitest-pool-workers": {
@@ -2176,6 +2205,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/react": {
+      "version": "19.2.18",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
+      "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.66.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.66.0.tgz",
@@ -2404,6 +2453,32 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.5.tgz",
+      "integrity": "sha512-BOVzne/NL162sMdResB25mUv+vWMF5NoAjNf09TeGlE7ZpszZWSD3winycicLJw72yeVsoCn/2kOhEuCvEShMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rolldown/pluginutils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
+        "babel-plugin-react-compiler": "^1.0.0",
+        "vite": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@rolldown/plugin-babel": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        }
       }
     },
     "node_modules/@vitest/expect": {
@@ -2666,6 +2741,13 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -4372,6 +4454,27 @@
         "node": ">=6"
       }
     },
+    "node_modules/react": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.8"
+      }
+    },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
@@ -4414,6 +4517,12 @@
         "@rolldown/binding-win32-arm64-msvc": "1.2.3",
         "@rolldown/binding-win32-x64-msvc": "1.2.3"
       }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "7.8.5",


### PR DESCRIPTION
Closes #17

## 動作確認

`npm run dev` 一発で SPA と Worker の両方が動く（プロセスは1つ、HMR あり）。

```
GET /            → index.html（SPA、HMR 付き）
GET /api/health  → {"status":"ok"}          Worker
GET /api/health/db → {"status":"ok","db":"ok"}  Worker + D1
GET /lists       → 200 index.html（SPA フォールバック）
GET /api/nope    → 404                      Worker
```

ビルドは `dist/client`（SPA）と `dist/yaritai100list`（Worker + 生成された wrangler.json）。
どちらも gitignore 済み。

### サーバーの型がクライアントに流れることの確認

サーバーのレスポンスを `{ status: 'ok' }` → `{ state: 'ok' }` に変えて型チェックした:

```
src/client/App.tsx(24,22): error TS2339:
  Property 'status' does not exist on type '{ readonly state: "ok"; }'.
```

**サーバーを変えるとクライアントが壊れることが型で分かる。** 確認後に元に戻した。

## 判断したこと

### `run_worker_first` でルートの境界を宣言した

最初 `not_found_handling: single-page-application` だけを設定したところ、
`/lists` が **Hono の 404** を返した。アセット層より先に Worker が動いていたため。

`run_worker_first: ["/api/*"]` を足して、**Worker に届くパスを明示**した。

- `run_worker_first: true`（全部 Worker に通す）にはしなかった。
  静的ファイルの配信まで Worker の実行回数を消費するので、無料枠に効く
- 代わりに**サーバー側のルートを増やすときは wrangler.jsonc にも足す必要がある。**
  足し忘れると Worker に届かず SPA の index.html が返る（404 にならないので気づきにくい）
- そのため、予定しているサーバー側ルート（`/share/:shareId` #7 / `/og/:shareId` #8 /
  `/export/:listId` #9）を wrangler.jsonc のコメントに列挙しておいた

### tsconfig を worker 用と client 用に分けた

**Worker 側に `DOM` を入れていない。** Worker のコードで `document` や `window` を触ると
型エラーになる。これは実行時にしか分からない事故を型で潰すための分離。

分け方は `src/client/tsconfig.json` を置く形にした。typescript-eslint の projectService は
**ファイルから最も近い tsconfig.json** を使うので、ESLint 側に設定を足さずに済む。

トレードオフ: client 側の tsconfig には `worker-configuration.d.ts` を含めている。
Hono RPC の `AppType` は `Hono<{ Bindings: Env }, ...>` なので、型を辿ると Workers の `Env` に
到達し、これを解決できないと client の型チェックが通らない。
結果として **client からは Workers のグローバル API が型として見えてしまう。**
逆方向（Worker から DOM が見える）の方が事故が重いので、この非対称は受け入れた。

### `AppType` は `import type` で読む

`verbatimModuleSyntax` が有効なのでこの import はビルド時に消え、
**Worker のコードがブラウザのバンドルに入らない。**
`import { type AppType }` と書くと消えないため、コメントで明示した。

## 未対応（別途イシューを立てる）

**クライアント（React）のテストが無い。** テストは workerd の中で走るため DOM が無く、
React コンポーネントをレンダリングできない。jsdom を足すか、別の vitest プロジェクトを
作るかの判断が必要で、#4（リストの UI）に着手する前に決める必要がある。
