### PR TITLE
Sentry の到達確認用ルートを削除する

### DIFF
--- a/apps/web/src/index.ts
+++ b/apps/web/src/index.ts
@@ -31,12 +31,6 @@ const app = new Hono<AppEnv>()
     return c.json({ status: 'ok', db: 'ok' } as const)
   })
 
-  // ⚠️ Sentry の到達確認用。**確認したらすぐ消す。**
-  // 恒久的に置くと、公開されたエラー発生器になり無料枠を焼かれる
-  .get('/api/dev/boom', () => {
-    throw new Error('Sentry の到達確認（一時的なルート）')
-  })
-
 /**
  * 🔴 **Hono は例外を自前で捕まえて 500 を返すため、`withSentry` には例外が届かない。**
  * ここで明示的に Sentry へ送る。これが無いと、SDK を正しく初期化していても

--- a/apps/web/test/error-handling.test.ts
+++ b/apps/web/test/error-handling.test.ts
@@ -1,24 +1,37 @@
+import { env } from 'cloudflare:workers'
 import { exports } from 'cloudflare:workers'
 import { describe, expect, it } from 'vitest'
 
 /**
  * ルート内で例外が起きたときの振る舞い。
  *
- * **Hono は例外を自前で捕まえて 500 を返す**ため、`withSentry` に例外が届かない。
- * `onError` で明示的に Sentry へ送っている（`src/index.ts`）。
- * ここでは `onError` が配線されていることと、レスポンスに内部情報が漏れないことを見る。
+ * **Hono は例外を自前で捕まえて 500 を返す**ため、`withSentry` だけでは
+ * 通知が飛ばない可能性がある。`onError` で明示的に Sentry へ送っている
+ * （`src/index.ts`）。ここでは 500 になることと、**例外の内容が
+ * レスポンスに漏れないこと**を見る。
  *
- * 通知が実際に届くかはテストでは確認できない（DSN が必要）。
- * 手順は `docs/console-settings.md`。
+ * 例外を起こす専用のルートは置かない。恒久的に置くと公開されたエラー発生器になり、
+ * 無料枠（5,000 errors/月、他プロジェクトと共有）を焼かれる。
+ * 代わりにテーブルを落として、本物の失敗経路を通す。
+ *
+ * 通知が実際に届くことは 2026-08-06 に本番で確認済み
+ * （手順と結果は `docs/console-settings.md`）。
  */
 describe('例外が起きたとき', () => {
   it('500 を返し、例外の内容をレスポンスに載せない', async () => {
-    const res = await exports.default.fetch(new Request('https://example.com/api/dev/boom'))
+    // D1 のクエリが失敗する状況を作る。onError を通る本物の経路になる
+    await env.DB.prepare('drop table lists').run()
+
+    const res = await exports.default.fetch(new Request('https://example.com/api/health/db'))
 
     expect(res.status).toBe(500)
 
     const body = await res.text()
     expect(body).toBe(JSON.stringify({ error: 'Internal Server Error' }))
-    expect(body).not.toContain('Sentry の到達確認')
+
+    // SQL やテーブル名などの内部情報が漏れていないこと
+    expect(body).not.toContain('lists')
+    expect(body).not.toContain('D1')
+    expect(body).not.toContain('SQL')
   })
 })

--- a/docs/console-settings.md
+++ b/docs/console-settings.md
@@ -104,8 +104,9 @@ gh api -X PUT repos/aiandrox/yaritai100list/rulesets/20485718 --input <file>
 | デプロイ方法 | `npm run deploy`（`vite build` + `wrangler deploy`） |
 | 確認済みの経路 | `/api/health` / `/api/health/db`（リモート D1 往復）/ `/`（SPA）/ `/lists`（SPA フォールバック）/ `/api/nope`（404）/ 静的アセット |
 
-**⚠️ `SENTRY_DSN` を本番に設定していないため、現時点で本番のエラー通知は無効。**
-利用者が `wrangler secret put SENTRY_DSN` を実行する必要がある（AI は値を持っていない）。
+`SENTRY_DSN` は設定済み（2026-08-06、利用者が `wrangler secret put` で登録）。
+**シークレットを登録すると新しいバージョンが自動でデプロイされる**（`deployments list` に
+`Source: Secret Change` として残る）。再デプロイは不要。
 
 ### コンソールでしか触れないもの
 
@@ -251,7 +252,33 @@ DSN が漏れると第三者にイベントを送り込まれて枠を焼かれ�
 という状況が実際に起きたとき。そのときは SPA 用のプロジェクトを別に作り、
 `ignoreErrors` でノイズを削ってから入れる。
 
-### 通知が実際に届くかの確認手順
+### 到達確認の結果（2026-08-06、本番で実施）
+
+**届いた。** 一時的に例外を投げるルートを本番に出して確認し、確認後すぐ削除した。
+
+| 確認項目 | 結果 |
+|---|---|
+| イベントの到達 | ✅ `YARITAI100LIST-WORKERS-1` として2件。**叩いた回数と一致（重複なし）** |
+| environment | ✅ `production` |
+| transaction | ✅ `GET /api/dev/boom` |
+| url | ✅ 送られている（`shareId` を隠さない方針どおり） |
+| リクエストボディ・Cookie | ✅ 含まれていない |
+
+**このとき `withSentry` だけでは通知が飛ばない可能性に気づいた。**
+Hono は例外を自前で捕まえて 500 を返すため、Sentry から見ると「成功したリクエスト」になる。
+`app.onError` で明示的に `captureException` する形に直してから確認した（#47）。
+
+#### `user` に IP が入る（実害なし）
+
+イベントの `user` に `2a06:98c0:3600::103` が入っていた。これは **Cloudflare のエッジ自身の
+IPv6**（`2a06:98c0::/29` は Cloudflare の範囲）で、**利用者の IP ではない。**
+Worker から Sentry へ送信するため、Sentry が送信元 IP を推測して埋めたもの。
+
+`dataCollection.userInfo: false` と `beforeSend` の `delete event.user` は効いており、
+SDK 側は何も送っていない。消したい場合は
+**Settings → Security & Privacy → Prevent Storing of IP Addresses** で止められる（未設定）。
+
+### 通知が実際に届くかの確認手順（再確認したいとき）
 
 **この確認には DSN が必要なので、コードだけでは完結しない。**
 自動テストで検証しているのは「DSN が無ければ SDK を初期化しない」「送る前に


### PR DESCRIPTION
Refs #18

**本番で通知が届くことを確認できた**ので、一時的に置いていた `/api/dev/boom` を削除する。

## 確認結果（利用者が Sentry 側を確認）

| 確認項目 | 結果 |
|---|---|
| イベントの到達 | ✅ `YARITAI100LIST-WORKERS-1` として2件。**叩いた回数と一致（重複なし）** |
| environment | ✅ `production` |
| transaction | ✅ `GET /api/dev/boom` |
| url | ✅ 送られている（`shareId` を隠さない方針どおり） |
| リクエストボディ・Cookie | ✅ 含まれていない |

**`onError` を入れたのは正解だった**（#47）。`withSentry` だけでは Hono が例外を
飲み込むため、通知が飛ばない可能性があった。

## `user` に IP が入っていた（実害なし）

イベントの `user` に `2a06:98c0:3600::103` が入っていたが、これは
**Cloudflare のエッジ自身の IPv6**（`2a06:98c0::/29` は Cloudflare の範囲）で、
**利用者の IP ではない。** Worker から送信するため Sentry が送信元 IP を推測して埋めたもの。

`dataCollection.userInfo: false` と `beforeSend` の `delete event.user` は効いており、
SDK 側は何も送っていない。止めたい場合のコンソール設定（Prevent Storing of IP Addresses）を
`docs/console-settings.md` に書いた。

## テストは例外用ルートに頼らない形にした

ルートを消すとテストも消えてしまうので、**D1 のテーブルを落として本物の失敗経路を通す**形に変えた。

```ts
await env.DB.prepare('drop table lists').run()
const res = await exports.default.fetch(new Request('https://example.com/api/health/db'))
expect(res.status).toBe(500)
expect(body).not.toContain('lists')   // SQL やテーブル名が漏れないこと
```

これで `onError` の配線とレスポンスの安全性が恒久的に検証される。
