### PR TITLE
Google のログイン導線を追加する（GET /api/login/google）

### DIFF
--- a/apps/web/src/client/App.tsx
+++ b/apps/web/src/client/App.tsx
@@ -6,13 +6,15 @@ import { api } from './api'
 /**
  * 土台の確認用の画面。リストの UI は #4 で作る。
  *
- * ここで確かめているのは3つ:
+ * ここで確かめているのは:
  * - SPA が Workers から配信されること
  * - 同一オリジンで API を呼べること（CORS の設定が要らないこと）
  * - **Hono RPC でサーバーの型がクライアントに流れること**
+ * - ログインが通ること（ログアウトと状態表示は #53 で作る）
  */
 export function App() {
   const [health, setHealth] = useState<string>('確認中')
+  const [session, setSession] = useState<string>('確認中')
 
   useEffect(() => {
     const check = async () => {
@@ -27,10 +29,31 @@ export function App() {
     void check()
   }, [])
 
+  useEffect(() => {
+    const check = async () => {
+      // Better Auth のエンドポイントは Hono RPC の型に乗らないので普通の fetch で呼ぶ
+      const res = await fetch('/api/auth/get-session')
+      const body: unknown = await res.json()
+
+      setSession(body === null ? '未ログイン' : 'ログイン中')
+    }
+
+    void check()
+  }, [])
+
   return (
     <main>
       <h1>{SERVICE_NAME}</h1>
       <p>API: {health}</p>
+      <p>セッション: {session}</p>
+      {/*
+        Better Auth の sign-in は POST なので、`<a>` から叩ける GET の入口を
+        サーバー側に用意している（`/api/login/google`）。
+        ボタンの見た目とログアウトは #53 で作る。
+      */}
+      <p>
+        <a href="/api/login/google">Google でログイン</a>
+      </p>
     </main>
   )
 }

--- a/apps/web/src/index.ts
+++ b/apps/web/src/index.ts
@@ -37,7 +37,34 @@ const app = new Hono<AppEnv>()
   })
 
   /**
-   * Better Auth の全エンドポイント（セッション取得、サインイン、コールバック等）。
+   * Google のログインを開始する。**リンクから辿れるようにするための GET。**
+   *
+   * Better Auth の `/api/auth/sign-in/social` は POST なので、`<a>` から直接叩けない。
+   * ここで受けて Google へリダイレクトする。
+   *
+   * 🔴 **Set-Cookie を引き継ぐこと。** `signInSocial` のレスポンスには
+   * OAuth の `state` と PKCE の verifier を入れた Cookie が乗っている。
+   * URL だけ取り出してリダイレクトすると、コールバックで state 不一致になる。
+   */
+  .get('/api/login/google', async (c) => {
+    const auth = createAuth(createDb(c.env.DB), c.env)
+
+    const res = await auth.api.signInSocial({
+      body: { provider: 'google', callbackURL: '/' },
+      asResponse: true,
+    })
+
+    const { url } = await res.json<{ url?: string }>()
+    if (!url) throw new Error('Google のサインイン URL を取得できなかった')
+
+    const headers = new Headers({ location: url })
+    for (const cookie of res.headers.getSetCookie()) headers.append('set-cookie', cookie)
+
+    return new Response(null, { status: 302, headers })
+  })
+
+  /**
+   * Better Auth の全エンドポイント（セッション取得、コールバック等）。
    *
    * **`wrangler.jsonc` の `run_worker_first` に `/api/*` が入っているので Worker に届く。**
    * ここを `/auth/*` のような別のプレフィックスに変えるなら、あちらにも足すこと。

--- a/apps/web/test/auth.test.ts
+++ b/apps/web/test/auth.test.ts
@@ -1,3 +1,4 @@
+import { exports } from 'cloudflare:workers'
 import { describe, expect, it } from 'vitest'
 
 import { createAuth } from '../src/auth'
@@ -157,5 +158,39 @@ describe('Google プロバイダ', () => {
     // ローカルで .dev.vars に入れていない場合。ログイン手段が無くなるだけで
     // /api/health などは動く
     expect(Object.keys(testAuth().options.socialProviders)).toEqual([])
+  })
+})
+
+describe('GET /api/login/google', () => {
+  it('Google の認可 URL へ 302 で送る', async () => {
+    const res = await exports.default.fetch(new Request('https://example.com/api/login/google'), {
+      redirect: 'manual',
+    })
+
+    expect(res.status).toBe(302)
+    expect(res.headers.get('location')).toMatch(
+      /^https:\/\/accounts\.google\.com\/o\/oauth2\/v2\/auth\?/,
+    )
+  })
+
+  it('🔴 state と PKCE の Cookie を引き継ぐ', async () => {
+    // signInSocial のレスポンスに乗っている Set-Cookie を落とすと、
+    // コールバックで state 不一致になりログインできない。
+    // URL だけ取り出す実装にしていないことをここで固定する
+    const res = await exports.default.fetch(new Request('https://example.com/api/login/google'), {
+      redirect: 'manual',
+    })
+
+    expect(res.headers.getSetCookie().length).toBeGreaterThan(0)
+  })
+
+  it('要求するスコープが最小限（openid / email / profile）', async () => {
+    const res = await exports.default.fetch(new Request('https://example.com/api/login/google'), {
+      redirect: 'manual',
+    })
+
+    const scope = new URL(res.headers.get('location') ?? '').searchParams.get('scope')
+
+    expect(scope?.split(' ').sort()).toEqual(['email', 'openid', 'profile'])
   })
 })

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -23,7 +23,14 @@ export default defineConfig(async () => ({
         // ローカルのシークレットを使ってしまう。**CI には `.dev.vars` が無い**ため、
         // ここで固定値を入れておかないと「手元では緑、CI だけ落ちる」状態になる。
         // テスト専用の値であり、本番のシークレットとは無関係。
-        bindings: { BETTER_AUTH_SECRET: 'test-secret-not-used-outside-tests-0123456789' },
+        bindings: {
+          BETTER_AUTH_SECRET: 'test-secret-not-used-outside-tests-0123456789',
+
+          // Google のログイン導線をテストするためのダミー。
+          // 認可 URL の組み立てはローカルで完結するのでネットワークには出ない
+          GOOGLE_CLIENT_ID: 'dummy-client-id.apps.googleusercontent.com',
+          GOOGLE_CLIENT_SECRET: 'dummy-client-secret',
+        },
       },
     }),
   ],


### PR DESCRIPTION
Refs #53

利用者がログインを試そうとしたところ、**Chrome の DevTools がペーストを拒否**した
（`Don't paste code into the DevTools Console...`）。
コンソールに貼らせる手順自体が筋が悪いので、**リンクをクリックするだけで済むようにした。**

## 🔴 Set-Cookie を引き継ぐ必要がある

Better Auth の `/api/auth/sign-in/social` は **POST** なので `<a>` から叩けない。
GET の入口を作って Google へ 302 で送る。

ここで**実装を1つ間違えると本番でだけ壊れる。**
`signInSocial` のレスポンスには **OAuth の `state` と PKCE の verifier を入れた Cookie** が
乗っている。URL だけ取り出してリダイレクトすると、**コールバックで state 不一致になり
ログインが失敗する。**

```ts
const headers = new Headers({ location: url })
for (const cookie of res.headers.getSetCookie()) headers.append('set-cookie', cookie)
```

**テストで固定した**（`getSetCookie().length > 0`）。これが無いと、次に誰かが
「URL だけ返せばいい」と単純化したときに静かに壊れる。

## テスト（39件）

vitest にダミーの Google 資格情報を渡して、認可 URL の組み立てを検証している。
**認可 URL の生成はローカルで完結するのでネットワークには出ない。**

- 302 で `https://accounts.google.com/o/oauth2/v2/auth?...` に送る
- Set-Cookie を引き継ぐ
- **要求スコープが `openid` / `email` / `profile` だけ**（余計な権限を要求していないこと）

## 画面

セッション状態の表示（`未ログイン` / `ログイン中`）とログインのリンクを置いた。
**ボタンの見た目とログアウトは #53 で作る**ので、このイシューは閉じない。

## 途中で踏んだこと

`res.json()` は Workers の型では `unknown` を返すため型引数が必要
（`res.json<{ url?: string }>()`）。`as` で書くと lint の
`no-unnecessary-type-assertion` と typecheck が食い違って両立しなかった。
