### PR TITLE
lists に user_id を足す

### DIFF
--- a/apps/web/migrations/0002_add_user_id_to_lists.sql
+++ b/apps/web/migrations/0002_add_user_id_to_lists.sql
@@ -1,0 +1,22 @@
+-- 手で書いたマイグレーション。drizzle-kit の生成物をそのまま使えなかった。
+--
+-- 生成されたのは次の1文だけだった:
+--   ALTER TABLE `lists` ADD `user_id` text NOT NULL REFERENCES users(id);
+--
+-- これは2つの意味で使えない:
+--   1. SQLite は NOT NULL の列を DEFAULT 無しで ADD COLUMN できない（行が無くても DDL で失敗する）
+--   2. ON DELETE CASCADE が落ちている。スキーマに書いた cascade が SQL に出ていない
+--
+-- lists は local / remote ともに 0 行だったので作り直す。
+-- 行がある場合はそもそも移行できない（持ち主を決められないため）。
+DROP TABLE `lists`;--> statement-breakpoint
+CREATE TABLE `lists` (
+	`id` text PRIMARY KEY NOT NULL,
+	`user_id` text NOT NULL,
+	`title` text NOT NULL,
+	`visibility` text DEFAULT 'private' NOT NULL,
+	`created_at` integer DEFAULT (unixepoch('subsec') * 1000) NOT NULL,
+	`updated_at` integer DEFAULT (unixepoch('subsec') * 1000) NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade,
+	CONSTRAINT "lists_visibility_check" CHECK("lists"."visibility" in ('private', 'unlisted', 'public'))
+);

--- a/apps/web/migrations/meta/0002_snapshot.json
+++ b/apps/web/migrations/meta/0002_snapshot.json
@@ -1,0 +1,415 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "80d5e4ea-a12f-4877-9f55-35a7b510e993",
+  "prevId": "4a642d41-dd74-4bf0-8eb8-ac3f5ffc56ac",
+  "tables": {
+    "accounts": {
+      "name": "accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verifications": {
+      "name": "verifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "lists": {
+      "name": "lists",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'private'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('subsec') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('subsec') * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "lists_user_id_users_id_fk": {
+          "name": "lists_user_id_users_id_fk",
+          "tableFrom": "lists",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "lists_visibility_check": {
+          "name": "lists_visibility_check",
+          "value": "\"lists\".\"visibility\" in ('private', 'unlisted', 'public')"
+        }
+      }
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/apps/web/migrations/meta/_journal.json
+++ b/apps/web/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1786018741880,
       "tag": "0001_add_auth_tables",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1786019122716,
+      "tag": "0002_add_user_id_to_lists",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/src/db/schema/lists.ts
+++ b/apps/web/src/db/schema/lists.ts
@@ -2,11 +2,12 @@ import { VISIBILITIES } from '@yaritai100list/shared'
 import { sql } from 'drizzle-orm'
 import { check, integer, sqliteTable, text } from 'drizzle-orm/sqlite-core'
 
+import { users } from './auth'
+
 /**
  * リスト。
  *
  * ここで持たない列と、それを足すイシュー:
- * - `user_id`: 認証のテーブルがまだ無いため #3 で足す
  * - `share_id`: 公開用の ID。#7（リストの共有）で足す
  *
  * 決めた仕様はできる限り DB の制約にする。人間がレビューしない開発では
@@ -20,6 +21,19 @@ export const lists = sqliteTable(
      * 公開用の `share_id` とは別の値にする。
      */
     id: text('id').primaryKey(),
+
+    /**
+     * 所有者。**NOT NULL。持ち主のいないリストは DB に存在しない。**
+     *
+     * 未ログインのリストはブラウザの localStorage にあり、DB には来ない
+     * （`PRODUCT_SPEC.md` §2）。つまり DB の行は必ず誰かのもの。
+     *
+     * 利用者を削除したらリストも消える（`on delete cascade`）。
+     * 消し残しがあると、持ち主のいない行が公開面に出る事故につながる。
+     */
+    userId: text('user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
 
     title: text('title').notNull(),
 

--- a/apps/web/test/helpers.ts
+++ b/apps/web/test/helpers.ts
@@ -2,6 +2,7 @@ import { env } from 'cloudflare:workers'
 
 import { type Auth, createAuth } from '../src/auth'
 import { createDb, type Db } from '../src/db'
+import { users } from '../src/db/schema'
 
 /**
  * テスト用の Drizzle クライアント。
@@ -19,10 +20,14 @@ export function testDb(): Db {
  * テーブル名を列挙せず `sqlite_master` から引くので、**テーブルを増やしても
  * ここを直す必要がない**（消し忘れたテーブルのデータが次のテストに漏れない）。
  *
- * 削除は**作成順の逆**で行う。`sqlite_master` の行は作成順に並んでいるため、
- * 逆順にすると子テーブルが親より先に消える。マイグレーションは親を先に作るのが
- * 普通なので、これで外部キー制約の順序問題をたいてい回避できる。
- * （FK を持つテーブルが増えるのは #3。そこで実際に確認する）
+ * 削除は `sqlite_master` の作成順の逆で行うが、**順序に頼って成立しているわけではない。**
+ * 実際の削除順は `verifications` → `users` → `sessions` → `accounts` → `lists` で、
+ * 親（`users`）が子（`sessions` / `lists`）より先に消えている。
+ * それでも壊れないのは、**子の外部キーがすべて `on delete cascade` だから。**
+ *
+ * ⚠️ `on delete restrict` や `no action` の外部キーを持つテーブルを足したら、
+ * ここは順序を考える必要が出る。**D1 は外部キーを実際に強制する**
+ * （`FOREIGN KEY constraint failed` が出ることを `test/lists.test.ts` で確認済み）。
  */
 export async function resetDb(): Promise<void> {
   const { results } = await env.DB.prepare(
@@ -51,6 +56,28 @@ export function testAuth(): Auth {
     BETTER_AUTH_SECRET: 'test-secret-not-used-outside-tests-0123456789',
     BETTER_AUTH_URL: 'https://example.com',
   })
+}
+
+/**
+ * テスト用の利用者を1人作り、その id を返す。
+ *
+ * `lists.user_id` は NOT NULL で `users.id` を参照するため、
+ * リストのテストでは先に所有者が必要になる。
+ */
+export async function createTestUser(email = 'owner@example.com'): Promise<string> {
+  const id = crypto.randomUUID()
+
+  await testDb().insert(users).values({
+    id,
+    // 名前は保存するが表示しない（PRODUCT_SPEC.md §3）。テストでは空でよい
+    name: '',
+    email,
+    emailVerified: false,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  })
+
+  return id
 }
 
 /**

--- a/apps/web/test/lists.test.ts
+++ b/apps/web/test/lists.test.ts
@@ -1,14 +1,15 @@
 import { env } from 'cloudflare:workers'
-import { count } from 'drizzle-orm'
+import { count, eq } from 'drizzle-orm'
 import { describe, expect, it } from 'vitest'
 
-import { lists } from '../src/db/schema'
-import { testDb } from './helpers'
+import { lists, users } from '../src/db/schema'
+import { createTestUser, testDb } from './helpers'
 
 describe('lists テーブル', () => {
-  it('id と title だけで insert すると、公開範囲の既定が private になる', async () => {
+  it('必須の列だけで insert すると、公開範囲の既定が private になる', async () => {
     const db = testDb()
-    await db.insert(lists).values({ id: 'list-1', title: 'やりたいことリスト' })
+    const userId = await createTestUser()
+    await db.insert(lists).values({ id: 'list-1', userId, title: 'やりたいことリスト' })
 
     const [row] = await db.select().from(lists)
 
@@ -18,8 +19,9 @@ describe('lists テーブル', () => {
 
   it('created_at と updated_at に現在時刻が入る', async () => {
     const db = testDb()
+    const userId = await createTestUser()
     const before = Date.now()
-    await db.insert(lists).values({ id: 'list-1', title: 'x' })
+    await db.insert(lists).values({ id: 'list-1', userId, title: 'x' })
 
     const [row] = await db.select().from(lists)
 
@@ -29,19 +31,51 @@ describe('lists テーブル', () => {
   })
 
   it('不正な公開範囲は DB が拒否する', async () => {
+    const userId = await createTestUser()
+
     // Drizzle の enum は型の上だけの話なので、型を迂回する経路（生 SQL）で
     // CHECK 制約が実際に効いていることを確認する
     const insert = env.DB.prepare(
-      "insert into lists (id, title, visibility) values ('list-1', 'x', 'everyone')",
-    ).run()
+      "insert into lists (id, user_id, title, visibility) values ('list-1', ?, 'x', 'everyone')",
+    )
+      .bind(userId)
+      .run()
 
     await expect(insert).rejects.toThrow(/CHECK constraint failed/)
+  })
+
+  describe('所有者（user_id）', () => {
+    it('所有者のいないリストは作れない', async () => {
+      // 型では防いでいるが、DB でも止まることを確認する
+      const insert = env.DB.prepare("insert into lists (id, title) values ('list-1', 'x')").run()
+
+      await expect(insert).rejects.toThrow(/NOT NULL constraint failed/)
+    })
+
+    it('存在しない利用者を所有者にできない', async () => {
+      const insert = env.DB.prepare(
+        "insert into lists (id, user_id, title) values ('list-1', 'no-such-user', 'x')",
+      ).run()
+
+      await expect(insert).rejects.toThrow(/FOREIGN KEY constraint failed/)
+    })
+
+    it('利用者を消すとリストも消える', async () => {
+      const db = testDb()
+      const userId = await createTestUser()
+      await db.insert(lists).values({ id: 'list-1', userId, title: 'x' })
+
+      await db.delete(users).where(eq(users.id, userId))
+
+      expect(await db.select().from(lists)).toEqual([])
+    })
   })
 
   describe('テストごとに状態が巻き戻る', () => {
     it('1件 insert する', async () => {
       const db = testDb()
-      await db.insert(lists).values({ id: 'list-1', title: 'x' })
+      const userId = await createTestUser()
+      await db.insert(lists).values({ id: 'list-1', userId, title: 'x' })
 
       expect(await db.select({ n: count() }).from(lists)).toEqual([{ n: 1 }])
     })


### PR DESCRIPTION
Closes #51

#14 で意図的に持たせなかった列。**持ち主のいないリストは DB に存在しない**ため `NOT NULL`。
未ログインのリストは localStorage にあり DB には来ない（`PRODUCT_SPEC.md` §2）。

## 🔴 生成された SQL が2箇所で間違っていた

drizzle-kit が出したのは1文だけ。

```sql
ALTER TABLE `lists` ADD `user_id` text NOT NULL REFERENCES users(id);
```

1. **SQLite は `NOT NULL` の列を `DEFAULT` 無しで `ADD COLUMN` できない。**
   行が無くても DDL の時点で失敗する
2. **`ON DELETE CASCADE` が落ちている。** スキーマに `onDelete: 'cascade'` と書いたのに SQL に出ない

**そのまま適用したら失敗し、仮に通っても cascade が無い状態になっていた。**
生成物を確認せずに適用していたら気づけなかった。

`lists` は local / remote とも 0 行だったので、作り直す形で手書きした
（行がある場合は持ち主を決められないので、そもそも移行できない）。
判断の理由はマイグレーションファイルの先頭にコメントで残した。

## D1 は外部キーを強制する（実測）

テストで確認できた。**SQLite は設定次第で外部キーを無視することがあるので、
確認しておく価値がある。**

- 所有者のいないリストは作れない（`NOT NULL constraint failed`）
- 存在しない利用者を所有者にできない（**`FOREIGN KEY constraint failed`**）
- 利用者を消すとリストも消える（cascade）

## #15 の説明を訂正した

`resetDb` の実装コメントに「削除は作成順の逆なので、子テーブルが親より先に消える」と
書いていたが**実態と違った。** 実際の削除順は
`verifications` → `users` → `sessions` → `accounts` → `lists` で、
**親が子より先に消えている。**

壊れないのは**子の外部キーがすべて `on delete cascade` だから**で、順序のおかげではない。
`restrict` や `no action` の外部キーを足したら順序を考える必要がある、という記述に直した。

## テスト（42件、7.1秒）

リモートにもマイグレーションを適用済み。
