### PR TITLE
ログアウトが 415 になるのを直す

### DIFF
--- a/apps/web/src/client/App.tsx
+++ b/apps/web/src/client/App.tsx
@@ -2,7 +2,7 @@ import { SERVICE_NAME } from '@yaritai100list/shared'
 import { useCallback, useEffect, useState } from 'react'
 
 import { api } from './api'
-import { toSessionState, type SessionState } from './model'
+import { signOutRequestInit, toSessionState, type SessionState } from './model'
 
 /**
  * 土台の確認用の画面。リストの UI は #4 で作る。
@@ -50,7 +50,8 @@ export function App() {
   const signOut = useCallback(async () => {
     setSignOutFailed(false)
 
-    const res = await fetch('/api/auth/sign-out', { method: 'POST' })
+    // 要求の中身は model.ts に置いている（content-type と本文が要る理由もそこ）
+    const res = await fetch('/api/auth/sign-out', signOutRequestInit())
 
     // **失敗を黙って飲まない。** ここで状態を取り直すと画面は「ログイン中」に
     // 戻るだけなので、利用者にはログアウトできたのか判断がつかない

--- a/apps/web/src/client/model.ts
+++ b/apps/web/src/client/model.ts
@@ -44,3 +44,36 @@ export function toSessionState(response: { ok: boolean; body: unknown }): Sessio
 
   return { status: 'authenticated' }
 }
+
+/**
+ * `POST /api/auth/sign-out` に送る内容。**`App.tsx` とテストで同じものを使う。**
+ *
+ * 🔴 **`content-type: application/json` と本文 `{}` の両方が要る。**
+ * 素の `fetch(url, { method: 'POST' })` は本番で **415** になる（実際に踏んだ）。
+ *
+ * better-call の本文パーサ（`better-call/dist/utils.mjs`）はこう書かれている:
+ *
+ * ```js
+ * if (!request.body) return                                  // 本文が無ければ素通し
+ * if (!normalizedContentType) throw new APIError(415, ...)   // 本文があるのに content-type が無い
+ * ```
+ *
+ * ブラウザは本文の無い POST でも `Content-Length: 0` を送るため、Workers 側からは
+ * **空ストリームの「本文あり」**に見えて 415 に落ちる。
+ * 一方 `new Request(url, { method: 'POST' })` は `body` が `null` なので素通しし、
+ * **テストだけ 200 になる。** テストからこの定義を使うのは、その差を作らないため。
+ *
+ * `content-type` だけ付けて本文を空にすると、今度は `request.json()` が
+ * SyntaxError になり **400** が返る。だから `{}` を送る。
+ */
+export function signOutRequestInit(): {
+  method: string
+  headers: Record<string, string>
+  body: string
+} {
+  return {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: '{}',
+  }
+}

--- a/apps/web/test/authorization.test.ts
+++ b/apps/web/test/authorization.test.ts
@@ -2,6 +2,7 @@ import { exports } from 'cloudflare:workers'
 import { eq } from 'drizzle-orm'
 import { describe, expect, it } from 'vitest'
 
+import { signOutRequestInit } from '../src/client/model'
 import { lists, sessions } from '../src/db/schema'
 import { signIn, testBaseUrl, testDb } from './helpers'
 
@@ -187,14 +188,21 @@ describe('入力の検証', () => {
 
 describe('ログアウト', () => {
   /**
-   * ブラウザが送る形に合わせる。**Origin が無いと Better Auth の CSRF 保護に弾かれる**
-   * （Cookie を伴う POST で Origin を検証している）。
+   * ブラウザが送る形に合わせる。
+   *
+   * - **Origin が無いと Better Auth の CSRF 保護に弾かれる**
+   *   （Cookie を伴う POST で Origin を検証している）
+   * - **要求の中身は画面側と同じ `signOutRequestInit()` を使う。**
+   *   ここに直接書くと、画面側だけ直したときにテストが気づけない
    */
-  const signOutRequest = (headers: Headers) =>
-    request('/api/auth/sign-out', {
-      method: 'POST',
-      headers: { ...Object.fromEntries(headers), origin: testBaseUrl() },
+  const signOutRequest = (headers: Headers) => {
+    const init = signOutRequestInit()
+
+    return request('/api/auth/sign-out', {
+      ...init,
+      headers: { ...init.headers, ...Object.fromEntries(headers), origin: testBaseUrl() },
     })
+  }
 
   it('セッションが D1 から消える', async () => {
     const me = await signIn('signout@example.com')
@@ -224,6 +232,26 @@ describe('ログアウト', () => {
 
     expect(res.status).toBe(403)
     // 拒否されたのだからセッションは残っている
+    expect(await testDb().select().from(sessions)).toHaveLength(1)
+  })
+
+  it('🔴 本文があって content-type が無いと 415（本番で踏んだ）', async () => {
+    // ブラウザの `fetch(url, { method: 'POST' })` は本文が無くても Content-Length: 0 を
+    // 送るため、Workers 側では「本文あり」に見えて better-call の 415 に落ちる。
+    // **`new Request` は body が null なのでこの経路を再現しない。**
+    // 明示的に本文を付けて、415 になること自体を固定する（画面側が content-type を
+    // 落としたら、この仕様のせいで壊れると分かるように）
+    const me = await signIn('media-type@example.com')
+
+    // 本文をバイト列で渡す。**文字列を渡すと `Request` が
+    // `content-type: text/plain` を勝手に付けてしまい、「無い」状態を作れない**
+    const res = await request('/api/auth/sign-out', {
+      method: 'POST',
+      headers: { ...Object.fromEntries(me.headers), origin: testBaseUrl() },
+      body: new TextEncoder().encode('{}'),
+    })
+
+    expect(res.status).toBe(415)
     expect(await testDb().select().from(sessions)).toHaveLength(1)
   })
 })


### PR DESCRIPTION
Refs #53

ブラウザでログアウトを押すと **415 Unsupported Media Type** が返っていた（利用者が本番で確認）。

## 原因

`better-call/dist/utils.mjs` の本文パーサ。

```js
if (!request.body) return                                 // 本文が無ければ素通し
if (!normalizedContentType) throw new APIError(415, ...)  // 本文があるのに content-type が無い
```

ブラウザの `fetch(url, { method: 'POST' })` は**本文が無くても `Content-Length: 0` を送る**ため、
Workers 側からは空ストリームの「本文あり」に見えて 415 に落ちる。

## なぜテストが緑だったか

`new Request(url, { method: 'POST' })` は `body` が **`null`** なので、
上の1行目で素通しされて 200 になっていた。**本番の経路を再現していなかった。**

本番で確認済み:

```
POST /api/auth/sign-out                              → 415
POST /api/auth/sign-out  content-type: application/json + {}  → 200
```

## 直し方

要求の中身を `src/client/model.ts` の `signOutRequestInit()` に置き、
**画面側とテストで同じものを使う。** 画面側だけ直してもテストが気づけない状態にしない。

`content-type` だけ付けて本文を空にすると、今度は `request.json()` が SyntaxError になり
**400** が返るので、本文 `{}` も送る。

## 足したテスト

- 🔴 **本文があって content-type が無いと 415**（本番で踏んだ形。セッションは残る）
  - 本文は**バイト列**で渡している。文字列だと `Request` が `text/plain` を勝手に付けてしまい、
    「content-type が無い」状態を作れない
- 既存の「セッションが D1 から消える」テストは `signOutRequestInit()` 経由になったので、
  画面側から `content-type` を落とすと**このテストが落ちる**

63 tests / 8 files が緑。