### PR TITLE
リストのロジックを model.ts に純関数で書く

### DIFF
--- a/apps/web/src/client/model.ts
+++ b/apps/web/src/client/model.ts
@@ -4,7 +4,19 @@
  * ここだけをテストする（`TECH_STACK.md` §10 の方針。#43 で決定）。
  * テストは workerd の中で走るので、**このファイルに DOM の API を持ち込まないこと。**
  * 持ち込むとテストが落ちる。描画と配線は `*.tsx` 側に置く。
+ *
+ * **時刻と ID もここでは作らない。** `Date.now()` や `crypto.randomUUID()` を
+ * 関数の中で呼ぶと、戻り値が呼ぶたびに変わってテストで固定できない。
+ * 呼び出し側（`*.tsx`）が作って引数で渡す。
  */
+
+import {
+  DEFAULT_LIST_TITLE,
+  ITEMS_PER_LIST_MAX,
+  itemTextSchema,
+  listTitleSchema,
+} from '@yaritai100list/shared'
+import { z } from 'zod'
 
 /**
  * ログイン状態。
@@ -76,4 +88,231 @@ export function signOutRequestInit(): {
     headers: { 'content-type': 'application/json' },
     body: '{}',
   }
+}
+
+// ---------------------------------------------------------------------------
+// 未ログインで書くリスト（#4 / #72）
+// ---------------------------------------------------------------------------
+
+/**
+ * やりたいこと1件。
+ *
+ * **完了は真偽値ではなく日時**（`PRODUCT_SPEC.md` §3）。
+ * いつ叶えたかは思い出として意味があるので、`true` に潰さない。
+ */
+export interface Item {
+  /**
+   * クライアント内で一意な ID。**呼び出し側が `crypto.randomUUID()` などで作って渡す。**
+   *
+   * 配列の添字を ID 代わりにしない。途中の項目を消したときに以降の同一性がずれ、
+   * React が別の項目を使い回して**入力中のフォーカスや値が隣に飛ぶ。**
+   */
+  id: string
+  text: string
+  /** 完了日時（epoch ms）。未完了なら `null`。 */
+  completedAt: number | null
+}
+
+/**
+ * 未ログインで持てる唯一のリスト（`PRODUCT_SPEC.md` §2）。
+ *
+ * **並び順は `items` の配列順そのもの。** 並び順の列を別に持たない。
+ * 2つあると必ずずれるし、ずれたときにどちらが正しいか決められない。
+ * 表示上の番号は配列の添字 + 1（`formatItemNumber`）。
+ *
+ * **項目の実体は可変長。** 100個の空スロットは持たない（`PRODUCT_SPEC.md` §3）。
+ * 空枠は表示のときだけ作る（`toSlots`）。
+ */
+export interface LocalList {
+  title: string
+  items: Item[]
+}
+
+/**
+ * 操作の結果。**失敗を握り潰さない。**
+ *
+ * 上限に当たったのか、入力が不正なのか、対象が見つからないのかで
+ * 画面に出すべきことが違う。`null` を返して呼び出し側に推測させない。
+ */
+export type ListResult =
+  | { ok: true; list: LocalList }
+  | { ok: false; reason: 'invalid-text' | 'invalid-title' | 'list-full' | 'not-found' }
+
+export function createEmptyList(): LocalList {
+  return { title: DEFAULT_LIST_TITLE, items: [] }
+}
+
+/**
+ * 項目を末尾に足す。
+ *
+ * 検証は `packages/shared` の `itemTextSchema` に任せる（前後の空白は落ちる）。
+ * **ここで文字数を書かない。** 上限の情報源は1箇所（`CLAUDE.md` の不変条件）。
+ */
+export function addItem(list: LocalList, item: { id: string; text: string }): ListResult {
+  if (list.items.length >= ITEMS_PER_LIST_MAX) return { ok: false, reason: 'list-full' }
+
+  const text = itemTextSchema.safeParse(item.text)
+  if (!text.success) return { ok: false, reason: 'invalid-text' }
+
+  return {
+    ok: true,
+    list: { ...list, items: [...list.items, { id: item.id, text: text.data, completedAt: null }] },
+  }
+}
+
+/** 項目の本文を変える。完了日時は触らない。 */
+export function updateItemText(list: LocalList, id: string, text: string): ListResult {
+  if (!list.items.some((item) => item.id === id)) return { ok: false, reason: 'not-found' }
+
+  const parsed = itemTextSchema.safeParse(text)
+  if (!parsed.success) return { ok: false, reason: 'invalid-text' }
+
+  return { ok: true, list: mapItem(list, id, (item) => ({ ...item, text: parsed.data })) }
+}
+
+/**
+ * 完了にする / 取り消す。
+ *
+ * `completedAt` に `null` を渡すと取り消し。**リスト内の位置は動かさない**
+ * （`PRODUCT_SPEC.md` §4.5。番号 = 並び順が動くと、どれを完了したのか分からなくなる）。
+ */
+export function setItemCompletedAt(
+  list: LocalList,
+  id: string,
+  completedAt: number | null,
+): ListResult {
+  if (!list.items.some((item) => item.id === id)) return { ok: false, reason: 'not-found' }
+
+  return { ok: true, list: mapItem(list, id, (item) => ({ ...item, completedAt })) }
+}
+
+export function removeItem(list: LocalList, id: string): ListResult {
+  if (!list.items.some((item) => item.id === id)) return { ok: false, reason: 'not-found' }
+
+  return { ok: true, list: { ...list, items: list.items.filter((item) => item.id !== id) } }
+}
+
+/**
+ * 項目を `toIndex` の位置へ動かす（並び替え）。
+ *
+ * 画面の並び替え（DnD）は MVP では省略可だが、**データは並び順前提にしておく**
+ * という決定があるので、計算だけ先に置く（`PRODUCT_SPEC.md` §4.4）。
+ *
+ * `toIndex` は移動**後**の添字。範囲外は端に丸める（画面から来る値を信用しない）。
+ */
+export function moveItem(list: LocalList, id: string, toIndex: number): ListResult {
+  const from = list.items.findIndex((item) => item.id === id)
+  if (from === -1) return { ok: false, reason: 'not-found' }
+
+  const moved = list.items[from]
+  if (!moved) return { ok: false, reason: 'not-found' }
+
+  const rest = list.items.filter((item) => item.id !== id)
+  const to = Math.min(Math.max(Math.trunc(toIndex), 0), rest.length)
+
+  return { ok: true, list: { ...list, items: [...rest.slice(0, to), moved, ...rest.slice(to)] } }
+}
+
+/** リストのタイトルを変える。検証は `listTitleSchema`（空文字は通らない）。 */
+export function renameList(list: LocalList, title: string): ListResult {
+  const parsed = listTitleSchema.safeParse(title)
+  if (!parsed.success) return { ok: false, reason: 'invalid-title' }
+
+  return { ok: true, list: { ...list, title: parsed.data } }
+}
+
+function mapItem(list: LocalList, id: string, fn: (item: Item) => Item): LocalList {
+  return { ...list, items: list.items.map((item) => (item.id === id ? fn(item) : item)) }
+}
+
+// --- 表示 -------------------------------------------------------------------
+
+/**
+ * 100枠の表示用。**未入力の枠も含めて常に `ITEMS_PER_LIST_MAX` 個返す**
+ * （`PRODUCT_SPEC.md` §4.1）。データ側に空スロットを作らないための変換。
+ */
+export interface Slot {
+  number: string
+  item: Item | null
+}
+
+export function toSlots(list: LocalList): Slot[] {
+  return Array.from({ length: ITEMS_PER_LIST_MAX }, (_, index) => ({
+    number: formatItemNumber(index + 1),
+    item: list.items[index] ?? null,
+  }))
+}
+
+/** 表示上の番号。`001` から始まる連番（`PRODUCT_SPEC.md` §3）。 */
+export function formatItemNumber(n: number): string {
+  return String(n).padStart(3, '0')
+}
+
+/**
+ * 「23 / 100」の左側。**達成度ではなく埋まり具合**（`PRODUCT_SPEC.md` §3）。
+ *
+ * 完了した数ではない。ここを完了数にすると、埋めることの動機付けが消える。
+ */
+export function filledCount(list: LocalList): number {
+  return list.items.length
+}
+
+// --- 保存 -------------------------------------------------------------------
+
+/**
+ * localStorage のキー。**読み書きそのものは `*.tsx` 側**（ここに DOM を持ち込まない）。
+ *
+ * 末尾の `v1` は保存形式の版。形を変えるときは新しいキーにして、
+ * 古いキーからの引き継ぎを明示的に書く。同じキーのまま形を変えると、
+ * 既存の利用者の保存が全部「壊れている」に落ちる。
+ */
+export const LIST_STORAGE_KEY = 'yaritai100list:list:v1'
+
+/**
+ * 保存の読み込み結果。
+ *
+ * 🔴 **`broken` を `empty` に混ぜないこと。** 混ぜると、読めなかっただけの保存に
+ * 空リストを上書きして**利用者の書いたものを消す。** 区別があれば、画面側は
+ * 「読めなかった」と伝えて上書きを止められる。`toSessionState` と同じ考え方。
+ */
+export type StoredListResult =
+  { status: 'empty' } | { status: 'loaded'; list: LocalList } | { status: 'broken' }
+
+/**
+ * 保存されている形。**上限（文字数・件数）はここで検査しない。**
+ *
+ * 検査すると、後で上限を下げたときに既存の保存が丸ごと `broken` になり、
+ * 1項目のために100項目を捨てることになる。上限は「新しく入れるとき」に効かせる
+ * （`addItem` / `updateItemText`）。
+ */
+const storedListSchema = z.object({
+  title: z.string(),
+  items: z.array(
+    z.object({
+      id: z.string(),
+      text: z.string(),
+      completedAt: z.number().nullable(),
+    }),
+  ),
+})
+
+export function serializeList(list: LocalList): string {
+  return JSON.stringify(list)
+}
+
+/** 保存されていなければ `null` を渡す（localStorage の `getItem` の戻り値をそのまま）。 */
+export function parseStoredList(raw: string | null): StoredListResult {
+  if (raw === null) return { status: 'empty' }
+
+  let json: unknown
+  try {
+    json = JSON.parse(raw)
+  } catch {
+    return { status: 'broken' }
+  }
+
+  const parsed = storedListSchema.safeParse(json)
+  if (!parsed.success) return { status: 'broken' }
+
+  return { status: 'loaded', list: parsed.data }
 }

--- a/apps/web/test/client-model.test.ts
+++ b/apps/web/test/client-model.test.ts
@@ -1,6 +1,28 @@
+import {
+  DEFAULT_LIST_TITLE,
+  ITEM_TEXT_MAX_LENGTH,
+  ITEMS_PER_LIST_MAX,
+  LIST_TITLE_MAX_LENGTH,
+} from '@yaritai100list/shared'
 import { describe, expect, it } from 'vitest'
 
-import { toSessionState } from '../src/client/model'
+import {
+  addItem,
+  createEmptyList,
+  filledCount,
+  formatItemNumber,
+  moveItem,
+  parseStoredList,
+  removeItem,
+  renameList,
+  serializeList,
+  setItemCompletedAt,
+  toSessionState,
+  toSlots,
+  updateItemText,
+  type ListResult,
+  type LocalList,
+} from '../src/client/model'
 
 /**
  * クライアント側で**唯一テストする層**（`TECH_STACK.md` §10、#43）。
@@ -33,5 +55,274 @@ describe('toSessionState', () => {
     expect(toSessionState({ ok: true, body: {} })).toEqual({ status: 'error' })
     expect(toSessionState({ ok: true, body: 'ok' })).toEqual({ status: 'error' })
     expect(toSessionState({ ok: true, body: undefined })).toEqual({ status: 'error' })
+  })
+})
+
+/**
+ * 失敗すると分かっている操作でも `ok: true` を仮定して書きたくなるので、
+ * **成功を主張してから中身を見る**ヘルパを通す。
+ * 失敗していたら理由付きで落ちるので、原因が分かる。
+ */
+function expectOk(result: ListResult): LocalList {
+  if (!result.ok) throw new Error(`失敗した: ${result.reason}`)
+
+  return result.list
+}
+
+/** テスト用のリストを作る。ID は `i1`, `i2`, ... と決め打ちにして結果を固定する。 */
+function listOf(...texts: string[]): LocalList {
+  return texts.reduce(
+    (list, text, index) => expectOk(addItem(list, { id: `i${String(index + 1)}`, text })),
+    createEmptyList(),
+  )
+}
+
+describe('createEmptyList', () => {
+  it('既定のタイトルを持ち、項目は空', () => {
+    // 100個の空スロットを持たない（PRODUCT_SPEC.md §3）
+    expect(createEmptyList()).toEqual({ title: DEFAULT_LIST_TITLE, items: [] })
+  })
+})
+
+describe('addItem', () => {
+  it('末尾に足す。完了日時は null で始まる', () => {
+    const list = expectOk(addItem(createEmptyList(), { id: 'i1', text: '南極に行く' }))
+
+    expect(list.items).toEqual([{ id: 'i1', text: '南極に行く', completedAt: null }])
+  })
+
+  it('元のリストを書き換えない', () => {
+    // React の state をそのまま渡すので、破壊的に変えると再描画が起きない
+    const before = createEmptyList()
+    addItem(before, { id: 'i1', text: '南極に行く' })
+
+    expect(before.items).toEqual([])
+  })
+
+  it('前後の空白は落ちる（shared の itemTextSchema がそうしている）', () => {
+    const list = expectOk(addItem(createEmptyList(), { id: 'i1', text: '  南極に行く  ' }))
+
+    expect(list.items[0]?.text).toBe('南極に行く')
+  })
+
+  it('空文字と空白だけは通らない', () => {
+    expect(addItem(createEmptyList(), { id: 'i1', text: '' })).toEqual({
+      ok: false,
+      reason: 'invalid-text',
+    })
+    expect(addItem(createEmptyList(), { id: 'i1', text: '   ' })).toEqual({
+      ok: false,
+      reason: 'invalid-text',
+    })
+  })
+
+  it('🔴 上限の文字数は shared のスキーマで決まる。画面側に別の上限を書いていない', () => {
+    const justFits = 'あ'.repeat(ITEM_TEXT_MAX_LENGTH)
+    const tooLong = 'あ'.repeat(ITEM_TEXT_MAX_LENGTH + 1)
+
+    expect(expectOk(addItem(createEmptyList(), { id: 'i1', text: justFits })).items).toHaveLength(1)
+    expect(addItem(createEmptyList(), { id: 'i1', text: tooLong })).toEqual({
+      ok: false,
+      reason: 'invalid-text',
+    })
+  })
+
+  it('🔴 100件を超えて足せない', () => {
+    const full = listOf(
+      ...Array.from({ length: ITEMS_PER_LIST_MAX }, (_, i) => `やりたい${String(i)}`),
+    )
+
+    expect(addItem(full, { id: 'over', text: 'あふれる' })).toEqual({
+      ok: false,
+      reason: 'list-full',
+    })
+  })
+})
+
+describe('updateItemText', () => {
+  it('本文だけ変える。完了日時は残る', () => {
+    const completed = expectOk(setItemCompletedAt(listOf('南極に行く'), 'i1', 1_700_000_000_000))
+    const list = expectOk(updateItemText(completed, 'i1', '北極に行く'))
+
+    expect(list.items[0]).toEqual({
+      id: 'i1',
+      text: '北極に行く',
+      completedAt: 1_700_000_000_000,
+    })
+  })
+
+  it('検証は追加のときと同じ。空にはできない', () => {
+    expect(updateItemText(listOf('南極に行く'), 'i1', '  ')).toEqual({
+      ok: false,
+      reason: 'invalid-text',
+    })
+  })
+
+  it('無い ID なら not-found。invalid-text と区別する', () => {
+    // 消した項目の入力欄から遅れて届いた変更を、検証エラーとして見せない
+    expect(updateItemText(listOf('南極に行く'), 'nope', '北極に行く')).toEqual({
+      ok: false,
+      reason: 'not-found',
+    })
+  })
+})
+
+describe('setItemCompletedAt', () => {
+  it('完了日時を入れる。真偽値にしない（いつ叶えたかを残す）', () => {
+    const list = expectOk(setItemCompletedAt(listOf('南極に行く'), 'i1', 1_700_000_000_000))
+
+    expect(list.items[0]?.completedAt).toBe(1_700_000_000_000)
+  })
+
+  it('null を渡すと完了の取り消し', () => {
+    const completed = expectOk(setItemCompletedAt(listOf('南極に行く'), 'i1', 1_700_000_000_000))
+
+    expect(expectOk(setItemCompletedAt(completed, 'i1', null)).items[0]?.completedAt).toBeNull()
+  })
+
+  it('🔴 完了してもリスト内の位置は動かない', () => {
+    // 番号 = 並び順なので、動くとどれを完了したのか分からなくなる（PRODUCT_SPEC.md §4.5）
+    const list = expectOk(setItemCompletedAt(listOf('1つ目', '2つ目', '3つ目'), 'i2', 1))
+
+    expect(list.items.map((item) => item.id)).toEqual(['i1', 'i2', 'i3'])
+  })
+
+  it('無い ID なら not-found', () => {
+    expect(setItemCompletedAt(listOf('南極に行く'), 'nope', 1)).toEqual({
+      ok: false,
+      reason: 'not-found',
+    })
+  })
+})
+
+describe('removeItem', () => {
+  it('消すと後ろが詰まる（番号は並び順なので振り直される）', () => {
+    const list = expectOk(removeItem(listOf('1つ目', '2つ目', '3つ目'), 'i2'))
+
+    expect(list.items.map((item) => item.id)).toEqual(['i1', 'i3'])
+  })
+
+  it('無い ID なら not-found。黙って成功にしない', () => {
+    expect(removeItem(listOf('南極に行く'), 'nope')).toEqual({ ok: false, reason: 'not-found' })
+  })
+})
+
+describe('moveItem', () => {
+  it('指定した位置へ動かす（toIndex は移動後の添字）', () => {
+    const list = expectOk(moveItem(listOf('1つ目', '2つ目', '3つ目'), 'i1', 2))
+
+    expect(list.items.map((item) => item.id)).toEqual(['i2', 'i3', 'i1'])
+  })
+
+  it('後ろから前へも動く', () => {
+    const list = expectOk(moveItem(listOf('1つ目', '2つ目', '3つ目'), 'i3', 0))
+
+    expect(list.items.map((item) => item.id)).toEqual(['i3', 'i1', 'i2'])
+  })
+
+  it('範囲外の位置は端に丸める。画面から来る値を信用しない', () => {
+    const list = listOf('1つ目', '2つ目', '3つ目')
+
+    expect(expectOk(moveItem(list, 'i1', 99)).items.map((i) => i.id)).toEqual(['i2', 'i3', 'i1'])
+    expect(expectOk(moveItem(list, 'i3', -5)).items.map((i) => i.id)).toEqual(['i3', 'i1', 'i2'])
+  })
+
+  it('無い ID なら not-found', () => {
+    expect(moveItem(listOf('南極に行く'), 'nope', 0)).toEqual({ ok: false, reason: 'not-found' })
+  })
+})
+
+describe('renameList', () => {
+  it('タイトルを変える', () => {
+    expect(expectOk(renameList(createEmptyList(), '2026年の目標')).title).toBe('2026年の目標')
+  })
+
+  it('🔴 上限は shared の listTitleSchema で決まる', () => {
+    const tooLong = 'あ'.repeat(LIST_TITLE_MAX_LENGTH + 1)
+
+    expect(renameList(createEmptyList(), tooLong)).toEqual({ ok: false, reason: 'invalid-title' })
+  })
+
+  it('空にはできない', () => {
+    expect(renameList(createEmptyList(), '  ')).toEqual({ ok: false, reason: 'invalid-title' })
+  })
+
+  it('既定のタイトルは上限に収まっている', () => {
+    // DEFAULT_LIST_TITLE は12文字で上限15。上限を下げるとここが先に落ちる
+    expect(expectOk(renameList(createEmptyList(), DEFAULT_LIST_TITLE)).title).toBe(
+      DEFAULT_LIST_TITLE,
+    )
+  })
+})
+
+describe('toSlots / formatItemNumber / filledCount', () => {
+  it('未入力の枠も含めて常に100枠返す', () => {
+    expect(toSlots(listOf('南極に行く'))).toHaveLength(ITEMS_PER_LIST_MAX)
+  })
+
+  it('入っている枠には項目が、残りには null が入る', () => {
+    const slots = toSlots(listOf('南極に行く'))
+
+    expect(slots[0]).toEqual({
+      number: '001',
+      item: { id: 'i1', text: '南極に行く', completedAt: null },
+    })
+    expect(slots[1]).toEqual({ number: '002', item: null })
+  })
+
+  it('番号は 001 から始まる3桁', () => {
+    expect(formatItemNumber(1)).toBe('001')
+    expect(formatItemNumber(23)).toBe('023')
+    expect(formatItemNumber(100)).toBe('100')
+  })
+
+  it('🔴 「23 / 100」の左は埋まり具合。完了した数ではない', () => {
+    const list = expectOk(setItemCompletedAt(listOf('1つ目', '2つ目', '3つ目'), 'i1', 1))
+
+    expect(filledCount(list)).toBe(3)
+  })
+})
+
+describe('serializeList / parseStoredList', () => {
+  it('直列化して読み戻すと同じリストになる', () => {
+    const list = expectOk(
+      setItemCompletedAt(listOf('南極に行く', 'オーロラを見る'), 'i1', 1_700_000_000_000),
+    )
+
+    expect(parseStoredList(serializeList(list))).toEqual({ status: 'loaded', list })
+  })
+
+  it('保存が無ければ empty（初回訪問）', () => {
+    // localStorage.getItem は未保存で null を返す。それをそのまま渡す
+    expect(parseStoredList(null)).toEqual({ status: 'empty' })
+  })
+
+  it('🔴 壊れた JSON は broken。empty に混ぜない', () => {
+    // empty に倒すと、読めなかっただけの保存に空リストを上書きして書いたものを消す
+    expect(parseStoredList('{壊れている')).toEqual({ status: 'broken' })
+    expect(parseStoredList('')).toEqual({ status: 'broken' })
+  })
+
+  it('🔴 JSON として読めても形が違えば broken', () => {
+    expect(parseStoredList('null')).toEqual({ status: 'broken' })
+    expect(parseStoredList('[]')).toEqual({ status: 'broken' })
+    expect(parseStoredList('{"title":"あ"}')).toEqual({ status: 'broken' })
+    expect(parseStoredList('{"title":"あ","items":[{"id":"i1"}]}')).toEqual({ status: 'broken' })
+    // completedAt は「未完了なら null」。キーごと無いのは想定外の形
+    expect(parseStoredList('{"title":"あ","items":[{"id":"i1","text":"x"}]}')).toEqual({
+      status: 'broken',
+    })
+  })
+
+  it('保存された値の文字数は検査しない。1項目のために全部を捨てない', () => {
+    // 上限を下げたときに、既存の保存が丸ごと broken になるのを避けている。
+    // 上限は「新しく入れるとき」に効かせる（addItem / updateItemText）
+    const tooLong = 'あ'.repeat(ITEM_TEXT_MAX_LENGTH + 1)
+    const raw = JSON.stringify({
+      title: DEFAULT_LIST_TITLE,
+      items: [{ id: 'i1', text: tooLong, completedAt: null }],
+    })
+
+    expect(parseStoredList(raw)).toMatchObject({ status: 'loaded' })
   })
 })


### PR DESCRIPTION
Closes #72

未ログインで書くリスト（#4）のデータモデルと操作。**描画と配線は #73。**

## データモデル

```ts
interface Item     { id: string; text: string; completedAt: number | null }
interface LocalList { title: string; items: Item[] }
```

- **並び順は `items` の配列順そのもの。** 並び順の列を別に持たない
  （2つあると必ずずれるし、ずれたときにどちらが正しいか決められない）
- **項目の実体は可変長。** 100枠は表示のときだけ作る（`toSlots`）
- **完了は日時。** 真偽値にしない（`PRODUCT_SPEC.md` §3）
- ID は配列の添字にしない。途中を消したときに React が別の項目を使い回し、
  入力中のフォーカスや値が隣に飛ぶ

## 判断したこと

**時刻と ID を関数の中で作らない。** `Date.now()` / `crypto.randomUUID()` を
呼ぶと戻り値が呼ぶたびに変わり、テストで固定できない。呼び出し側（`*.tsx`）が渡す。

**失敗は理由付きの `ListResult` で返す**（`invalid-text` / `invalid-title` /
`list-full` / `not-found`）。`null` を返して呼び出し側に推測させない。
消した項目から遅れて届いた変更を「文字数エラー」として見せないため。

**保存の読み込みは `empty` / `loaded` / `broken` の3状態。**
`broken` を `empty` に混ぜると、読めなかっただけの保存に空リストを上書きして
**利用者の書いたものを消す。** `toSessionState` と同じ考え方。

**保存された値の文字数は検査しない。** 検査すると、後で上限を下げたときに
既存の保存が丸ごと `broken` になり、1項目のために100項目を捨てることになる。
上限は「新しく入れるとき」（`addItem` / `updateItemText`）に効かせる。

## 上限の情報源

`packages/shared` の `itemTextSchema` / `listTitleSchema` / `ITEMS_PER_LIST_MAX`
をそのまま使う。**画面側に数字を書いていない**ことをテストで固定した
（定数を参照して `+1` した値が弾かれることを確認している）。

## テスト

`apps/web/test/client-model.test.ts` に 33 件追加（全体で **101 tests / 8 files が緑**）。

- 元のリストを破壊しないこと（React の state をそのまま渡すため）
- 完了してもリスト内の位置が動かないこと（`PRODUCT_SPEC.md` §4.5）
- 100件を超えて足せないこと
- 壊れた JSON / 形の違う JSON が `broken` になること

🤖 Generated with [Claude Code](https://claude.com/claude-code)