### PR TITLE
認可をサーバー1箇所に集約し、認可のテストを書く

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -28,12 +28,14 @@
     "wrangler": "^4.119.0"
   },
   "dependencies": {
+    "@hono/zod-validator": "^0.9.0",
     "@sentry/cloudflare": "^10.69.0",
     "@yaritai100list/shared": "^0.0.0",
     "better-auth": "~1.6.26",
     "drizzle-orm": "^0.45.2",
     "hono": "^4.13.0",
     "react": "^19.2.8",
-    "react-dom": "^19.2.8"
+    "react-dom": "^19.2.8",
+    "zod": "^4.4.3"
   }
 }

--- a/apps/web/src/authorization.ts
+++ b/apps/web/src/authorization.ts
@@ -1,0 +1,79 @@
+import * as Sentry from '@sentry/cloudflare'
+import { and, eq } from 'drizzle-orm'
+import { createMiddleware } from 'hono/factory'
+
+import { createAuth } from './auth'
+import { createDb } from './db'
+import { lists } from './db/schema'
+import type { AppEnv } from './env'
+
+/**
+ * 認可はここに集める。**ハンドラごとに所有者チェックを書かない。**
+ *
+ * `CLAUDE.md` の不変条件「認可はサーバーのコード1箇所に集める」の実体。
+ * 1箇所に集めるだけでなく、**構造的に迂回できない形**にしている:
+ *
+ * - ハンドラは `listId` を受け取らない。`c.get('list')` で**すでに認可を通った行**を受け取る
+ * - つまりミドルウェアを付け忘れたハンドラには、そもそも触れるリストが無い
+ *
+ * 「チェックを呼び忘れる」ではなく「呼び忘れたら動かない」に寄せている。
+ */
+
+/**
+ * ログインしていることを要求する。
+ *
+ * セッションは D1 から引く（Cookie キャッシュは無効。`src/auth.ts`）。
+ * つまり**サーバー側で行を消せば、この時点で拒否される。**
+ */
+export const requireUser = createMiddleware<AppEnv>(async (c, next) => {
+  const auth = createAuth(createDb(c.env.DB), c.env)
+  const session = await auth.api.getSession({ headers: c.req.raw.headers })
+
+  if (!session) {
+    return c.json({ error: 'Unauthorized' } as const, 401)
+  }
+
+  c.set('userId', session.user.id)
+
+  // 障害がどの利用者で起きたかを追えるようにする。**id だけ。**
+  // メールアドレスや名前は送らない（`src/sentry.ts` の scrubEvent で二重に落としている）
+  Sentry.setUser({ id: session.user.id })
+
+  // noImplicitReturns があるので return で揃える
+  return next()
+})
+
+/**
+ * URL の `listId` が**ログイン中の利用者のもの**であることを要求する。
+ *
+ * 🔴 **見つからない場合と他人のものである場合で、同じ応答を返す。**
+ * 404 と 403 を出し分けると「その ID は存在する」ことが分かってしまい、
+ * 推測不可能な ID にしている意味が薄れる（`CLAUDE.md` の不変条件）。
+ *
+ * `requireUser` の後に置く。
+ */
+export const requireOwnedList = createMiddleware<AppEnv>(async (c, next) => {
+  const listId = c.req.param('listId')
+  const userId = c.get('userId')
+
+  // このミドルウェアを `:listId` を持たないルートに付けた場合。
+  // 型が `string | undefined` になることで気づける。
+  // 例外にせず 404 にするのは、他の「見つからない」と応答を揃えるため
+  if (listId === undefined) {
+    return c.json({ error: 'Not Found' } as const, 404)
+  }
+
+  const [list] = await createDb(c.env.DB)
+    .select()
+    .from(lists)
+    .where(and(eq(lists.id, listId), eq(lists.userId, userId)))
+    .limit(1)
+
+  if (!list) {
+    return c.json({ error: 'Not Found' } as const, 404)
+  }
+
+  c.set('list', list)
+
+  return next()
+})

--- a/apps/web/src/env.ts
+++ b/apps/web/src/env.ts
@@ -1,0 +1,34 @@
+import type { InferSelectModel } from 'drizzle-orm'
+
+import type { AuthEnv } from './auth'
+import type { lists } from './db/schema'
+import type { SentryEnv } from './sentry'
+
+/**
+ * Hono に渡す環境。ミドルウェアとハンドラの両方から参照するため、
+ * `index.ts` ではなくここに置いている（循環 import を避ける）。
+ *
+ * `Env` は `npm run cf-typegen`（wrangler types）が wrangler.jsonc の
+ * バインディングから生成する。バインディングを増やしたら cf-typegen を再実行する
+ * （typecheck の前に自動で走る）。
+ *
+ * `AuthEnv` と `SentryEnv` を交差させているのは、**シークレットが `Env` に入らない**ため。
+ * `wrangler types` は `.dev.vars` から型を作るが、それは gitignore されていて CI に無い。
+ * **このアプリが動くために必要な環境変数の一覧**がここに集まる形になっている。
+ */
+export interface AppEnv {
+  Bindings: Env & AuthEnv & SentryEnv
+
+  Variables: {
+    /** `requireUser` が入れる。ログイン中の利用者の id */
+    userId: string
+
+    /**
+     * `requireOwnedList` が入れる。**すでに所有者チェックを通ったリスト。**
+     *
+     * ハンドラは `listId` ではなくこれを受け取る。
+     * ミドルウェアを付け忘れたハンドラには触れるリストが無い、という構造にしている。
+     */
+    list: InferSelectModel<typeof lists>
+  }
+}

--- a/apps/web/src/index.ts
+++ b/apps/web/src/index.ts
@@ -1,25 +1,27 @@
 import * as Sentry from '@sentry/cloudflare'
+import { listTitleSchema, visibilitySchema } from '@yaritai100list/shared'
+import { zValidator } from '@hono/zod-validator'
+import { eq } from 'drizzle-orm'
 import { Hono } from 'hono'
+import { z } from 'zod'
 
-import { type AuthEnv, createAuth } from './auth'
+import { createAuth } from './auth'
+import { requireOwnedList, requireUser } from './authorization'
 import { createDb } from './db'
 import { lists } from './db/schema'
-import { type SentryEnv, sentryOptions } from './sentry'
+import type { AppEnv } from './env'
+import { sentryOptions } from './sentry'
 
 /**
- * Hono に渡す環境。
- *
- * `Env` は `npm run cf-typegen`（wrangler types）が wrangler.jsonc の
- * バインディングから生成する。バインディングを増やしたら cf-typegen を再実行する
- * （typecheck の前に自動で走る）。
- *
- * `AuthEnv` と `SentryEnv` を交差させているのは、**シークレットが `Env` に入らない**ため。
- * `wrangler types` は `.dev.vars` から型を作るが、それは gitignore されていて CI に無い。
- * **このアプリが動くために必要な環境変数の一覧**がここに集まる形になっている。
+ * リストの更新で受け付ける内容。**上限は packages/shared の Zod スキーマが唯一の情報源。**
+ * 画面側でも同じスキーマを使うので、上限がずれない。
  */
-export interface AppEnv {
-  Bindings: Env & AuthEnv & SentryEnv
-}
+const updateListSchema = z
+  .object({
+    title: listTitleSchema.optional(),
+    visibility: visibilitySchema.optional(),
+  })
+  .strict()
 
 /**
  * ルートはコンストラクタから直接チェーンする。Hono RPC はメソッドチェーンの
@@ -61,6 +63,53 @@ const app = new Hono<AppEnv>()
     for (const cookie of res.headers.getSetCookie()) headers.append('set-cookie', cookie)
 
     return new Response(null, { status: 302, headers })
+  })
+
+  /**
+   * 自分のリストの一覧。**他人の行が混ざらないよう `userId` で絞る。**
+   */
+  .get('/api/lists', requireUser, async (c) => {
+    const rows = await createDb(c.env.DB)
+      .select()
+      .from(lists)
+      .where(eq(lists.userId, c.get('userId')))
+
+    return c.json({ lists: rows })
+  })
+
+  /**
+   * リスト1件。**`requireOwnedList` が認可を通した行を返すだけ。**
+   * ハンドラは `listId` を触らないので、認可を迂回する余地が無い。
+   */
+  .get('/api/lists/:listId', requireUser, requireOwnedList, (c) => c.json({ list: c.get('list') }))
+
+  /** リストのタイトルと公開範囲を変える。 */
+  .patch(
+    '/api/lists/:listId',
+    requireUser,
+    requireOwnedList,
+    zValidator('json', updateListSchema),
+    async (c) => {
+      const list = c.get('list')
+      const patch = c.req.valid('json')
+
+      const [updated] = await createDb(c.env.DB)
+        .update(lists)
+        .set({ ...patch, updatedAt: new Date() })
+        .where(eq(lists.id, list.id))
+        .returning()
+
+      return c.json({ list: updated })
+    },
+  )
+
+  /** リストを削除する。 */
+  .delete('/api/lists/:listId', requireUser, requireOwnedList, async (c) => {
+    await createDb(c.env.DB)
+      .delete(lists)
+      .where(eq(lists.id, c.get('list').id))
+
+    return c.json({ deleted: true } as const)
   })
 
   /**

--- a/apps/web/test/authorization.test.ts
+++ b/apps/web/test/authorization.test.ts
@@ -1,0 +1,186 @@
+import { exports } from 'cloudflare:workers'
+import { eq } from 'drizzle-orm'
+import { describe, expect, it } from 'vitest'
+
+import { lists, sessions } from '../src/db/schema'
+import { signIn, testBaseUrl, testDb } from './helpers'
+
+/**
+ * 認可のテスト。**「通らないこと」を書く。**
+ *
+ * `docs/workflow.md` §6 の通り、成功パスだけでは意味がない。
+ * 他人のリストに触れないこと、失効したセッションが通らないことを固定する。
+ */
+
+// オリジンは Worker の BETTER_AUTH_URL に揃える（Cookie 名と Origin チェックのため）
+const request = (path: string, init?: RequestInit) =>
+  exports.default.fetch(new Request(`${testBaseUrl()}${path}`, init))
+
+/** 自分と他人、それぞれのリストを用意する */
+async function twoUsers() {
+  const me = await signIn('me@example.com')
+  const other = await signIn('other@example.com')
+
+  await testDb()
+    .insert(lists)
+    .values([
+      { id: 'my-list', userId: me.userId, title: '自分のリスト' },
+      { id: 'other-list', userId: other.userId, title: '他人のリスト' },
+    ])
+
+  return { me, other }
+}
+
+describe('未ログイン', () => {
+  it('リストの一覧を取れない', async () => {
+    const res = await request('/api/lists')
+
+    expect(res.status).toBe(401)
+    expect(await res.json()).toEqual({ error: 'Unauthorized' })
+  })
+
+  it('リスト1件を取れない', async () => {
+    const { me } = await twoUsers()
+
+    const res = await request('/api/lists/my-list')
+
+    expect(res.status).toBe(401)
+    // 存在は漏らさない
+    expect(await res.json()).toEqual({ error: 'Unauthorized' })
+    expect(me.userId).toBeTruthy()
+  })
+
+  it('リストを更新できない', async () => {
+    await twoUsers()
+
+    const res = await request('/api/lists/my-list', {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ title: '書き換え' }),
+    })
+
+    expect(res.status).toBe(401)
+
+    const [row] = await testDb().select().from(lists).where(eq(lists.id, 'my-list'))
+    expect(row?.title).toBe('自分のリスト')
+  })
+
+  it('リストを削除できない', async () => {
+    await twoUsers()
+
+    const res = await request('/api/lists/my-list', { method: 'DELETE' })
+
+    expect(res.status).toBe(401)
+    expect(await testDb().select().from(lists).where(eq(lists.id, 'my-list'))).toHaveLength(1)
+  })
+})
+
+describe('ログイン中', () => {
+  it('自分のリストは取れる', async () => {
+    const { me } = await twoUsers()
+
+    const res = await request('/api/lists/my-list', { headers: me.headers })
+
+    expect(res.status).toBe(200)
+  })
+
+  it('一覧に他人のリストが混ざらない', async () => {
+    const { me } = await twoUsers()
+
+    const res = await request('/api/lists', { headers: me.headers })
+    const body = await res.json<{ lists: { id: string }[] }>()
+
+    expect(body.lists.map((l) => l.id)).toEqual(['my-list'])
+  })
+
+  it('他人のリストは読めない', async () => {
+    const { me } = await twoUsers()
+
+    const res = await request('/api/lists/other-list', { headers: me.headers })
+
+    expect(res.status).toBe(404)
+  })
+
+  it('他人のリストには書けない', async () => {
+    const { me } = await twoUsers()
+
+    const res = await request('/api/lists/other-list', {
+      method: 'PATCH',
+      headers: { ...Object.fromEntries(me.headers), 'content-type': 'application/json' },
+      body: JSON.stringify({ title: '乗っ取り' }),
+    })
+
+    expect(res.status).toBe(404)
+
+    const [row] = await testDb().select().from(lists).where(eq(lists.id, 'other-list'))
+    expect(row?.title).toBe('他人のリスト')
+  })
+
+  it('他人のリストは削除できない', async () => {
+    const { me } = await twoUsers()
+
+    const res = await request('/api/lists/other-list', { method: 'DELETE', headers: me.headers })
+
+    expect(res.status).toBe(404)
+    expect(await testDb().select().from(lists).where(eq(lists.id, 'other-list'))).toHaveLength(1)
+  })
+
+  it('🔴 存在しない ID と他人の ID で応答が完全に一致する', async () => {
+    const { me } = await twoUsers()
+
+    const missing = await request('/api/lists/no-such-list', { headers: me.headers })
+    const others = await request('/api/lists/other-list', { headers: me.headers })
+
+    // 404 と 403 を出し分けると「その ID は存在する」と分かってしまい、
+    // 推測不可能な ID にしている意味が薄れる
+    expect(missing.status).toBe(others.status)
+    expect(await missing.text()).toBe(await others.text())
+  })
+})
+
+describe('失効したセッション', () => {
+  it('セッションの行を消すと通らなくなる', async () => {
+    const { me } = await twoUsers()
+
+    // 消す前は通る
+    expect((await request('/api/lists', { headers: me.headers })).status).toBe(200)
+
+    // サーバー側から失効させる
+    await testDb().delete(sessions)
+
+    expect((await request('/api/lists', { headers: me.headers })).status).toBe(401)
+  })
+})
+
+describe('入力の検証', () => {
+  it('上限を超えるタイトルは拒否する', async () => {
+    const me = await signIn('validator@example.com')
+    await testDb().insert(lists).values({ id: 'v-list', userId: me.userId, title: 'x' })
+
+    const res = await request('/api/lists/v-list', {
+      method: 'PATCH',
+      headers: { ...Object.fromEntries(me.headers), 'content-type': 'application/json' },
+      // リストタイトルの上限は 15 文字（packages/shared）
+      body: JSON.stringify({ title: 'あ'.repeat(16) }),
+    })
+
+    expect(res.status).toBe(400)
+
+    const [row] = await testDb().select().from(lists).where(eq(lists.id, 'v-list'))
+    expect(row?.title).toBe('x')
+  })
+
+  it('知らないキーは拒否する', async () => {
+    const me = await signIn('validator2@example.com')
+    await testDb().insert(lists).values({ id: 'v2-list', userId: me.userId, title: 'x' })
+
+    // user_id を書き換えて他人に付け替える、といった経路を塞ぐ
+    const res = await request('/api/lists/v2-list', {
+      method: 'PATCH',
+      headers: { ...Object.fromEntries(me.headers), 'content-type': 'application/json' },
+      body: JSON.stringify({ userId: 'someone-else' }),
+    })
+
+    expect(res.status).toBe(400)
+  })
+})

--- a/apps/web/test/helpers.ts
+++ b/apps/web/test/helpers.ts
@@ -1,4 +1,5 @@
 import { env } from 'cloudflare:workers'
+import { makeSignature } from 'better-auth/crypto'
 
 import { type Auth, createAuth } from '../src/auth'
 import { createDb, type Db } from '../src/db'
@@ -53,9 +54,40 @@ export async function resetDb(): Promise<void> {
  */
 export function testAuth(): Auth {
   return createAuth(testDb(), {
-    BETTER_AUTH_SECRET: 'test-secret-not-used-outside-tests-0123456789',
-    BETTER_AUTH_URL: 'https://example.com',
+    BETTER_AUTH_SECRET: workerEnv('BETTER_AUTH_SECRET'),
+    BETTER_AUTH_URL: testBaseUrl(),
   })
+}
+
+/**
+ * テストのリクエストに使うオリジン。**Worker の `BETTER_AUTH_URL` と揃える。**
+ *
+ * ずれると2つの理由で認証が通らない:
+ * - **Cookie 名が変わる。** https なら `__Secure-` 接頭辞が付き、http なら付かない
+ * - Better Auth の Origin チェックに引っかかる
+ */
+export function testBaseUrl(): string {
+  return workerEnv('BETTER_AUTH_URL')
+}
+
+/**
+ * 🔴 **Worker が実際に使っている環境変数を読む。テスト側に固定値を書かない。**
+ *
+ * `wrangler` は `.dev.vars` を読み、**その値が vitest の `miniflare.bindings` を上書きする。**
+ * つまり手元では `.dev.vars`、CI では `miniflare.bindings` の値が使われる。
+ * テスト側に固定値を書くと、**手元だけ、あるいは CI だけ落ちる。**
+ *
+ * `Env` の型には入らない（`.dev.vars` は gitignore されていて CI に無いため）ので、
+ * ここで narrow する。
+ */
+function workerEnv(name: string): string {
+  const value = (env as unknown as Record<string, unknown>)[name]
+
+  if (typeof value !== 'string' || value === '') {
+    throw new Error(`${name} がテスト環境に無い。vitest.config.ts を確認する`)
+  }
+
+  return value
 }
 
 /**
@@ -81,5 +113,35 @@ export async function createTestUser(email = 'owner@example.com'): Promise<strin
 }
 
 /**
- * 認証済みセッションを作るヘルパはここに足す（#52 で認可のテストを書くときに必要）。
+ * 利用者を作り、**認証済みリクエスト用の Headers** を返す。
+ *
+ * Better Auth のセッション Cookie は**署名付き**なので手では作れない。
+ * 署名の作り方は better-auth 自身のテストユーティリティ
+ * （`dist/plugins/test-utils/cookie-builder.mjs`）と同じ:
+ *
+ * ```
+ * signCookieValue(value, secret) => `${value}.${await makeSignature(value, secret)}`
+ * ```
+ *
+ * そのユーティリティは `exports` に公開されていないため deep import できない。
+ * 依存している `makeSignature` は `better-auth/crypto` から公開されているので、
+ * **1行だけ同じ実装を持つ。** Better Auth を上げるときは
+ * cookie-builder.mjs の実装が変わっていないか確認する。
  */
+export async function signIn(email = 'owner@example.com'): Promise<{
+  userId: string
+  headers: Headers
+}> {
+  const auth = testAuth()
+  const ctx = await auth.$context
+
+  const userId = await createTestUser(email)
+  const session = await ctx.internalAdapter.createSession(userId, undefined)
+
+  const signed = `${session.token}.${await makeSignature(session.token, ctx.secret)}`
+  const headers = new Headers({
+    cookie: `${ctx.authCookies.sessionToken.name}=${signed}`,
+  })
+
+  return { userId, headers }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,13 +27,15 @@
       "name": "@yaritai100list/web",
       "version": "0.0.0",
       "dependencies": {
+        "@hono/zod-validator": "^0.9.0",
         "@sentry/cloudflare": "^10.69.0",
         "@yaritai100list/shared": "^0.0.0",
         "better-auth": "~1.6.26",
         "drizzle-orm": "^0.45.2",
         "hono": "^4.13.0",
         "react": "^19.2.8",
-        "react-dom": "^19.2.8"
+        "react-dom": "^19.2.8",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@cloudflare/vite-plugin": "^1.51.0",
@@ -1410,6 +1412,16 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@hono/zod-validator": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@hono/zod-validator/-/zod-validator-0.9.0.tgz",
+      "integrity": "sha512-n0ZSXmCiHVIp4Y5wlOOyZCeTd/rsawA/qW1cipB8QOYKZ9N8Tk0nZUZCXho9cu374AN4JpDNKioNKBJ/W+LBug==",
+      "license": "MIT",
+      "peerDependencies": {
+        "hono": ">=4.11.2",
+        "zod": "^3.25.0 || ^4.0.0"
       }
     },
     "node_modules/@humanfs/core": {


### PR DESCRIPTION
Closes #52

`CLAUDE.md` の不変条件「**認可はサーバーのコード1箇所に集める**」の実体。

## 1箇所に集めるだけでなく、迂回できない形にした

```ts
.get('/api/lists/:listId', requireUser, requireOwnedList, (c) => c.json({ list: c.get('list') }))
```

**ハンドラは `listId` を受け取らない。** `c.get('list')` で**すでに認可を通った行**を受け取る。
つまり `requireOwnedList` を付け忘れたハンドラには、そもそも触れるリストが無い。

「チェックを呼び忘れる」ではなく「**呼び忘れたら動かない**」に寄せている。
人間がレビューしない前提では、規律より構造で守る方が確実。

## 存在しない ID と他人の ID で応答を完全に一致させた

404 と 403 を出し分けると「**その ID は存在する**」ことが分かってしまい、
推測不可能な ID にしている意味が薄れる。

```ts
expect(missing.status).toBe(others.status)
expect(await missing.text()).toBe(await others.text())
```

ステータスだけでなく**本文まで一致**を確認している。

## テスト（55件、8.2秒）

「通らないこと」を中心に書いた。

| 観点 | 確認 |
|---|---|
| 未ログイン | 一覧・取得・更新・削除すべて 401。**更新と削除では行が変わっていないことも確認** |
| 他人のリスト | 読めない・書けない・削除できない（すべて 404） |
| 一覧 | 他人の行が混ざらない |
| 存在しない ID | 他人の ID と**応答が完全一致** |
| 失効 | セッションの行を消すと 401 になる |
| 入力 | 上限超過のタイトルを拒否。**知らないキー（`userId` の付け替え）を拒否** |

## 🔴 テストで踏んだ設定の食い違い

**`.dev.vars` の値が vitest の `miniflare.bindings` を上書きする。**

最初、認証済みリクエストのテストが8件すべて 401 になった。原因は2段階あった。

1. **署名鍵の不一致。** テスト側は固定リテラルで署名し、Worker 側は `.dev.vars` の鍵で検証していた
2. **Cookie 名の不一致。** `__Secure-` 接頭辞が付くかは `baseURL` のプロトコルで決まる。
   テストは `https://example.com` を前提にしていたが、Worker は `.dev.vars` の
   `http://localhost:5173` を使うため接頭辞が付かない名前を期待していた

どちらも「テスト側に固定値を書いた」ことが原因。**テストは Worker の env から読む**形に直した
（`workerEnv()`）。これで手元と CI のどちらでも、鍵やオリジンの出所に依存しなくなる。

## セッション Cookie の署名について

Better Auth の Cookie は署名付きなので手では作れない。
better-auth 自身のテストユーティリティ（`dist/plugins/test-utils/cookie-builder.mjs`）と
同じ方法で作っている。

```
signCookieValue(value, secret) => `${value}.${await makeSignature(value, secret)}`
```

そのユーティリティは `exports` に公開されていないため deep import できない。
依存している `makeSignature` は `better-auth/crypto` から公開されているので、
**1行だけ同じ実装を持っている。** Better Auth を上げるときは実装が変わっていないか確認する旨を
ヘルパのコメントに書いた。

## 未検証

**`Sentry.setUser({ id })` が実際に効くかは未確認。** `dataCollection.userInfo: false` が
明示的な `setUser` まで落とさないかを本番で見る必要がある（#52 の本文に書いた確認項目）。
ログイン中に例外を起こす経路が今は無いので、#5 以降で自然に確認できるようになる。
