### PR TITLE
ログイン状態の判定を純関数に切り出し、取得の失敗を未ログインと区別する

### DIFF
--- a/apps/web/src/client/App.tsx
+++ b/apps/web/src/client/App.tsx
@@ -2,19 +2,18 @@ import { SERVICE_NAME } from '@yaritai100list/shared'
 import { useCallback, useEffect, useState } from 'react'
 
 import { api } from './api'
-
-/** ログイン状態。判定中と未ログインを区別する（未ログインのときだけ導線を出すため） */
-type SessionState = { status: 'loading' } | { status: 'anonymous' } | { status: 'authenticated' }
+import { toSessionState, type SessionState } from './model'
 
 /**
  * 土台の確認用の画面。リストの UI は #4 で作る。
  *
- * ロジックを純関数に切り出すのは #4 から（`TECH_STACK.md` §10 の方針）。
- * ここにあるのはセッションの取得とログアウトの呼び出しだけで、切り出す中身が無い。
+ * **状態の判定は `model.ts` の純関数に置く**（`TECH_STACK.md` §10 の方針）。
+ * ここに残すのは取得と描画の配線だけ。
  */
 export function App() {
   const [health, setHealth] = useState('確認中')
   const [session, setSession] = useState<SessionState>({ status: 'loading' })
+  const [signOutFailed, setSignOutFailed] = useState(false)
 
   useEffect(() => {
     const check = async () => {
@@ -30,11 +29,18 @@ export function App() {
   }, [])
 
   const loadSession = useCallback(async () => {
-    // Better Auth のエンドポイントは Hono RPC の型に乗らないので普通の fetch で呼ぶ
-    const res = await fetch('/api/auth/get-session')
-    const body: unknown = await res.json()
+    setSession({ status: 'loading' })
 
-    setSession({ status: body === null ? 'anonymous' : 'authenticated' })
+    try {
+      // Better Auth のエンドポイントは Hono RPC の型に乗らないので普通の fetch で呼ぶ
+      const res = await fetch('/api/auth/get-session')
+      const body: unknown = await res.json()
+
+      setSession(toSessionState({ ok: res.ok, body }))
+    } catch {
+      // 通信自体が失敗した場合（オフラインなど）。未ログインと区別する
+      setSession({ status: 'error' })
+    }
   }, [])
 
   useEffect(() => {
@@ -42,7 +48,13 @@ export function App() {
   }, [loadSession])
 
   const signOut = useCallback(async () => {
-    await fetch('/api/auth/sign-out', { method: 'POST' })
+    setSignOutFailed(false)
+
+    const res = await fetch('/api/auth/sign-out', { method: 'POST' })
+
+    // **失敗を黙って飲まない。** ここで状態を取り直すと画面は「ログイン中」に
+    // 戻るだけなので、利用者にはログアウトできたのか判断がつかない
+    if (!res.ok) setSignOutFailed(true)
 
     // サーバー側でセッションを消したので、状態を取り直す
     await loadSession()
@@ -54,6 +66,15 @@ export function App() {
       <p>API: {health}</p>
 
       {session.status === 'loading' && <p>読み込み中</p>}
+
+      {session.status === 'error' && (
+        <p>
+          ログイン状態を確認できませんでした{' '}
+          <button type="button" onClick={() => void loadSession()}>
+            再試行
+          </button>
+        </p>
+      )}
 
       {/*
         ログインの開始は POST なので `<a>` から叩けない。
@@ -73,6 +94,8 @@ export function App() {
           </button>
         </p>
       )}
+
+      {signOutFailed && <p>ログアウトに失敗しました。時間をおいて試してください</p>}
     </main>
   )
 }

--- a/apps/web/src/client/model.ts
+++ b/apps/web/src/client/model.ts
@@ -1,0 +1,46 @@
+/**
+ * クライアントのロジックのうち、**DOM を触らない部分**。
+ *
+ * ここだけをテストする（`TECH_STACK.md` §10 の方針。#43 で決定）。
+ * テストは workerd の中で走るので、**このファイルに DOM の API を持ち込まないこと。**
+ * 持ち込むとテストが落ちる。描画と配線は `*.tsx` 側に置く。
+ */
+
+/**
+ * ログイン状態。
+ *
+ * **`error` を `anonymous` に混ぜないこと。** 混ぜると、
+ * セッションの取得に失敗しただけなのに「未ログイン」として扱われ、
+ * ログイン済みの利用者にログインの導線を出してしまう。逆に `authenticated` に
+ * 倒すと、未ログインの利用者からログインの導線が消える。**どちらも詰む。**
+ */
+export type SessionState =
+  | { status: 'loading' }
+  | { status: 'anonymous' }
+  | { status: 'authenticated' }
+  | { status: 'error' }
+
+/**
+ * `GET /api/auth/get-session` の応答からログイン状態を決める。
+ *
+ * Better Auth はログイン中なら `{ session, user }` を、未ログインなら `null` を
+ * **どちらも 200 で**返す。したがって**状態は本文で見分ける**。
+ *
+ * 🔴 **HTTP の失敗を「未ログイン」として扱わない。**
+ * `null` かどうかだけで判定すると、500 の応答（本文はエラーオブジェクト）が
+ * `authenticated` になり、**障害中にログインの導線が消える。**
+ * Better Auth 側にも内部エラーを `null` に潰す不具合があり
+ * （better-auth#10566。#3 に記録）、区別できるのは HTTP の状態までなので、
+ * **せめてそこは落とさない。**
+ */
+export function toSessionState(response: { ok: boolean; body: unknown }): SessionState {
+  if (!response.ok) return { status: 'error' }
+  if (response.body === null) return { status: 'anonymous' }
+
+  // 200 なのに想定外の形。ログイン中と決めつけない
+  if (typeof response.body !== 'object' || !('user' in response.body)) {
+    return { status: 'error' }
+  }
+
+  return { status: 'authenticated' }
+}

--- a/apps/web/test/client-model.test.ts
+++ b/apps/web/test/client-model.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+
+import { toSessionState } from '../src/client/model'
+
+/**
+ * クライアント側で**唯一テストする層**（`TECH_STACK.md` §10、#43）。
+ *
+ * 描画と配線（ボタンに handler が付いているか等）はテストしない。
+ * ここで担保するのは「応答からログイン状態をどう決めるか」だけ。
+ */
+describe('toSessionState', () => {
+  it('200 で本文が null なら未ログイン', () => {
+    // Better Auth は未ログインでも 200 を返す。**本文で見分ける**
+    expect(toSessionState({ ok: true, body: null })).toEqual({ status: 'anonymous' })
+  })
+
+  it('200 で user が入っていればログイン中', () => {
+    const body = { session: { id: 's1' }, user: { id: 'u1' } }
+
+    expect(toSessionState({ ok: true, body })).toEqual({ status: 'authenticated' })
+  })
+
+  it('🔴 HTTP が失敗なら error。未ログインにもログイン中にも倒さない', () => {
+    // 500 の本文はエラーオブジェクトなので、`null` かどうかだけで判定すると
+    // **ログイン中**になり、障害中にログインの導線が消える
+    const body = { code: 'INTERNAL_SERVER_ERROR', message: 'boom' }
+
+    expect(toSessionState({ ok: false, body })).toEqual({ status: 'error' })
+  })
+
+  it('200 でも想定外の形なら error', () => {
+    // 応答の形が変わったときに、黙ってログイン中として扱わない
+    expect(toSessionState({ ok: true, body: {} })).toEqual({ status: 'error' })
+    expect(toSessionState({ ok: true, body: 'ok' })).toEqual({ status: 'error' })
+    expect(toSessionState({ ok: true, body: undefined })).toEqual({ status: 'error' })
+  })
+})


### PR DESCRIPTION
Refs #53

## 直した不具合

`GET /api/auth/get-session` が **500 を返したときに「ログイン中」と表示されていた。**

```ts
setSession({ status: body === null ? 'anonymous' : 'authenticated' })
```

500 の本文はエラーオブジェクトで `null` ではないため `authenticated` に倒れる。
**画面からログインの導線が消える**ので、障害中に未ログインの利用者は何もできない。
Better Auth 側にも内部エラーを `null` に潰す不具合があり（better-auth#10566。#3 に記録）、
アプリ側で区別できるのは HTTP の状態までなので、せめてそこは落とさないようにした。

`error` を `anonymous` に倒すのも駄目で、その場合はログイン済みの人にログイン導線が出る。
**独立した状態として持つ**しかないので `SessionState` に `error` を足し、再試行のボタンを置いた。

## 純関数への切り出し（#53 のチェック項目）

`src/client/model.ts` を新設し、判定を `toSessionState()` に移した。
`TECH_STACK.md` §10（#43 の決定）どおり、**クライアントでテストするのはこの層だけ。**
描画と配線はテストしない。

| 応答 | 状態 |
|---|---|
| 200 / `null` | `anonymous` |
| 200 / `{ session, user }` | `authenticated` |
| **非 2xx** | `error` |
| **200 だが想定外の形** | `error` |
| fetch が throw（オフライン等） | `error`（`App.tsx` 側の catch） |

## ログアウトの失敗を黙って飲まない

従来は失敗しても状態を取り直すだけで、画面は「ログイン中」に戻る。
成功したのか失敗したのか利用者に判断がつかないので、メッセージを出すようにした。

## 確認

- typecheck / lint / test（**62 tests, 8 files**）が緑
- `npm run dev` で起動して確認: `/api/auth/get-session` → `null` (200)、
  `/api/login/google` → 302（**`.dev.vars` の development クライアント ID** で
  `accounts.google.com` へ）、`/api/health` → ok、SPA → 200

**ブラウザで Google のログイン / ログアウトを通す確認は本番で行う**（#53 の完了条件）。