### PR TITLE
未ログインで書けるリストの画面を組む

### DIFF
--- a/apps/web/src/client/App.tsx
+++ b/apps/web/src/client/App.tsx
@@ -1,32 +1,64 @@
 import { SERVICE_NAME } from '@yaritai100list/shared'
 import { useCallback, useEffect, useState } from 'react'
 
-import { api } from './api'
-import { signOutRequestInit, toSessionState, type SessionState } from './model'
+import { ListEditor } from './ListEditor'
+import {
+  addItem,
+  createEmptyList,
+  LIST_STORAGE_KEY,
+  parseStoredList,
+  removeItem,
+  renameList,
+  serializeList,
+  setItemCompletedAt,
+  signOutRequestInit,
+  toSessionState,
+  updateItemText,
+  type Item,
+  type ListResult,
+  type LocalList,
+  type SessionState,
+} from './model'
 
 /**
- * 土台の確認用の画面。リストの UI は #4 で作る。
+ * 未ログインでも書ける画面（#4）。
  *
- * **状態の判定は `model.ts` の純関数に置く**（`TECH_STACK.md` §10 の方針）。
- * ここに残すのは取得と描画の配線だけ。
+ * **判定と計算は `model.ts` の純関数に置く**（`TECH_STACK.md` §10 の方針）。
+ * ここに残すのは、localStorage との読み書き・取得の配線・描画だけ。
  */
+
+/**
+ * 保存の状態。**「読めなかった」を「まだ何も無い」に混ぜない。**
+ *
+ * 混ぜると、読めなかっただけの保存に空リストを上書きして
+ * 利用者の書いたものを消す（`parseStoredList` の注意書きと同じ話）。
+ */
+type StorageState =
+  | { status: 'loading' }
+  | { status: 'ok' }
+  /** 保存はあるが読めない。**利用者が了解するまで書き込まない。** */
+  | { status: 'broken' }
+  /** localStorage 自体が使えない（プライベートブラウズなど）。書けるが残らない。 */
+  | { status: 'unavailable' }
+  /** 書き込みに失敗した（容量など）。**黙って失敗しない。** */
+  | { status: 'save-failed' }
+
+const ERROR_MESSAGES = {
+  'invalid-text': 'やりたいことは1文字以上で入力してください',
+  'invalid-title': 'タイトルは1文字以上で入力してください',
+  'list-full': '100件まで書けます。減らすと続けて書けます',
+  'not-found': '対象の項目が見つかりませんでした',
+} as const
+
 export function App() {
-  const [health, setHealth] = useState('確認中')
   const [session, setSession] = useState<SessionState>({ status: 'loading' })
   const [signOutFailed, setSignOutFailed] = useState(false)
 
-  useEffect(() => {
-    const check = async () => {
-      const res = await api.api.health.$get()
-      const data = await res.json()
+  const [list, setList] = useState<LocalList | null>(null)
+  const [storage, setStorage] = useState<StorageState>({ status: 'loading' })
+  const [error, setError] = useState<string | null>(null)
 
-      // data.status は サーバーの `c.json({ status: 'ok' } as const)` から
-      // 型が流れてきている。サーバー側を変えるとここが型エラーになる
-      setHealth(data.status)
-    }
-
-    void check()
-  }, [])
+  // --- セッション（#3 で入れた配線。消さないこと） ---
 
   const loadSession = useCallback(async () => {
     setSession({ status: 'loading' })
@@ -61,42 +93,221 @@ export function App() {
     await loadSession()
   }, [loadSession])
 
+  // --- localStorage ---
+
+  useEffect(() => {
+    let raw: string | null
+
+    try {
+      raw = window.localStorage.getItem(LIST_STORAGE_KEY)
+    } catch {
+      // 保存できないだけで、書くことはできる。空のリストで始める
+      setList(createEmptyList())
+      setStorage({ status: 'unavailable' })
+      return
+    }
+
+    const stored = parseStoredList(raw)
+
+    if (stored.status === 'broken') {
+      // **リストを作らない。** 作ると最初の編集で保存を上書きしてしまう
+      setStorage({ status: 'broken' })
+      return
+    }
+
+    setList(stored.status === 'loaded' ? stored.list : createEmptyList())
+    setStorage({ status: 'ok' })
+  }, [])
+
+  /**
+   * 変更を反映して保存する。**保存は変更のたびにここだけで行う。**
+   *
+   * `useEffect` で `list` を監視して保存すると、読み込み直後にも走るため、
+   * 「読めなかった保存」を上書きする経路ができてしまう。
+   */
+  const applyResult = useCallback(
+    (result: ListResult): boolean => {
+      if (!result.ok) {
+        setError(ERROR_MESSAGES[result.reason])
+        return false
+      }
+
+      setError(null)
+      setList(result.list)
+
+      if (storage.status === 'unavailable') return true
+
+      try {
+        window.localStorage.setItem(LIST_STORAGE_KEY, serializeList(result.list))
+        setStorage({ status: 'ok' })
+      } catch {
+        setStorage({ status: 'save-failed' })
+      }
+
+      return true
+    },
+    [storage.status],
+  )
+
   return (
-    <main className="mx-auto max-w-md p-4">
-      <h1 className="text-xl font-bold">{SERVICE_NAME}</h1>
-      <p>API: {health}</p>
+    <div className="min-h-dvh bg-brand-soft">
+      {/* モバイル縦1カラムを主対象にする（PRODUCT_SPEC.md §4.5）。
+          広い画面では中央に寄せるだけで、列は増やさない */}
+      <div className="mx-auto max-w-md px-4 pb-24">
+        <header className="-mx-4 mb-4 bg-brand px-4 py-3">
+          <p className="text-xs font-bold text-slate-900">{SERVICE_NAME}</p>
+        </header>
 
-      {session.status === 'loading' && <p>読み込み中</p>}
+        <SessionArea
+          session={session}
+          signOutFailed={signOutFailed}
+          onRetry={() => void loadSession()}
+          onSignOut={() => void signOut()}
+        />
 
+        {storage.status === 'loading' && <p className="py-8 text-slate-500">読み込み中</p>}
+
+        {storage.status === 'broken' && (
+          <BrokenStorageNotice
+            onStartOver={() => {
+              // ここでは保存を消さない。最初の編集で上書きされる
+              setList(createEmptyList())
+              setStorage({ status: 'ok' })
+            }}
+          />
+        )}
+
+        {list && (
+          <>
+            <StorageNotice storage={storage} session={session} />
+
+            {error !== null && (
+              <p role="alert" className="mb-2 rounded bg-white px-3 py-2 text-sm text-brand-deep">
+                {error}
+              </p>
+            )}
+
+            <ListEditor
+              list={list}
+              onRenameList={(title) => applyResult(renameList(list, title))}
+              onAddItem={(text) => applyResult(addItem(list, { id: crypto.randomUUID(), text }))}
+              onUpdateItemText={(id, text) => applyResult(updateItemText(list, id, text))}
+              onToggleItem={(item: Item) => {
+                // 完了日時は**呼び出し側で作る**（model.ts に時計を持ち込まない）
+                applyResult(
+                  setItemCompletedAt(list, item.id, item.completedAt === null ? Date.now() : null),
+                )
+              }}
+              onRemoveItem={(id) => {
+                applyResult(removeItem(list, id))
+              }}
+            />
+          </>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function SessionArea({
+  session,
+  signOutFailed,
+  onRetry,
+  onSignOut,
+}: {
+  session: SessionState
+  signOutFailed: boolean
+  onRetry: () => void
+  onSignOut: () => void
+}) {
+  return (
+    <div className="mb-2 text-right text-xs text-slate-600">
       {session.status === 'error' && (
         <p>
           ログイン状態を確認できませんでした{' '}
-          <button type="button" onClick={() => void loadSession()}>
+          <button type="button" onClick={onRetry} className="underline">
             再試行
           </button>
-        </p>
-      )}
-
-      {/*
-        ログインの開始は POST なので `<a>` から叩けない。
-        サーバー側に GET の入口を用意している（`/api/login/google`）
-      */}
-      {session.status === 'anonymous' && (
-        <p>
-          <a href="/api/login/google">Google でログイン</a>
         </p>
       )}
 
       {session.status === 'authenticated' && (
         <p>
           ログイン中{' '}
-          <button type="button" onClick={() => void signOut()}>
+          <button type="button" onClick={onSignOut} className="underline">
             ログアウト
           </button>
         </p>
       )}
 
-      {signOutFailed && <p>ログアウトに失敗しました。時間をおいて試してください</p>}
-    </main>
+      {signOutFailed && <p className="text-brand-deep">ログアウトに失敗しました</p>}
+    </div>
+  )
+}
+
+/**
+ * 「保存されていない可能性がある」ことを伝える導線（`PRODUCT_SPEC.md` §4.1）。
+ *
+ * ログインの動機付けなので、**未ログインのときだけログインの入口を出す。**
+ * ログイン済みでもいまは localStorage にしか保存していない（サーバーへの保存は #5）。
+ */
+function StorageNotice({ storage, session }: { storage: StorageState; session: SessionState }) {
+  if (storage.status === 'unavailable') {
+    return (
+      <Notice tone="warn">
+        このブラウザでは保存できない設定です。閉じると書いた内容は消えます
+      </Notice>
+    )
+  }
+
+  if (storage.status === 'save-failed') {
+    return <Notice tone="warn">保存できませんでした。書いた内容が残らないおそれがあります</Notice>
+  }
+
+  return (
+    <Notice tone="info">
+      いまはこのブラウザにだけ保存されています。端末を変えると見られません
+      {session.status === 'anonymous' && (
+        <>
+          {' '}
+          {/* ログインの開始は POST なので <a> から叩けない。
+              サーバー側に GET の入口を用意している（/api/login/google） */}
+          <a href="/api/login/google" className="font-bold text-brand-deep underline">
+            Google でログイン
+          </a>
+        </>
+      )}
+    </Notice>
+  )
+}
+
+function BrokenStorageNotice({ onStartOver }: { onStartOver: () => void }) {
+  return (
+    <div className="rounded bg-white px-3 py-3 text-sm text-slate-700">
+      <p className="font-bold text-brand-deep">保存されていた内容を読み込めませんでした</p>
+      <p className="mt-1">
+        壊れた内容を勝手に消さないよう、編集を止めています。
+        新しく書き始めると、次に書いた時点で保存が置き換わります。
+      </p>
+      <button
+        type="button"
+        onClick={onStartOver}
+        className="mt-2 rounded bg-brand-deep px-3 py-1.5 text-white"
+      >
+        新しく書き始める
+      </button>
+    </div>
+  )
+}
+
+function Notice({ tone, children }: { tone: 'info' | 'warn'; children: React.ReactNode }) {
+  return (
+    <p
+      className={`mb-3 rounded px-3 py-2 text-xs ${
+        tone === 'warn' ? 'bg-white text-brand-deep' : 'bg-white/70 text-slate-600'
+      }`}
+    >
+      {children}
+    </p>
   )
 }

--- a/apps/web/src/client/ListEditor.tsx
+++ b/apps/web/src/client/ListEditor.tsx
@@ -1,0 +1,237 @@
+import {
+  ITEM_TEXT_MAX_LENGTH,
+  ITEMS_PER_LIST_MAX,
+  LIST_TITLE_MAX_LENGTH,
+} from '@yaritai100list/shared'
+import { useState } from 'react'
+
+import { filledCount, toSlots, type Item, type LocalList } from './model'
+
+/**
+ * リストの編集画面。**ここに置くのは描画と入力欄の下書きだけ。**
+ *
+ * 何が正しい値かは `model.ts` の純関数が決める（`TECH_STACK.md` §10）。
+ * このファイルはテストしない。
+ *
+ * 変更を伝える関数は**受理されたかを真偽値で返す。** 入力欄は受理されたときだけ
+ * 下書きを捨てる。捨ててから拒否されると、利用者が書いた文字が黙って消える。
+ */
+interface ListEditorProps {
+  list: LocalList
+  onRenameList: (title: string) => boolean
+  onAddItem: (text: string) => boolean
+  onUpdateItemText: (id: string, text: string) => boolean
+  onToggleItem: (item: Item) => void
+  onRemoveItem: (id: string) => void
+}
+
+export function ListEditor({
+  list,
+  onRenameList,
+  onAddItem,
+  onUpdateItemText,
+  onToggleItem,
+  onRemoveItem,
+}: ListEditorProps) {
+  const filled = filledCount(list)
+
+  // 次に書ける枠は「埋まっている数」の位置。ここより後ろの枠は表示だけで、触れない。
+  // どこにでも書けると、書いた行と入る行がずれて驚く（項目は末尾に足されるため）
+  const nextIndex = filled
+
+  return (
+    <div>
+      <ListTitleField title={list.title} onRename={onRenameList} />
+
+      <p className="mt-1 flex items-baseline gap-1 text-brand-deep">
+        <span className="text-2xl font-bold tabular-nums">{filled}</span>
+        <span className="text-sm tabular-nums">/ {ITEMS_PER_LIST_MAX}</span>
+        {/* 「達成度ではなく埋まり具合」（PRODUCT_SPEC.md §3）と分かる言葉を添える */}
+        <span className="text-xs text-slate-500">書けた</span>
+      </p>
+
+      <ol className="mt-4">
+        {toSlots(list).map((slot, index) =>
+          slot.item ? (
+            <ItemRow
+              key={slot.item.id}
+              number={slot.number}
+              item={slot.item}
+              onCommit={onUpdateItemText}
+              onToggle={onToggleItem}
+              onRemove={onRemoveItem}
+            />
+          ) : index === nextIndex ? (
+            // key を固定して**同じ入力欄を使い回す**。項目を足すと1つ下へ移るが、
+            // React が DOM を作り直さないのでフォーカスが外れず、続けて書ける
+            <NextRow key="next" number={slot.number} onAdd={onAddItem} />
+          ) : (
+            <EmptyRow key={slot.number} number={slot.number} />
+          ),
+        )}
+      </ol>
+    </div>
+  )
+}
+
+function ListTitleField({ title, onRename }: { title: string; onRename: (t: string) => boolean }) {
+  const [draft, setDraft] = useState(title)
+
+  const commit = () => {
+    if (draft === title) return
+    if (!onRename(draft)) setDraft(title) // 拒否されたら見えている値を実際の値に戻す
+  }
+
+  return (
+    <input
+      type="text"
+      value={draft}
+      aria-label="リストのタイトル"
+      // 上限は shared の定数。ここに数字を書かない（CLAUDE.md の不変条件）
+      maxLength={LIST_TITLE_MAX_LENGTH}
+      onChange={(e) => {
+        setDraft(e.target.value)
+      }}
+      onBlur={commit}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter') e.currentTarget.blur()
+      }}
+      className="w-full rounded-md bg-transparent text-xl font-bold text-slate-900 focus:bg-white focus:outline-2 focus:outline-brand-deep"
+    />
+  )
+}
+
+const ROW = 'flex items-center gap-2 border-b border-brand/40 py-1.5'
+const NUMBER = 'w-8 shrink-0 text-right text-xs tabular-nums'
+const TEXT_INPUT =
+  'min-w-0 flex-1 rounded bg-transparent px-1 py-1 text-base focus:bg-white focus:outline-2 focus:outline-brand-deep'
+
+function ItemRow({
+  number,
+  item,
+  onCommit,
+  onToggle,
+  onRemove,
+}: {
+  number: string
+  item: Item
+  onCommit: (id: string, text: string) => boolean
+  onToggle: (item: Item) => void
+  onRemove: (id: string) => void
+}) {
+  const [draft, setDraft] = useState(item.text)
+  const done = item.completedAt !== null
+
+  const commit = () => {
+    if (draft === item.text) return
+    if (!onCommit(item.id, draft)) setDraft(item.text)
+  }
+
+  return (
+    <li className={ROW}>
+      <span className={`${NUMBER} ${done ? 'text-brand-deep' : 'text-slate-400'}`}>{number}</span>
+
+      <button
+        type="button"
+        // 押されている状態を色だけで伝えない（読み上げと、色が見えない環境のため）
+        aria-pressed={done}
+        aria-label={done ? '完了を取り消す' : '完了にする'}
+        onClick={() => {
+          onToggle(item)
+        }}
+        className={`size-6 shrink-0 rounded-full border-2 text-xs leading-none ${
+          done ? 'border-brand-deep bg-brand-deep text-white' : 'border-brand bg-white text-white'
+        }`}
+      >
+        ✓
+      </button>
+
+      <input
+        type="text"
+        value={draft}
+        aria-label={`${number} 番目のやりたいこと`}
+        maxLength={ITEM_TEXT_MAX_LENGTH}
+        onChange={(e) => {
+          setDraft(e.target.value)
+        }}
+        onBlur={commit}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') e.currentTarget.blur()
+        }}
+        // 完了しても**行の位置は動かさない**（PRODUCT_SPEC.md §4.5）。
+        // 動くと番号と項目の対応が崩れて、どれを完了したのか分からなくなる
+        className={`${TEXT_INPUT} ${done ? 'text-slate-400 line-through' : 'text-slate-900'}`}
+      />
+
+      {done && item.completedAt !== null && (
+        <span className="shrink-0 text-[10px] text-brand-deep tabular-nums">
+          {new Date(item.completedAt).toLocaleDateString('ja-JP')}
+        </span>
+      )}
+
+      <button
+        type="button"
+        aria-label={`${number} 番目を削除`}
+        onClick={() => {
+          onRemove(item.id)
+        }}
+        className="shrink-0 px-1 text-sm text-slate-400"
+      >
+        ×
+      </button>
+    </li>
+  )
+}
+
+function NextRow({ number, onAdd }: { number: string; onAdd: (text: string) => boolean }) {
+  const [draft, setDraft] = useState('')
+
+  const commit = () => {
+    // 空白だけの入力は「書いていない」として扱う。エラーを出す場面ではない
+    if (draft.trim() === '') {
+      setDraft('')
+      return
+    }
+
+    if (onAdd(draft)) setDraft('')
+  }
+
+  return (
+    <li className={ROW}>
+      <span className={`${NUMBER} text-slate-400`}>{number}</span>
+      <span className="size-6 shrink-0 rounded-full border-2 border-dashed border-brand" />
+      <input
+        type="text"
+        value={draft}
+        aria-label="やりたいことを書く"
+        placeholder="やりたいことを書く"
+        maxLength={ITEM_TEXT_MAX_LENGTH}
+        onChange={(e) => {
+          setDraft(e.target.value)
+        }}
+        onBlur={commit}
+        onKeyDown={(e) => {
+          // Enter で続けて書ける。この入力欄は使い回されるのでフォーカスは外れない
+          if (e.key === 'Enter') commit()
+        }}
+        className={`${TEXT_INPUT} text-slate-900 placeholder:text-slate-400`}
+      />
+    </li>
+  )
+}
+
+/**
+ * まだ書けない枠。**入力欄にしない**（触れると末尾に足されて行がずれる）。
+ *
+ * それでも描くのは、100という枠が「まだ埋まっていない」と見えることに
+ * 意味があるため（`PRODUCT_SPEC.md` §1）。
+ */
+function EmptyRow({ number }: { number: string }) {
+  return (
+    <li className={`${ROW} opacity-50`} aria-hidden="true">
+      <span className={`${NUMBER} text-slate-300`}>{number}</span>
+      <span className="size-6 shrink-0 rounded-full border-2 border-dashed border-brand/50" />
+      <span className="flex-1" />
+    </li>
+  )
+}

--- a/apps/web/src/client/api.ts
+++ b/apps/web/src/client/api.ts
@@ -10,5 +10,8 @@ import type { AppType } from '../index'
  * `import { type AppType }` ではなく `import type { ... }` と書くこと。
  *
  * 同一オリジンで配信されるため、ベース URL は相対でよい（CORS の設定が要らない）。
+ *
+ * **いまは画面から呼んでいない**（未ログインのリストは localStorage だけで完結するため）。
+ * サーバーへの保存を始める #5 で使う。消さないこと。
  */
 export const api = hc<AppType>('/')

--- a/apps/web/src/client/index.css
+++ b/apps/web/src/client/index.css
@@ -10,3 +10,18 @@
  * ユーティリティの生成が有効になる。テーマを足すときは下の `@theme` に書く。
  */
 @import 'tailwindcss';
+
+/*
+ * 配色（`PRODUCT_SPEC.md` §4.5）。**色の値を書くのはここだけ。**
+ * JSX には `bg-brand` のような名前だけを書く。
+ *
+ * `--color-*` に置いた名前がそのままユーティリティになる（v4 の名前空間）。
+ *
+ * `brand` は明るいので、**その上に置く文字は暗い色にする**（白だとコントラストが出ない）。
+ * 文字色として使うのは `brand-deep`（`brand-soft` の背景に対して約 5.2:1）。
+ */
+@theme {
+  --color-brand: #ffa2ab;
+  --color-brand-soft: #fff5f6;
+  --color-brand-deep: #b34452;
+}


### PR DESCRIPTION
Closes #73

土台の確認用だった `App.tsx` を、リストの編集画面に置き換えた。
**ログイン状態の表示とログアウト（#53）はそのまま残している。**

## 画面

- **100枠を常に描く。** ただし入力欄になるのは「次に書ける枠」だけで、
  それより後ろは表示だけ。どこにでも書けると、書いた行と入る行がずれて驚く
  （項目は末尾に足されるため）
- **「23 / 100」は埋まり具合**。完了した数ではない（`PRODUCT_SPEC.md` §3）
- 完了は色と取り消し線で示し、**行の位置は動かさない**（§4.5）
- モバイル縦1カラム。広い画面では中央に寄せるだけで列は増やさない
- 配色は `index.css` の `@theme` に置いた `brand`（`#ffa2ab`）のみ。
  **JSX に色の値を書かない**

## 判断したこと

**「読めなかった保存」を「まだ何も無い」と区別する。**
読めなかったときはリストを作らず、利用者が「新しく書き始める」を押すまで
書き込みを止める。空リストを作ると最初の編集で保存を上書きしてしまう。

**保存は変更のたびに `applyResult` でだけ行う。** `useEffect` で `list` を
監視して保存すると読み込み直後にも走り、上書きの経路ができる。

`localStorage` が使えない場合（プライベートブラウズなど）と書き込みに失敗した場合を
分けて画面に出す。**黙って保存できていない状態にしない。**

**入力欄は受理されたときだけ下書きを捨てる。** 捨ててから拒否されると、
書いた文字が黙って消える。

## 残していること

- `api.ts` は画面から呼ばなくなったが、サーバーへの保存を始める #5 で使うので残した
- 並び替えの DnD は MVP では省略（`moveItem` の計算だけ #72 で入れてある）

## 確認

- `npm run typecheck && npm run lint && npm run format:check && npm test` が緑（101 tests）
- `npm run build` が通る（CSS 9.82 kB）
- ⚠️ **見た目の目視確認はこれから**（`docs/workflow.md` §5 に従い本番で確認する）

🤖 Generated with [Claude Code](https://claude.com/claude-code)