### PR TITLE
ログアウトを実装する

### DIFF
--- a/apps/web/src/client/App.tsx
+++ b/apps/web/src/client/App.tsx
@@ -1,20 +1,20 @@
 import { SERVICE_NAME } from '@yaritai100list/shared'
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 
 import { api } from './api'
+
+/** ログイン状態。判定中と未ログインを区別する（未ログインのときだけ導線を出すため） */
+type SessionState = { status: 'loading' } | { status: 'anonymous' } | { status: 'authenticated' }
 
 /**
  * 土台の確認用の画面。リストの UI は #4 で作る。
  *
- * ここで確かめているのは:
- * - SPA が Workers から配信されること
- * - 同一オリジンで API を呼べること（CORS の設定が要らないこと）
- * - **Hono RPC でサーバーの型がクライアントに流れること**
- * - ログインが通ること（ログアウトと状態表示は #53 で作る）
+ * ロジックを純関数に切り出すのは #4 から（`TECH_STACK.md` §10 の方針）。
+ * ここにあるのはセッションの取得とログアウトの呼び出しだけで、切り出す中身が無い。
  */
 export function App() {
-  const [health, setHealth] = useState<string>('確認中')
-  const [session, setSession] = useState<string>('確認中')
+  const [health, setHealth] = useState('確認中')
+  const [session, setSession] = useState<SessionState>({ status: 'loading' })
 
   useEffect(() => {
     const check = async () => {
@@ -29,31 +29,50 @@ export function App() {
     void check()
   }, [])
 
-  useEffect(() => {
-    const check = async () => {
-      // Better Auth のエンドポイントは Hono RPC の型に乗らないので普通の fetch で呼ぶ
-      const res = await fetch('/api/auth/get-session')
-      const body: unknown = await res.json()
+  const loadSession = useCallback(async () => {
+    // Better Auth のエンドポイントは Hono RPC の型に乗らないので普通の fetch で呼ぶ
+    const res = await fetch('/api/auth/get-session')
+    const body: unknown = await res.json()
 
-      setSession(body === null ? '未ログイン' : 'ログイン中')
-    }
-
-    void check()
+    setSession({ status: body === null ? 'anonymous' : 'authenticated' })
   }, [])
+
+  useEffect(() => {
+    void loadSession()
+  }, [loadSession])
+
+  const signOut = useCallback(async () => {
+    await fetch('/api/auth/sign-out', { method: 'POST' })
+
+    // サーバー側でセッションを消したので、状態を取り直す
+    await loadSession()
+  }, [loadSession])
 
   return (
     <main>
       <h1>{SERVICE_NAME}</h1>
       <p>API: {health}</p>
-      <p>セッション: {session}</p>
+
+      {session.status === 'loading' && <p>読み込み中</p>}
+
       {/*
-        Better Auth の sign-in は POST なので、`<a>` から叩ける GET の入口を
-        サーバー側に用意している（`/api/login/google`）。
-        ボタンの見た目とログアウトは #53 で作る。
+        ログインの開始は POST なので `<a>` から叩けない。
+        サーバー側に GET の入口を用意している（`/api/login/google`）
       */}
-      <p>
-        <a href="/api/login/google">Google でログイン</a>
-      </p>
+      {session.status === 'anonymous' && (
+        <p>
+          <a href="/api/login/google">Google でログイン</a>
+        </p>
+      )}
+
+      {session.status === 'authenticated' && (
+        <p>
+          ログイン中{' '}
+          <button type="button" onClick={() => void signOut()}>
+            ログアウト
+          </button>
+        </p>
+      )}
     </main>
   )
 }

--- a/apps/web/src/index.ts
+++ b/apps/web/src/index.ts
@@ -113,7 +113,18 @@ const app = new Hono<AppEnv>()
   })
 
   /**
-   * Better Auth の全エンドポイント（セッション取得、コールバック等）。
+   * ⚠️ **一時的なルート。Sentry に `user.id` が届くかを確認するためだけに置いている。**
+   * 確認できたら次の PR で消す（恒久的に置くと公開されたエラー発生器になる。#48 と同じ理由）。
+   *
+   * `requireUser` の後に置いているので、**ログイン中の状態で例外が起きる。**
+   * `Sentry.setUser({ id })` の効果を見るにはこの条件が必要。
+   */
+  .get('/api/dev/sentry-check', requireUser, () => {
+    throw new Error('Sentry に user.id が届くかの確認（一時的なルート）')
+  })
+
+  /**
+   * Better Auth の全エンドポイント（セッション取得、サインアウト、コールバック等）。
    *
    * **`wrangler.jsonc` の `run_worker_first` に `/api/*` が入っているので Worker に届く。**
    * ここを `/auth/*` のような別のプレフィックスに変えるなら、あちらにも足すこと。

--- a/apps/web/test/authorization.test.ts
+++ b/apps/web/test/authorization.test.ts
@@ -184,3 +184,46 @@ describe('入力の検証', () => {
     expect(res.status).toBe(400)
   })
 })
+
+describe('ログアウト', () => {
+  /**
+   * ブラウザが送る形に合わせる。**Origin が無いと Better Auth の CSRF 保護に弾かれる**
+   * （Cookie を伴う POST で Origin を検証している）。
+   */
+  const signOutRequest = (headers: Headers) =>
+    request('/api/auth/sign-out', {
+      method: 'POST',
+      headers: { ...Object.fromEntries(headers), origin: testBaseUrl() },
+    })
+
+  it('セッションが D1 から消える', async () => {
+    const me = await signIn('signout@example.com')
+
+    expect(await testDb().select().from(sessions)).toHaveLength(1)
+
+    const res = await signOutRequest(me.headers)
+
+    expect(res.status).toBe(200)
+    // Cookie を消すだけでなく、**サーバー側の行が消えること**を確認する。
+    // 行が残っていると、Cookie を持っている誰かが使い続けられる
+    expect(await testDb().select().from(sessions)).toHaveLength(0)
+  })
+
+  it('ログアウト後は保護 API が通らない', async () => {
+    const me = await signIn('signout2@example.com')
+
+    await signOutRequest(me.headers)
+
+    expect((await request('/api/lists', { headers: me.headers })).status).toBe(401)
+  })
+
+  it('Origin の無いログアウト要求は拒否される（CSRF 保護）', async () => {
+    const me = await signIn('csrf@example.com')
+
+    const res = await request('/api/auth/sign-out', { method: 'POST', headers: me.headers })
+
+    expect(res.status).toBe(403)
+    // 拒否されたのだからセッションは残っている
+    expect(await testDb().select().from(sessions)).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
Refs #53 #52

旧実装で未完成だった部分（`PRODUCT_SPEC.md` §4.2）。

## サーバー側の行が消えることを確認している

```ts
expect(res.status).toBe(200)
expect(await testDb().select().from(sessions)).toHaveLength(0)
```

**Cookie を消すだけでは不十分。** 行が残っている限り、その Cookie を持っている誰かが
使い続けられる。`CLAUDE.md` の「セッションはサーバー側から失効できる方式にする」は
ログアウトでも同じ話になる。

## CSRF 保護が効いていることも固定した

テストを書いたとき、`POST /api/auth/sign-out` が **403** を返した。
Better Auth が **Cookie を伴う POST で `Origin` を検証している**（CSRF 保護）。

ブラウザは `Origin` を自動で送るので実際の操作では問題にならないが、
テストでは明示する必要がある。**保護が効いていること自体をテストにした。**

```ts
it('Origin の無いログアウト要求は拒否される（CSRF 保護）', ...)
// 403 になり、セッションが残っていることも確認
```

## 一時的なルートを含む

`/api/dev/sentry-check` を入れている。**`requireUser` の後に置いてあるので、
ログイン中の状態で例外が起きる。** `Sentry.setUser({ id })` の効果を確認するにはこの条件が必要
（#52 で未検証として残した項目）。

**確認できたら次の PR で消す。** 恒久的に置くと公開されたエラー発生器になる（#48 と同じ理由）。

## ⚠️ テストの実行時間が伸びている

**8.2秒 → 13.7秒。** テストファイルが7つになり、ファイルごとの setup（マイグレーション適用）が
積み上がっている。`TECH_STACK.md` §1 の「赤/緑が数秒で返る」の限界に近づいている。

まだ許容範囲だが、#4 以降でファイルが増えると超える。
**次に伸びたら構成を見直す**（setup の共有、`singleWorker` など）。
