### PR TITLE
リストの作成 API と1人あたりの上限

### DIFF
--- a/apps/web/src/id.ts
+++ b/apps/web/src/id.ts
@@ -1,0 +1,16 @@
+/**
+ * ID を作る唯一の場所。
+ *
+ * **推測不可能な値を使う。連番を露出させない**（`CLAUDE.md` の不変条件）。
+ * 連番だと、他人のリストや項目の**存在と件数が URL から分かってしまう。**
+ *
+ * `crypto.randomUUID()` は Workers でも Deno でも使える（`packages/shared` と違い
+ * ここは Worker 専用だが、経路を揃えておく）。
+ *
+ * ⚠️ **公開用の `shareId`（#7）はここを使い回さない。**
+ * あちらは人が触る URL に載るので短さと読みやすさの要求が違う。
+ * 別の関数として、この隣に足すこと。
+ */
+export function newId(): string {
+  return crypto.randomUUID()
+}

--- a/apps/web/src/index.ts
+++ b/apps/web/src/index.ts
@@ -1,7 +1,12 @@
 import * as Sentry from '@sentry/cloudflare'
-import { listTitleSchema, visibilitySchema } from '@yaritai100list/shared'
+import {
+  DEFAULT_LIST_TITLE,
+  LISTS_PER_USER_MAX,
+  listTitleSchema,
+  visibilitySchema,
+} from '@yaritai100list/shared'
 import { zValidator } from '@hono/zod-validator'
-import { eq } from 'drizzle-orm'
+import { eq, sql } from 'drizzle-orm'
 import { Hono } from 'hono'
 import { z } from 'zod'
 
@@ -10,6 +15,7 @@ import { requireOwnedList, requireUser } from './authorization'
 import { createDb } from './db'
 import { lists } from './db/schema'
 import type { AppEnv } from './env'
+import { newId } from './id'
 import { sentryOptions } from './sentry'
 
 /**
@@ -22,6 +28,15 @@ const updateListSchema = z
     visibility: visibilitySchema.optional(),
   })
   .strict()
+
+/**
+ * リストの作成で受け付ける内容。
+ *
+ * タイトルは省略できる（既定は `DEFAULT_LIST_TITLE`）。
+ * ⚠️ **本文が空の POST は 400 になる。** `zValidator('json', ...)` は本文を要求するので、
+ * 何も指定しない場合でも `{}` を送ること（Better Auth の 415 と同じ性質の落とし穴）。
+ */
+const createListSchema = z.object({ title: listTitleSchema.optional() }).strict()
 
 /**
  * ルートはコンストラクタから直接チェーンする。Hono RPC はメソッドチェーンの
@@ -75,6 +90,43 @@ const app = new Hono<AppEnv>()
       .where(eq(lists.userId, c.get('userId')))
 
     return c.json({ lists: rows })
+  })
+
+  /**
+   * リストを作る。
+   *
+   * 🔴 **件数の判定と挿入を1文で行う。**
+   * 「数えてから入れる」と、素早く2回押されたときに**両方が上限内だと判断して
+   * 上限を超える。** `where (select count(*) ...) < 上限` を付けた insert なら、
+   * 入らなかったことが「0行返る」で分かる。
+   *
+   * 上限の値は `packages/shared` から取る。SQL に数字を書かない
+   * （`CLAUDE.md` の不変条件）。DB の制約としての上限は #6 で足す。
+   */
+  .post('/api/lists', requireUser, zValidator('json', createListSchema), async (c) => {
+    const db = createDb(c.env.DB)
+    const userId = c.get('userId')
+
+    // 推測不可能な ID。連番にしない（CLAUDE.md の不変条件）
+    const id = newId()
+    const title = c.req.valid('json').title ?? DEFAULT_LIST_TITLE
+
+    const inserted = await db.all<{ id: string }>(sql`
+      insert into ${lists} (id, user_id, title)
+      select ${id}, ${userId}, ${title}
+      where (select count(*) from ${lists} where ${lists.userId} = ${userId}) < ${LISTS_PER_USER_MAX}
+      returning id
+    `)
+
+    // 0行 = 上限に達していた。**404 と同じ応答にしない**（理由が分からないと直せない）
+    if (inserted.length === 0) {
+      return c.json({ error: 'List Limit Reached' } as const, 409)
+    }
+
+    const [list] = await db.select().from(lists).where(eq(lists.id, id))
+    if (!list) throw new Error('作ったリストを読み戻せなかった')
+
+    return c.json({ list }, 201)
   })
 
   /**

--- a/apps/web/test/lists-api.test.ts
+++ b/apps/web/test/lists-api.test.ts
@@ -1,0 +1,173 @@
+import { exports } from 'cloudflare:workers'
+import {
+  LISTS_PER_USER_MAX,
+  DEFAULT_LIST_TITLE,
+  LIST_TITLE_MAX_LENGTH,
+} from '@yaritai100list/shared'
+import { eq } from 'drizzle-orm'
+import { describe, expect, it } from 'vitest'
+
+import { lists } from '../src/db/schema'
+import { signIn, testBaseUrl, testDb } from './helpers'
+
+/**
+ * リストの作成 API のテスト（#88）。
+ *
+ * 認可の「通らないこと」は `authorization.test.ts` と同じ書き方で入れる
+ * （`docs/workflow.md` §6）。成功パスだけにしない。
+ */
+
+// オリジンは Worker の BETTER_AUTH_URL に揃える（Cookie 名と Origin チェックのため）
+const request = (path: string, init?: RequestInit) =>
+  exports.default.fetch(new Request(`${testBaseUrl()}${path}`, init))
+
+/** ログイン済みの利用者としてリストを作る。 */
+function createList(headers: Headers, body: unknown = {}) {
+  return request('/api/lists', {
+    method: 'POST',
+    headers: { ...Object.fromEntries(headers), 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('POST /api/lists', () => {
+  it('🔴 未ログインでは作れない', async () => {
+    const res = await request('/api/lists', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: '{}',
+    })
+
+    expect(res.status).toBe(401)
+    expect(await testDb().select().from(lists)).toEqual([])
+  })
+
+  it('タイトルを省略すると既定のタイトルになる', async () => {
+    const me = await signIn('creator@example.com')
+
+    const res = await createList(me.headers)
+
+    expect(res.status).toBe(201)
+
+    const [row] = await testDb().select().from(lists)
+    expect(row?.title).toBe(DEFAULT_LIST_TITLE)
+  })
+
+  it('タイトルを指定できる。公開範囲の既定は非公開', async () => {
+    const me = await signIn('creator2@example.com')
+
+    await createList(me.headers, { title: '2026年の目標' })
+
+    const [row] = await testDb().select().from(lists)
+    expect(row?.title).toBe('2026年の目標')
+    // 公開は明示的な操作でのみ起きる（PRODUCT_SPEC.md §5.1）
+    expect(row?.visibility).toBe('private')
+  })
+
+  it('作った本人のものになる', async () => {
+    const me = await signIn('owner@example.com')
+
+    const res = await createList(me.headers)
+    const { list } = await res.json<{ list: { id: string; userId: string } }>()
+
+    expect(list.userId).toBe(me.userId)
+  })
+
+  it('🔴 ID が連番ではない（推測できない）', async () => {
+    const me = await signIn('ids@example.com')
+
+    const first = await (await createList(me.headers)).json<{ list: { id: string } }>()
+    const second = await (await createList(me.headers)).json<{ list: { id: string } }>()
+
+    expect(first.list.id).not.toBe(second.list.id)
+    // 連番だと他人のリストの存在と件数が URL から分かる（CLAUDE.md の不変条件）
+    expect(first.list.id).not.toMatch(/^\d+$/)
+    expect(first.list.id.length).toBeGreaterThan(16)
+  })
+
+  describe('1人あたりの上限', () => {
+    it('🔴 上限を超えて作れない', async () => {
+      const me = await signIn('many@example.com')
+
+      for (let i = 0; i < LISTS_PER_USER_MAX; i++) {
+        expect((await createList(me.headers)).status).toBe(201)
+      }
+
+      const over = await createList(me.headers)
+
+      expect(over.status).toBe(409)
+      expect(await over.json()).toEqual({ error: 'List Limit Reached' })
+      expect(await testDb().select().from(lists)).toHaveLength(LISTS_PER_USER_MAX)
+    })
+
+    it('🔴 他人のリストを自分の件数に入れない', async () => {
+      const other = await signIn('other@example.com')
+      const db = testDb()
+
+      await db.insert(lists).values(
+        Array.from({ length: LISTS_PER_USER_MAX }, (_, i) => ({
+          id: `other-${String(i)}`,
+          userId: other.userId,
+          title: 'x',
+        })),
+      )
+
+      const me = await signIn('me@example.com')
+
+      // 他人が上限まで持っていても、自分は作れる
+      expect((await createList(me.headers)).status).toBe(201)
+      expect(await db.select().from(lists).where(eq(lists.userId, me.userId))).toHaveLength(1)
+    })
+
+    it('1つ消せばまた作れる', async () => {
+      const me = await signIn('recycle@example.com')
+      const db = testDb()
+
+      for (let i = 0; i < LISTS_PER_USER_MAX; i++) await createList(me.headers)
+
+      const [first] = await db.select().from(lists).limit(1)
+      await db.delete(lists).where(eq(lists.id, first?.id ?? ''))
+
+      expect((await createList(me.headers)).status).toBe(201)
+    })
+  })
+
+  describe('入力の検証', () => {
+    it('上限を超えるタイトルは拒否する', async () => {
+      const me = await signIn('long@example.com')
+
+      const res = await createList(me.headers, { title: 'あ'.repeat(LIST_TITLE_MAX_LENGTH + 1) })
+
+      expect(res.status).toBe(400)
+      expect(await testDb().select().from(lists)).toEqual([])
+    })
+
+    it('空のタイトルは拒否する（省略とは違う）', async () => {
+      const me = await signIn('empty@example.com')
+
+      const res = await createList(me.headers, { title: '   ' })
+
+      expect(res.status).toBe(400)
+      expect(await testDb().select().from(lists)).toEqual([])
+    })
+
+    it('🔴 知らないキーは拒否する', async () => {
+      const me = await signIn('extra@example.com')
+
+      // userId を送って他人のものとして作る、といった経路を塞ぐ
+      const res = await createList(me.headers, { userId: 'someone-else', title: 'x' })
+
+      expect(res.status).toBe(400)
+      expect(await testDb().select().from(lists)).toEqual([])
+    })
+
+    it('🔴 公開範囲を指定して作れない（公開は明示的な操作でのみ）', async () => {
+      const me = await signIn('visible@example.com')
+
+      const res = await createList(me.headers, { visibility: 'public' })
+
+      expect(res.status).toBe(400)
+      expect(await testDb().select().from(lists)).toEqual([])
+    })
+  })
+})


### PR DESCRIPTION
Closes #88

いままで**リストを作る経路が無かった**（`GET` / `PATCH` / `DELETE` だけ）。

## 実装

`POST /api/lists`。タイトルは省略可（既定は `DEFAULT_LIST_TITLE`）、公開範囲は既定の非公開。

🔴 **件数の判定と挿入を1文で行う。**

```sql
insert into lists (id, user_id, title)
select ?, ?, ?
where (select count(*) from lists where lists.user_id = ?) < ?
returning id
```

「数えてから入れる」と、**素早く2回押されたときに両方が上限内だと判断して上限を超える。**
この形なら、入らなかったことが「0行返る」で分かる。
上限の値は `packages/shared` から渡す（**SQL に数字を書かない**。`CLAUDE.md` の不変条件）。
DB の制約としての上限は #6 の担当。

上限に当たったら **409**（`{ error: 'List Limit Reached' }`）。
404 と同じ応答にすると理由が分からず直せない。

ID は `src/id.ts` の `newId()` に集約した。**公開用の `shareId`（#7）は
ここを使い回さない**旨をコメントに書いてある（人が触る URL は要求が違う）。

## テスト（`apps/web/test/lists-api.test.ts`、12件）

「通らないこと」を中心に（`docs/workflow.md` §6）:

- **未ログインでは作れない**（401、行も増えない）
- **上限を超えて作れない**（409、件数が増えていない）
- **他人のリストを自分の件数に入れない**（他人が上限まで持っていても自分は作れる）
- **知らないキーを拒否する**（`userId` を送って他人のものとして作る経路を塞ぐ）
- **`visibility` を指定して作れない**（公開は明示的な操作でのみ）
- ID が連番でない

全体で **129 tests / 10 files が緑**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)