### PR TITLE
Hono の例外を Sentry に送る（onError を追加）

### DIFF
--- a/apps/web/src/index.ts
+++ b/apps/web/src/index.ts
@@ -31,8 +31,27 @@ const app = new Hono<AppEnv>()
     return c.json({ status: 'ok', db: 'ok' } as const)
   })
 
+  // ⚠️ Sentry の到達確認用。**確認したらすぐ消す。**
+  // 恒久的に置くと、公開されたエラー発生器になり無料枠を焼かれる
+  .get('/api/dev/boom', () => {
+    throw new Error('Sentry の到達確認（一時的なルート）')
+  })
+
 /**
- * Sentry で包んでからエクスポートする。未処理の例外がここで捕まる。
+ * 🔴 **Hono は例外を自前で捕まえて 500 を返すため、`withSentry` には例外が届かない。**
+ * ここで明示的に Sentry へ送る。これが無いと、SDK を正しく初期化していても
+ * ルート内で起きた例外が1件も通知されない。
+ *
+ * レスポンスには理由を載せない。例外メッセージに内部の情報が入りうるため。
+ */
+app.onError((error, c) => {
+  Sentry.captureException(error)
+  return c.json({ error: 'Internal Server Error' } as const, 500)
+})
+
+/**
+ * Sentry で包んでからエクスポートする。`onError` を通らない経路
+ * （ミドルウェアより手前で起きる例外など）はここで捕まる。
  *
  * `defineCloudflareOptions` + `instrument.server.ts` による自動計装もあるが、
  * **プラグインが暗黙に拾う形は採らない。** どこで初期化されているかがコードから

--- a/apps/web/test/error-handling.test.ts
+++ b/apps/web/test/error-handling.test.ts
@@ -1,0 +1,24 @@
+import { exports } from 'cloudflare:workers'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * ルート内で例外が起きたときの振る舞い。
+ *
+ * **Hono は例外を自前で捕まえて 500 を返す**ため、`withSentry` に例外が届かない。
+ * `onError` で明示的に Sentry へ送っている（`src/index.ts`）。
+ * ここでは `onError` が配線されていることと、レスポンスに内部情報が漏れないことを見る。
+ *
+ * 通知が実際に届くかはテストでは確認できない（DSN が必要）。
+ * 手順は `docs/console-settings.md`。
+ */
+describe('例外が起きたとき', () => {
+  it('500 を返し、例外の内容をレスポンスに載せない', async () => {
+    const res = await exports.default.fetch(new Request('https://example.com/api/dev/boom'))
+
+    expect(res.status).toBe(500)
+
+    const body = await res.text()
+    expect(body).toBe(JSON.stringify({ error: 'Internal Server Error' }))
+    expect(body).not.toContain('Sentry の到達確認')
+  })
+})


### PR DESCRIPTION
Refs #18

## 🔴 #18 の実装に穴があった

**Hono は例外を自前で捕まえて 500 を返すため、`withSentry` には例外が届かない。**

`Sentry.withSentry` は Worker の `fetch` ハンドラを計装するが、Hono が内部で例外を処理して
正常なレスポンスを返してしまうので、Sentry から見ると「成功したリクエスト」になる。
つまり **SDK を正しく初期化していても、ルート内で起きた例外は1件も通知されない。**

`app.onError` で明示的に `Sentry.captureException` する。

```ts
app.onError((error, c) => {
  Sentry.captureException(error)
  return c.json({ error: 'Internal Server Error' } as const, 500)
})
```

レスポンスには理由を載せない（例外メッセージに内部の情報が入りうる）。
これはテストで固定した。

## 一時的なルートを含む

到達確認のため `/api/dev/boom` を入れている。**確認後すぐに消す PR を出す。**
恒久的に置くと公開されたエラー発生器になり、無料枠（5,000 errors/月、他プロジェクトと共有）を焼かれる。

## この PR で確認できないこと

**通知が実際に Sentry に届くかはテストでは確認できない**（DSN が必要）。
マージ後にデプロイして `/api/dev/boom` を叩き、利用者に Sentry 側を見てもらう。
