### PR TITLE
テーブル名を複数形に統一する

### DIFF
--- a/apps/web/migrations/0001_add_auth_tables.sql
+++ b/apps/web/migrations/0001_add_auth_tables.sql
@@ -1,4 +1,4 @@
-CREATE TABLE `account` (
+CREATE TABLE `accounts` (
 	`id` text PRIMARY KEY NOT NULL,
 	`account_id` text NOT NULL,
 	`provider_id` text NOT NULL,
@@ -12,10 +12,10 @@ CREATE TABLE `account` (
 	`password` text,
 	`created_at` integer NOT NULL,
 	`updated_at` integer NOT NULL,
-	FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
+	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade
 );
 --> statement-breakpoint
-CREATE TABLE `session` (
+CREATE TABLE `sessions` (
 	`id` text PRIMARY KEY NOT NULL,
 	`token` text NOT NULL,
 	`expires_at` integer NOT NULL,
@@ -24,11 +24,11 @@ CREATE TABLE `session` (
 	`user_id` text NOT NULL,
 	`created_at` integer NOT NULL,
 	`updated_at` integer NOT NULL,
-	FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
+	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade
 );
 --> statement-breakpoint
-CREATE UNIQUE INDEX `session_token_unique` ON `session` (`token`);--> statement-breakpoint
-CREATE TABLE `user` (
+CREATE UNIQUE INDEX `sessions_token_unique` ON `sessions` (`token`);--> statement-breakpoint
+CREATE TABLE `users` (
 	`id` text PRIMARY KEY NOT NULL,
 	`name` text NOT NULL,
 	`email` text NOT NULL,
@@ -38,8 +38,8 @@ CREATE TABLE `user` (
 	`updated_at` integer NOT NULL
 );
 --> statement-breakpoint
-CREATE UNIQUE INDEX `user_email_unique` ON `user` (`email`);--> statement-breakpoint
-CREATE TABLE `verification` (
+CREATE UNIQUE INDEX `users_email_unique` ON `users` (`email`);--> statement-breakpoint
+CREATE TABLE `verifications` (
 	`id` text PRIMARY KEY NOT NULL,
 	`identifier` text NOT NULL,
 	`value` text NOT NULL,

--- a/apps/web/migrations/meta/0001_snapshot.json
+++ b/apps/web/migrations/meta/0001_snapshot.json
@@ -1,11 +1,11 @@
 {
   "version": "6",
   "dialect": "sqlite",
-  "id": "ad1a442c-76f9-4df0-af0c-46672bb0f069",
+  "id": "4a642d41-dd74-4bf0-8eb8-ac3f5ffc56ac",
   "prevId": "d7118127-5b16-4f5d-ab73-18f4a48377f4",
   "tables": {
-    "account": {
-      "name": "account",
+    "accounts": {
+      "name": "accounts",
       "columns": {
         "id": {
           "name": "id",
@@ -101,10 +101,10 @@
       },
       "indexes": {},
       "foreignKeys": {
-        "account_user_id_user_id_fk": {
-          "name": "account_user_id_user_id_fk",
-          "tableFrom": "account",
-          "tableTo": "user",
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
           "columnsFrom": [
             "user_id"
           ],
@@ -119,8 +119,8 @@
       "uniqueConstraints": {},
       "checkConstraints": {}
     },
-    "session": {
-      "name": "session",
+    "sessions": {
+      "name": "sessions",
       "columns": {
         "id": {
           "name": "id",
@@ -180,8 +180,8 @@
         }
       },
       "indexes": {
-        "session_token_unique": {
-          "name": "session_token_unique",
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
           "columns": [
             "token"
           ],
@@ -189,10 +189,10 @@
         }
       },
       "foreignKeys": {
-        "session_user_id_user_id_fk": {
-          "name": "session_user_id_user_id_fk",
-          "tableFrom": "session",
-          "tableTo": "user",
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
           "columnsFrom": [
             "user_id"
           ],
@@ -207,8 +207,8 @@
       "uniqueConstraints": {},
       "checkConstraints": {}
     },
-    "user": {
-      "name": "user",
+    "users": {
+      "name": "users",
       "columns": {
         "id": {
           "name": "id",
@@ -262,8 +262,8 @@
         }
       },
       "indexes": {
-        "user_email_unique": {
-          "name": "user_email_unique",
+        "users_email_unique": {
+          "name": "users_email_unique",
           "columns": [
             "email"
           ],
@@ -275,8 +275,8 @@
       "uniqueConstraints": {},
       "checkConstraints": {}
     },
-    "verification": {
-      "name": "verification",
+    "verifications": {
+      "name": "verifications",
       "columns": {
         "id": {
           "name": "id",

--- a/apps/web/migrations/meta/_journal.json
+++ b/apps/web/migrations/meta/_journal.json
@@ -12,7 +12,7 @@
     {
       "idx": 1,
       "version": "6",
-      "when": 1785998573147,
+      "when": 1786018741880,
       "tag": "0001_add_auth_tables",
       "breakpoints": true
     }

--- a/apps/web/src/auth.ts
+++ b/apps/web/src/auth.ts
@@ -74,6 +74,21 @@ export function createAuth(db: Db, env: AuthEnv) {
     }),
 
     /**
+     * テーブル名を複数形に揃えている（Better Auth の既定は単数形）。
+     *
+     * 🔴 **`modelName` と Drizzle の export 名の両方を変える必要がある。**
+     * Drizzle アダプタは**モデル名でスキーマのプロパティを引く**ため、
+     * 片方だけ変えるとスキーマを解決できず、認証全体が落ちる。
+     *
+     * `fields`（列名の対応）は指定しない。Drizzle アダプタでは列名は
+     * Drizzle 側の定義が使われるので、ここで書くと二重指定になる。
+     */
+    user: { modelName: 'users' },
+    account: { modelName: 'accounts' },
+    verification: { modelName: 'verifications' },
+    // `session` の `modelName` は下の session オプションにまとめて指定している
+
+    /**
      * **資格情報が揃っている環境だけで Google を有効にする。**
      *
      * 揃っていない環境（`.dev.vars` に入れていないローカル）でも
@@ -91,6 +106,8 @@ export function createAuth(db: Db, env: AuthEnv) {
         : {},
 
     session: {
+      modelName: 'sessions',
+
       /**
        * 🔴 **Cookie キャッシュを使わない。**
        *

--- a/apps/web/src/db/schema/auth.ts
+++ b/apps/web/src/db/schema/auth.ts
@@ -14,8 +14,9 @@ import { integer, sqliteTable, text } from 'drizzle-orm/sqlite-core'
  * ```
  *
  * 命名の制約:
- * - **テーブル名は `user` / `session` / `account` / `verification` から変えない。**
- *   Better Auth 側の既定値で、変えるなら設定でも合わせる必要がある
+ * - **テーブル名は複数形に統一している**（`users` / `sessions` / `accounts` / `verifications`）。
+ *   Better Auth の既定は単数形なので、`createAuth` の `modelName` でも同じ名前を指定している。
+ *   **片方だけ変えるとアダプタがスキーマを解決できなくなる**（モデル名でプロパティを引くため）
  * - **プロパティ名（`emailVerified` など）も変えない。** アダプタがこの名前で列を引く。
  *   DB 側の列名は snake_case にしている
  */
@@ -27,7 +28,7 @@ import { integer, sqliteTable, text } from 'drizzle-orm/sqlite-core'
  * どの公開面にも作者を表示しないため、表示に使う場所は無い。
  * Sentry にも送らない（送るのは `id` だけ。`src/sentry.ts`）。
  */
-export const user = sqliteTable('user', {
+export const users = sqliteTable('users', {
   id: text('id').primaryKey(),
   name: text('name').notNull(),
   email: text('email').notNull().unique(),
@@ -42,7 +43,7 @@ export const user = sqliteTable('user', {
  *
  * DB に持つので**サーバー側から失効させられる**。これは `CLAUDE.md` の不変条件。
  */
-export const session = sqliteTable('session', {
+export const sessions = sqliteTable('sessions', {
   id: text('id').primaryKey(),
   token: text('token').notNull().unique(),
   expiresAt: integer('expires_at', { mode: 'timestamp_ms' }).notNull(),
@@ -50,7 +51,7 @@ export const session = sqliteTable('session', {
   userAgent: text('user_agent'),
   userId: text('user_id')
     .notNull()
-    .references(() => user.id, { onDelete: 'cascade' }),
+    .references(() => users.id, { onDelete: 'cascade' }),
   createdAt: integer('created_at', { mode: 'timestamp_ms' }).notNull(),
   updatedAt: integer('updated_at', { mode: 'timestamp_ms' }).notNull(),
 })
@@ -62,13 +63,13 @@ export const session = sqliteTable('session', {
  * このアプリは**ログインにしか Google を使わない**ので、これらを保存する必要はない。
  * 保存するかどうかは #50（Google プロバイダの設定）で判断する。
  */
-export const account = sqliteTable('account', {
+export const accounts = sqliteTable('accounts', {
   id: text('id').primaryKey(),
   accountId: text('account_id').notNull(),
   providerId: text('provider_id').notNull(),
   userId: text('user_id')
     .notNull()
-    .references(() => user.id, { onDelete: 'cascade' }),
+    .references(() => users.id, { onDelete: 'cascade' }),
   accessToken: text('access_token'),
   refreshToken: text('refresh_token'),
   idToken: text('id_token'),
@@ -84,7 +85,7 @@ export const account = sqliteTable('account', {
  * メール確認などの一時的なトークン。
  * ソーシャルログインだけなら使われないが、Better Auth が存在を前提にする。
  */
-export const verification = sqliteTable('verification', {
+export const verifications = sqliteTable('verifications', {
   id: text('id').primaryKey(),
   identifier: text('identifier').notNull(),
   value: text('value').notNull(),

--- a/apps/web/test/auth.test.ts
+++ b/apps/web/test/auth.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest'
 
 import { createAuth } from '../src/auth'
 import { testAuth, testDb } from './helpers'
-import { session, user } from '../src/db/schema'
+import { sessions, users } from '../src/db/schema'
 
 /**
  * Better Auth が **D1 のバインディング経由**で読み書きできることを確認する。
@@ -69,7 +69,7 @@ describe('Better Auth と D1', () => {
 
     // Better Auth が書いた行を、アプリ側の経路（Drizzle）から読めること。
     // 片方だけで読めても意味がないので、両方から見る
-    const rows = await testDb().select({ userId: session.userId }).from(session)
+    const rows = await testDb().select({ userId: sessions.userId }).from(sessions)
 
     expect(rows).toEqual([{ userId: created.id }])
   })
@@ -90,9 +90,9 @@ describe('Better Auth と D1', () => {
     })
     await ctx.internalAdapter.createSession(created.id, undefined)
 
-    await db.delete(user)
+    await db.delete(users)
 
-    expect(await db.select().from(session)).toEqual([])
+    expect(await db.select().from(sessions)).toEqual([])
   })
 })
 
@@ -115,7 +115,7 @@ describe('セッションを失効させられること', () => {
     expect(await ctx.internalAdapter.findSession(s.token)).not.toBeNull()
 
     // サーバー側から失効させる
-    await testDb().delete(session)
+    await testDb().delete(sessions)
 
     expect(await ctx.internalAdapter.findSession(s.token)).toBeNull()
   })


### PR DESCRIPTION
Closes #59

`lists`（複数）と `user` / `session` / `account` / `verification`（単数）が混在していた。
後者は Better Auth の既定値。**複数形に統一した。**

## 🔴 2箇所を同時に変える必要がある

```ts
// Drizzle 側
export const users = sqliteTable('users', { ... })

// Better Auth 側
user: { modelName: 'users' },
```

**Drizzle アダプタはモデル名でスキーマのプロパティを引く。**
片方だけ変えるとスキーマを解決できず、**認証全体が落ちる。**
この対応関係を `src/auth.ts` と `src/db/schema/auth.ts` の両方にコメントで書いた。

`fields`（列名の対応）は**指定しない。** Drizzle アダプタでは列名は Drizzle 側の定義が使われるため、
書くと二重指定になる。

## マイグレーションを作り直した

`drizzle-kit generate` のリネーム判定は**対話が必要**で、非対話では実行できない。

```
Error: Interactive prompts require a TTY terminal
  at promptNamedWithSchemasConflict
```

`user` が消えて `users` が現れたとき、drizzle は「リネームか、削除＋作成か」を人間に聞く。
CI やこの環境では答えられない。

そこで **0001 を複数形で作り直した。** 判断の根拠:

- 0001 は前日に作ったもので、**適用先はローカルと本番だけ**（他の利用者がいない）
- 本番のデータは**検証用の1ユーザーとセッションのみ**
- リネームの綱渡り（生成された SQL とスナップショットを手で整合させる）より、
  作り直して両方の DB を揃える方が確実

本番は旧テーブルを削除し、`d1_migrations` の該当行を消してから再適用した。
リモートのテーブルは `accounts` / `sessions` / `users` / `verifications` / `lists` になっている。

**今後リネームが必要になったら**、データ量が増えている可能性があるので同じ手は使えない。
その場合は手書きのマイグレーション（`ALTER TABLE ... RENAME TO ...`）とスナップショットの
整合を取る必要がある。

## テスト（39件、7.3秒）

既存の認証テストがそのまま通っている。**これは `modelName` と Drizzle の export 名の
対応が取れていることの証明になっている**（アダプタ経由で読み書きしているため）。

## 🔴 再ログインが必要

**検証用のユーザーとセッションは消えた。** マージ・デプロイ後にもう一度
https://yaritai100list.aiandrox.workers.dev から「Google でログイン」を試してほしい。

これは #59 の完了条件（テーブル名の解決に失敗すると認証全体が落ちるため、本番で確認する）でもある。
