### PR TITLE
Google プロバイダとセッション Cookie を設定する

### DIFF
--- a/apps/web/.dev.vars.example
+++ b/apps/web/.dev.vars.example
@@ -20,3 +20,9 @@ SENTRY_DSN=
 # Sentry に送るイベントの environment。未設定なら production。
 # ローカルから通知を試すときは本番のイベントと混ざらないよう local などにする。
 SENTRY_ENVIRONMENT=local
+
+# Google の OAuth クライアント。**development 用の値を入れる**（production とは別のクライアント）。
+# 値の取得元は GCP コンソール。本番は `wrangler secret put` で入れる。
+# **未設定でもアプリは起動する**（ログイン手段が無くなるだけ）。
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=

--- a/apps/web/src/auth.ts
+++ b/apps/web/src/auth.ts
@@ -29,6 +29,20 @@ export interface AuthEnv {
    * ローカルは `.dev.vars` で上書きする。
    */
   readonly BETTER_AUTH_URL: string
+
+  /**
+   * Google の OAuth クライアント ID。
+   *
+   * **development と production で値が違う**（#1 でクライアントを2つに分けた）。
+   * 「Client ID は公開値だから」と `wrangler.jsonc` に直書きすると、
+   * ローカルで本番クライアントを使ってしまうため、環境変数で渡す。
+   *
+   * **未設定ならログイン手段が無くなるだけで、アプリは起動する**（下記）。
+   */
+  readonly GOOGLE_CLIENT_ID?: string
+
+  /** Google の OAuth クライアントシークレット。**シークレット**。 */
+  readonly GOOGLE_CLIENT_SECRET?: string
 }
 
 /**
@@ -59,7 +73,57 @@ export function createAuth(db: Db, env: AuthEnv) {
       schema,
     }),
 
-    // ソーシャルログインのプロバイダは #50 で足す
+    /**
+     * **資格情報が揃っている環境だけで Google を有効にする。**
+     *
+     * 揃っていない環境（`.dev.vars` に入れていないローカル）でも
+     * `npm run dev` が起動し、`/api/health` などは動く。ログイン手段が無くなるだけ。
+     * `SENTRY_DSN` が無ければ通知を無効にするのと同じ考え方。
+     */
+    socialProviders:
+      env.GOOGLE_CLIENT_ID && env.GOOGLE_CLIENT_SECRET
+        ? {
+            google: {
+              clientId: env.GOOGLE_CLIENT_ID,
+              clientSecret: env.GOOGLE_CLIENT_SECRET,
+            },
+          }
+        : {},
+
+    session: {
+      /**
+       * 🔴 **Cookie キャッシュを使わない。**
+       *
+       * 有効にすると、セッションの内容が署名付き Cookie に載って
+       * DB を見ずに認証が通る。つまり**サーバー側でセッションを消しても
+       * キャッシュの有効期間は通り続ける。**
+       * `CLAUDE.md` の「セッションはサーバー側から失効できる方式にする」に反する。
+       *
+       * 既定は無効だが、性能改善のつもりで有効にされると認可が静かに壊れるため
+       * 明示的に書いておく。
+       */
+      cookieCache: { enabled: false },
+    },
+
+    advanced: {
+      /**
+       * 🔴 **Cookie に `Domain` 属性を付けない（host-only）。**
+       *
+       * `crossSubDomainCookies` を有効にすると `Domain` が付く。
+       * `workers.dev` は**他人のワーカーとサブドメインを共有する空間**なので、
+       * `Domain=workers.dev` のような Cookie は他のワーカーにも送られてしまう。
+       * 既定は無効だが、これも明示しておく（`TECH_STACK.md` §8）。
+       */
+      crossSubDomainCookies: { enabled: false },
+
+      defaultCookieAttributes: {
+        httpOnly: true,
+        sameSite: 'lax',
+      },
+
+      // `Secure` は baseURL のプロトコルから決まる（本番は https なので付く）。
+      // ローカルは http://localhost で、ブラウザは localhost を安全な文脈として扱う
+    },
   })
 }
 

--- a/apps/web/test/auth.test.ts
+++ b/apps/web/test/auth.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
+import { createAuth } from '../src/auth'
 import { testAuth, testDb } from './helpers'
 import { session, user } from '../src/db/schema'
 
@@ -91,5 +92,70 @@ describe('Better Auth と D1', () => {
     await db.delete(user)
 
     expect(await db.select().from(session)).toEqual([])
+  })
+})
+
+describe('セッションを失効させられること', () => {
+  it('D1 の行を消すとセッションが見えなくなる', async () => {
+    const ctx = await testAuth().$context
+
+    const created = await ctx.adapter.create<UserRow>({
+      model: 'user',
+      data: {
+        name: '',
+        email: 'revoke@example.com',
+        emailVerified: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    })
+    const s = await ctx.internalAdapter.createSession(created.id, undefined)
+
+    expect(await ctx.internalAdapter.findSession(s.token)).not.toBeNull()
+
+    // サーバー側から失効させる
+    await testDb().delete(session)
+
+    expect(await ctx.internalAdapter.findSession(s.token)).toBeNull()
+  })
+
+  it('Cookie キャッシュが無効になっている', () => {
+    // 有効だと、DB を見ずに Cookie だけで認証が通るため
+    // 上のテスト（行を消したら見えない）が成り立たなくなる
+    expect(testAuth().options.session.cookieCache.enabled).toBe(false)
+  })
+})
+
+describe('Cookie の方針', () => {
+  it('Domain 属性を付けない（host-only）', () => {
+    // workers.dev は他人のワーカーとサブドメインを共有する空間なので、
+    // Domain 付きの Cookie は他のワーカーにも送られてしまう
+    expect(testAuth().options.advanced.crossSubDomainCookies.enabled).toBe(false)
+  })
+
+  it('HttpOnly と SameSite=Lax が既定になっている', () => {
+    const attrs = testAuth().options.advanced.defaultCookieAttributes
+
+    expect(attrs.httpOnly).toBe(true)
+    expect(attrs.sameSite).toBe('lax')
+  })
+})
+
+describe('Google プロバイダ', () => {
+  it('資格情報が揃っていれば有効になる', () => {
+    const auth = createAuth(testDb(), {
+      BETTER_AUTH_SECRET: 'test-secret-not-used-outside-tests-0123456789',
+      BETTER_AUTH_URL: 'https://example.com',
+      GOOGLE_CLIENT_ID: 'dummy-client-id',
+      GOOGLE_CLIENT_SECRET: 'dummy-client-secret',
+    })
+
+    expect(Object.keys(auth.options.socialProviders)).toEqual(['google'])
+  })
+
+  it('資格情報が無い環境では有効にしない（アプリは起動する）', () => {
+    // ローカルで .dev.vars に入れていない場合。ログイン手段が無くなるだけで
+    // /api/health などは動く
+    expect(Object.keys(testAuth().options.socialProviders)).toEqual([])
   })
 })

--- a/docs/console-settings.md
+++ b/docs/console-settings.md
@@ -134,11 +134,16 @@ GCP プロジェクトは1つ（同意画面はプロジェクト単位で共有
 |---|---|---|
 | Client ID | `360816377904-1h28d71uu6q42a1ggi1j8hdjquerhr34.apps.googleusercontent.com` | `360816377904-5jhsstvqt3313uvnv5g6n7k0vu2m8t2b.apps.googleusercontent.com` |
 | 種類 | ウェブアプリケーション | ウェブアプリケーション |
-| 承認済みリダイレクト URI | `https://yaritai100list.aiandrox.workers.dev/api/auth/callback/google` | `http://localhost:8787/api/auth/callback/google` |
+| 承認済みリダイレクト URI | `https://yaritai100list.aiandrox.workers.dev/api/auth/callback/google` | `http://localhost:5173/api/auth/callback/google` |
 | 承認済みの JavaScript 生成元 | **空** | **空** |
 | Client Secret の置き場所 | Workers のシークレット | `.dev.vars` |
+| 登録状況 | **登録済み**（2026-08-06） | **登録済み**（2026-08-06） |
 
 同意画面は **外部 / 公開**。
+
+**development のポートは 5173（Vite）。** #17 で dev サーバーを `wrangler dev`（8787）から
+Vite に変えたため、2026-08-06 に GCP 側のリダイレクト URI も 8787 から 5173 に直した。
+`npm run dev` のポートを変えるときは、ここと GCP の設定の両方を直す。
 
 ### 分けている理由
 


### PR DESCRIPTION
Closes #50

## 🔴 不変条件を壊しうる設定を2つ、明示的に切った

どちらも Better Auth の既定は安全側だが、**性能改善のつもりで有効にされると認可が静かに壊れる**ため
コードに書いて理由を残した。テストでも固定した。

### `session.cookieCache` を無効

有効にするとセッションの内容が署名付き Cookie に載り、**DB を見ずに認証が通る。**
つまり**サーバー側でセッションを消してもキャッシュの有効期間は通り続ける。**
`CLAUDE.md` の「セッションはサーバー側から失効できる方式にする」に反する。

### `crossSubDomainCookies` を無効（Cookie に `Domain` を付けない）

`workers.dev` は**他人のワーカーとサブドメインを共有する空間**なので、
`Domain` 付きの Cookie は他人のワーカーにも送られてしまう（`TECH_STACK.md` §8）。

## 資格情報が無い環境では Google を有効にしない

```ts
socialProviders:
  env.GOOGLE_CLIENT_ID && env.GOOGLE_CLIENT_SECRET ? { google: {...} } : {}
```

`.dev.vars` に入れていないローカルでも `npm run dev` が起動し、`/api/health` などは動く。
ログイン手段が無くなるだけ。`SENTRY_DSN` が無ければ通知を無効にするのと同じ考え方。

## テスト（36件、7.1秒）

失効については **2つに分けて証明**している。Cookie の署名を組み立てるのは重いので、
「キャッシュが無いこと」と「DB から消えれば見えないこと」を別々に確認する形にした。

- D1 の `session` 行を消すと `findSession` が `null` を返す
- `cookieCache.enabled` が `false`
- `crossSubDomainCookies.enabled` が `false`
- `defaultCookieAttributes` が `httpOnly: true` / `sameSite: 'lax'`
- 資格情報が揃えば `google` が有効、無ければ空

## ドキュメント

`docs/console-settings.md` のリダイレクト URI を **8787 → 5173** に更新した。
#17 で dev サーバーを `wrangler dev` から Vite に変えたため。
GCP 側の設定も利用者が修正済み。`npm run dev` のポートを変えるときは両方直す必要がある旨も書いた。

## `account` の OAuth トークンは保存されたまま（別イシューにする）

`accessToken` / `refreshToken` / `idToken` は**保存される。**
Better Auth 1.6.26 に「保存しない」設定は無く、`updateAccountOnSignIn` は更新するかどうかの制御だけ。

このアプリはログインにしか Google を使わないので保存は不要。
`databaseHooks` で落とせる見込みだが、**Google ログインを一度も通していない状態で
入れると、失敗したときの切り分けが難しくなる。**
先にログインが通ることを確認してから別イシューで対応する。

要求するスコープは `openid` / `email` / `profile` のみなので、
仮に DB が漏れてもトークンで得られるのは基本プロフィールに限られる。

## 🔴 このあと利用者にお願いすること

**本番で実際に Google ログインを試してもらう必要がある**（同意画面のクリックは AI ではできない）。
マージ・デプロイ後に手順を提示する。
