### PR TITLE
Sentry に userId だけを送るようにする

### DIFF
--- a/apps/web/src/sentry.ts
+++ b/apps/web/src/sentry.ts
@@ -38,11 +38,14 @@ export interface SentryEnv {
  * 落とすもの:
  * - **リクエストボディ。やりたいことの本文が入る**（これがこの関数の主目的）
  * - Cookie とヘッダ。セッションが入る
- * - ユーザー情報（そもそもユーザーに表示名を持たせていないが、念のため）
+ * - **ユーザー情報のうち `id` 以外すべて**（メールアドレス、名前、IP、位置情報）
  *
- * **URL はそのまま送る。** `shareId` や `listId` が載るが、これは隠さない判断。
- * ただし**自由入力が URL に乗るルート**（検索クエリなど）を作るときは、
- * そのパラメータをここで落とすことを検討する。現状 URL に載るのは ID と更新日時だけ。
+ * 残すもの:
+ * - **`user.id`。このサービス上の一意キー**。どの利用者で起きた障害かを追うために送る。
+ *   メールアドレスや名前は保存はするが（`PRODUCT_SPEC.md` §3）**通知には送らない**
+ * - URL。`shareId` や `listId` が載るが、これは隠さない判断。
+ *   ただし**自由入力が URL に乗るルート**（検索クエリなど）を作るときは、
+ *   そのパラメータをここで落とすことを検討する。現状 URL に載るのは ID と更新日時だけ
  *
  * `beforeSend` に渡ってくるイベントをそのまま加工して返す。
  * テストしやすいよう純関数として切り出している。
@@ -57,7 +60,13 @@ export function scrubEvent<T extends { request?: unknown; user?: unknown }>(even
     delete request.headers
   }
 
-  delete event.user
+  // `user` を丸ごと消すと `setUser({ id })` で入れた値も捨ててしまう。
+  // **`id` だけを残し、他は名前が何であれ落とす**（SDK や Sentry 側が
+  // 増やしたフィールドを個別に列挙しなくて済む）。
+  const user = event.user as { id?: unknown } | undefined
+  if (user) {
+    event.user = user.id === undefined ? undefined : { id: user.id }
+  }
 
   return event
 }

--- a/apps/web/test/sentry.test.ts
+++ b/apps/web/test/sentry.test.ts
@@ -69,8 +69,23 @@ describe('scrubEvent', () => {
     expect(JSON.stringify(scrubbed)).not.toContain('secret-session-token')
   })
 
-  it('ユーザー情報を落とす', () => {
-    const scrubbed = scrubEvent({ user: { id: 'user-1', email: 'a@example.com' } })
+  it('ユーザーは id だけ残し、メールアドレスや名前や IP は落とす', () => {
+    const scrubbed = scrubEvent({
+      user: {
+        id: 'user-1',
+        email: 'a@example.com',
+        username: 'aiandrox',
+        ip_address: '203.0.113.1',
+        geo: { country_code: 'JP' },
+      },
+    })
+
+    // どの利用者で起きた障害かを追うために id だけ送る
+    expect(scrubbed.user).toEqual({ id: 'user-1' })
+  })
+
+  it('id が無いユーザー情報は丸ごと落とす（IP だけ推測されたケース）', () => {
+    const scrubbed = scrubEvent({ user: { ip_address: '2a06:98c0:3600::103' } })
 
     expect(scrubbed.user).toBeUndefined()
   })


### PR DESCRIPTION
Refs #18 #52

## 直した罠

`scrubEvent` は `event.user` を**丸ごと削除**していた。この状態で
`Sentry.setUser({ id })` を書いても**黙って捨てられる。**
気づかないまま「userId を送っているつもり」になる。

`id` だけを残す実装に変えた。

```ts
const user = event.user as { id?: unknown } | undefined
if (user) {
  event.user = user.id === undefined ? undefined : { id: user.id }
}
```

**フィールド名を列挙して消すのではなく、`id` だけを残す**形にした。
SDK や Sentry 側が新しいフィールド（`geo` など）を増やしても追随不要になる。

## 送るもの / 送らないもの

| | |
|---|---|
| 送る | `user.id`（このサービス上の一意キー） |
| 送らない | メールアドレス、名前、`ip_address`、`geo` |

メールアドレスと名前は **DB には保存するが通知には送らない**
（保存する方針は利用者の判断。`PRODUCT_SPEC.md` §3 の記述は #49 の PR で実態に合わせて直す）。

`id` が無いユーザー情報（Sentry が送信元 IP を推測して埋めただけのケース）は
丸ごと落とす。これもテストで固定した。

## 未検証（#52 に持ち越し）

**`dataCollection.userInfo: false` が `setUser` の値まで落とさないかは実測していない。**
このオプションの説明は「instrumentation が自動で埋める `user.*` を止める」なので
明示的な `setUser` は通るはずだが、確認は #52 で `setUser` を配線したときに行う。
#52 の本文にチェック項目として追記済み。
