### PR TITLE
項目の API（作成・変更・完了・削除・並び替え）

### DIFF
--- a/apps/web/src/authorization.ts
+++ b/apps/web/src/authorization.ts
@@ -4,7 +4,7 @@ import { createMiddleware } from 'hono/factory'
 
 import { createAuth } from './auth'
 import { createDb } from './db'
-import { lists } from './db/schema'
+import { items, lists } from './db/schema'
 import type { AppEnv } from './env'
 
 /**
@@ -74,6 +74,40 @@ export const requireOwnedList = createMiddleware<AppEnv>(async (c, next) => {
   }
 
   c.set('list', list)
+
+  return next()
+})
+
+/**
+ * URL の `itemId` が**そのリストの項目**であることを要求する。
+ *
+ * **`requireOwnedList` の後に置く。** リストの所有者チェックは済んでいる前提で、
+ * ここでは「その項目がこのリストのものか」だけを見る。
+ *
+ * 🔴 **他人のリストの項目 ID を渡されても、応答は「見つからない」で揃える。**
+ * `requireOwnedList` が先に 404 を返すので他人のリストには入れないが、
+ * **自分のリストの URL に他人の項目 ID を混ぜる**経路がありうる。
+ * `list_id` で絞ることで、その項目が存在するかどうかも漏らさない。
+ */
+export const requireOwnedItem = createMiddleware<AppEnv>(async (c, next) => {
+  const itemId = c.req.param('itemId')
+
+  // `:itemId` を持たないルートに付けた場合。他の「見つからない」と応答を揃える
+  if (itemId === undefined) {
+    return c.json({ error: 'Not Found' } as const, 404)
+  }
+
+  const [item] = await createDb(c.env.DB)
+    .select()
+    .from(items)
+    .where(and(eq(items.id, itemId), eq(items.listId, c.get('list').id)))
+    .limit(1)
+
+  if (!item) {
+    return c.json({ error: 'Not Found' } as const, 404)
+  }
+
+  c.set('item', item)
 
   return next()
 })

--- a/apps/web/src/env.ts
+++ b/apps/web/src/env.ts
@@ -1,7 +1,7 @@
 import type { InferSelectModel } from 'drizzle-orm'
 
 import type { AuthEnv } from './auth'
-import type { lists } from './db/schema'
+import type { items, lists } from './db/schema'
 import type { SentryEnv } from './sentry'
 
 /**
@@ -30,5 +30,12 @@ export interface AppEnv {
      * ミドルウェアを付け忘れたハンドラには触れるリストが無い、という構造にしている。
      */
     list: InferSelectModel<typeof lists>
+
+    /**
+     * `requireOwnedItem` が入れる。**すでにリストとの紐付けを確認した項目。**
+     *
+     * `list` と同じ考え方で、ハンドラは `itemId` ではなくこれを受け取る。
+     */
+    item: InferSelectModel<typeof items>
   }
 }

--- a/apps/web/src/index.ts
+++ b/apps/web/src/index.ts
@@ -1,19 +1,21 @@
 import * as Sentry from '@sentry/cloudflare'
 import {
   DEFAULT_LIST_TITLE,
+  ITEMS_PER_LIST_MAX,
   LISTS_PER_USER_MAX,
+  itemTextSchema,
   listTitleSchema,
   visibilitySchema,
 } from '@yaritai100list/shared'
 import { zValidator } from '@hono/zod-validator'
-import { eq, sql } from 'drizzle-orm'
+import { and, asc, eq, gt, sql } from 'drizzle-orm'
 import { Hono } from 'hono'
 import { z } from 'zod'
 
 import { createAuth } from './auth'
-import { requireOwnedList, requireUser } from './authorization'
-import { createDb } from './db'
-import { lists } from './db/schema'
+import { requireOwnedItem, requireOwnedList, requireUser } from './authorization'
+import { createDb, type Db } from './db'
+import { items, lists } from './db/schema'
 import type { AppEnv } from './env'
 import { newId } from './id'
 import { sentryOptions } from './sentry'
@@ -37,6 +39,54 @@ const updateListSchema = z
  * 何も指定しない場合でも `{}` を送ること（Better Auth の 415 と同じ性質の落とし穴）。
  */
 const createListSchema = z.object({ title: listTitleSchema.optional() }).strict()
+
+/** 項目の作成。本文だけ受け取る。**並び順は末尾で、クライアントには決めさせない。** */
+const createItemSchema = z.object({ text: itemTextSchema }).strict()
+
+/**
+ * 項目の変更。
+ *
+ * 🔴 **完了「日時」を受け取らない。** `completed` の真偽値だけを受け取り、
+ * **日時はサーバーが決める。** 端末の時計は狂っていることがあり、
+ * 送られた値をそのまま入れると「未来に叶えたこと」になる。
+ *
+ * 空の本文（`{}`）は拒否する。黙って何もしない応答を返すと、
+ * 送り側の間違いに気づけない。
+ */
+const updateItemSchema = z
+  .object({
+    text: itemTextSchema.optional(),
+    completed: z.boolean().optional(),
+  })
+  .strict()
+  .refine((patch) => Object.keys(patch).length > 0, { message: '変更する項目がない' })
+
+/**
+ * 並び替え。**そのリストの項目 ID を全部、新しい順で受け取る。**
+ *
+ * 差分（「この項目を3番目へ」）ではなく全体を受け取るのは、
+ * 送り側と DB のずれをここで検出できるようにするため
+ * （`TECH_STACK.md` §7 のとおり、並び替えは全件書き直し）。
+ */
+const reorderItemsSchema = z
+  .object({ itemIds: z.array(z.string()).max(ITEMS_PER_LIST_MAX) })
+  .strict()
+
+/** そのリストの項目を並び順で取る。 */
+function selectItems(db: Db, listId: string) {
+  return db.select().from(items).where(eq(items.listId, listId)).orderBy(asc(items.position))
+}
+
+/**
+ * リストの `updated_at` を今にする。
+ *
+ * トップを開いたときに**最後に更新したリスト**を出すため（`PRODUCT_SPEC.md` §4.3）、
+ * **項目を変えたときもリスト側を触る。** 触らないと、項目だけ書き換えたリストが
+ * 「古いリスト」のままになる。
+ */
+function touchList(db: Db, listId: string) {
+  return db.update(lists).set({ updatedAt: new Date() }).where(eq(lists.id, listId))
+}
 
 /**
  * ルートはコンストラクタから直接チェーンする。Hono RPC はメソッドチェーンの
@@ -130,10 +180,17 @@ const app = new Hono<AppEnv>()
   })
 
   /**
-   * リスト1件。**`requireOwnedList` が認可を通した行を返すだけ。**
+   * リスト1件と、その項目。**`requireOwnedList` が認可を通した行だけを使う。**
    * ハンドラは `listId` を触らないので、認可を迂回する余地が無い。
+   *
+   * 項目を別の要求に分けていないのは、**画面が必ず両方を要るため**
+   * （1リストを開くのが基本の画面。`PRODUCT_SPEC.md` §4.3）。
    */
-  .get('/api/lists/:listId', requireUser, requireOwnedList, (c) => c.json({ list: c.get('list') }))
+  .get('/api/lists/:listId', requireUser, requireOwnedList, async (c) => {
+    const list = c.get('list')
+
+    return c.json({ list, items: await selectItems(createDb(c.env.DB), list.id) })
+  })
 
   /** リストのタイトルと公開範囲を変える。 */
   .patch(
@@ -163,6 +220,149 @@ const app = new Hono<AppEnv>()
 
     return c.json({ deleted: true } as const)
   })
+
+  /**
+   * 項目を末尾に足す。
+   *
+   * 🔴 **件数の判定・並び順の決定・挿入を1文で行う**（リストの作成と同じ理由）。
+   * 数えてから入れると、素早く2回押されたときに**上限を超える**し、
+   * **同じ並び順の項目が2つできる。**
+   */
+  .post(
+    '/api/lists/:listId/items',
+    requireUser,
+    requireOwnedList,
+    zValidator('json', createItemSchema),
+    async (c) => {
+      const db = createDb(c.env.DB)
+      const listId = c.get('list').id
+      const id = newId()
+      const { text } = c.req.valid('json')
+
+      const inserted = await db.all<{ id: string }>(sql`
+        insert into ${items} (id, list_id, text, position)
+        select ${id}, ${listId}, ${text},
+               (select count(*) from ${items} where ${items.listId} = ${listId})
+        where (select count(*) from ${items} where ${items.listId} = ${listId}) < ${ITEMS_PER_LIST_MAX}
+        returning id
+      `)
+
+      if (inserted.length === 0) {
+        return c.json({ error: 'Item Limit Reached' } as const, 409)
+      }
+
+      await touchList(db, listId)
+
+      const [item] = await db.select().from(items).where(eq(items.id, id))
+      if (!item) throw new Error('作った項目を読み戻せなかった')
+
+      return c.json({ item }, 201)
+    },
+  )
+
+  /**
+   * 項目の本文と完了を変える。
+   *
+   * **完了日時はサーバーが決める**（`updateItemSchema` の注意書き）。
+   * 完了しても並び順は動かさない（`PRODUCT_SPEC.md` §4.5）。
+   */
+  .patch(
+    '/api/lists/:listId/items/:itemId',
+    requireUser,
+    requireOwnedList,
+    requireOwnedItem,
+    zValidator('json', updateItemSchema),
+    async (c) => {
+      const db = createDb(c.env.DB)
+      const item = c.get('item')
+      const patch = c.req.valid('json')
+
+      const [updated] = await db
+        .update(items)
+        .set({
+          ...(patch.text === undefined ? {} : { text: patch.text }),
+          ...(patch.completed === undefined
+            ? {}
+            : { completedAt: patch.completed ? new Date() : null }),
+          updatedAt: new Date(),
+        })
+        .where(eq(items.id, item.id))
+        .returning()
+
+      await touchList(db, item.listId)
+
+      return c.json({ item: updated })
+    },
+  )
+
+  /**
+   * 項目を消す。
+   *
+   * **消したら後ろの並び順を詰める。** 詰めないと `position` に穴が空き、
+   * 「0から始まる詰まった連番」という前提が崩れる（`TECH_STACK.md` §7）。
+   * 削除と詰め直しは `batch` で1トランザクションにする。
+   */
+  .delete(
+    '/api/lists/:listId/items/:itemId',
+    requireUser,
+    requireOwnedList,
+    requireOwnedItem,
+    async (c) => {
+      const db = createDb(c.env.DB)
+      const item = c.get('item')
+
+      await db.batch([
+        db.delete(items).where(eq(items.id, item.id)),
+        db
+          .update(items)
+          .set({ position: sql`${items.position} - 1` })
+          .where(and(eq(items.listId, item.listId), gt(items.position, item.position))),
+        touchList(db, item.listId),
+      ])
+
+      return c.json({ deleted: true } as const)
+    },
+  )
+
+  /**
+   * 並び替え。**そのリストの項目 ID を全部、新しい順で受け取って全件書き直す。**
+   *
+   * 🔴 **送られた ID の集合が、いまの項目とぴったり一致することを確かめる。**
+   * 一致を見ないと、**他人の項目 ID を混ぜて自分のリストに引き込む**経路や、
+   * 抜けた項目の並び順が古いまま残る経路ができる。
+   */
+  .put(
+    '/api/lists/:listId/items/order',
+    requireUser,
+    requireOwnedList,
+    zValidator('json', reorderItemsSchema),
+    async (c) => {
+      const db = createDb(c.env.DB)
+      const listId = c.get('list').id
+      const { itemIds } = c.req.valid('json')
+
+      const current = await selectItems(db, listId)
+      const currentIds = new Set(current.map((item) => item.id))
+      const sameSet =
+        itemIds.length === current.length &&
+        new Set(itemIds).size === itemIds.length &&
+        itemIds.every((id) => currentIds.has(id))
+
+      if (!sameSet) {
+        return c.json({ error: 'Item Set Mismatch' } as const, 409)
+      }
+
+      await db.batch([
+        // batch は空配列を受け付けないので、必ず1つは入る touchList を先に置く
+        touchList(db, listId),
+        ...itemIds.map((id, position) =>
+          db.update(items).set({ position, updatedAt: new Date() }).where(eq(items.id, id)),
+        ),
+      ])
+
+      return c.json({ items: await selectItems(db, listId) })
+    },
+  )
 
   /**
    * Better Auth の全エンドポイント（セッション取得、サインアウト、コールバック等）。

--- a/apps/web/test/items-api.test.ts
+++ b/apps/web/test/items-api.test.ts
@@ -1,0 +1,387 @@
+import { exports } from 'cloudflare:workers'
+import { ITEM_TEXT_MAX_LENGTH, ITEMS_PER_LIST_MAX } from '@yaritai100list/shared'
+import { asc, eq } from 'drizzle-orm'
+import { describe, expect, it } from 'vitest'
+
+import { items, lists } from '../src/db/schema'
+import { signIn, testBaseUrl, testDb } from './helpers'
+
+/**
+ * 項目の API のテスト（#89）。
+ *
+ * 認可は「通らないこと」を書く（`docs/workflow.md` §6）。
+ * **自分のリストの URL に他人の項目 ID を混ぜる**経路も見る。
+ */
+
+const request = (path: string, init?: RequestInit) =>
+  exports.default.fetch(new Request(`${testBaseUrl()}${path}`, init))
+
+function json(headers: Headers, method: string, body: unknown) {
+  return {
+    method,
+    headers: { ...Object.fromEntries(headers), 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  }
+}
+
+/** 自分と他人、それぞれのリストを用意する。 */
+async function twoUsers() {
+  const me = await signIn('me@example.com')
+  const other = await signIn('other@example.com')
+
+  await testDb()
+    .insert(lists)
+    .values([
+      { id: 'my-list', userId: me.userId, title: '自分のリスト' },
+      { id: 'other-list', userId: other.userId, title: '他人のリスト' },
+    ])
+
+  return { me, other }
+}
+
+/** 項目を1件足して、その id を返す。 */
+async function addItem(headers: Headers, listId: string, text: string): Promise<string> {
+  const res = await request(`/api/lists/${listId}/items`, json(headers, 'POST', { text }))
+  const { item } = await res.json<{ item: { id: string } }>()
+
+  return item.id
+}
+
+/** そのリストの項目を並び順で読む。 */
+async function positionsOf(listId: string) {
+  const rows = await testDb()
+    .select()
+    .from(items)
+    .where(eq(items.listId, listId))
+    .orderBy(asc(items.position))
+
+  return rows.map((row) => `${String(row.position)}:${row.text}`)
+}
+
+describe('項目の作成', () => {
+  it('末尾に足される。完了日時は入っていない', async () => {
+    const { me } = await twoUsers()
+
+    await addItem(me.headers, 'my-list', '南極に行く')
+    await addItem(me.headers, 'my-list', 'オーロラを見る')
+
+    expect(await positionsOf('my-list')).toEqual(['0:南極に行く', '1:オーロラを見る'])
+
+    const [first] = await testDb().select().from(items).where(eq(items.position, 0))
+    expect(first?.completedAt).toBeNull()
+  })
+
+  it('リストの更新日時が新しくなる（最後に更新したリストを出すため）', async () => {
+    const { me } = await twoUsers()
+    const before = await testDb().select().from(lists).where(eq(lists.id, 'my-list'))
+
+    await addItem(me.headers, 'my-list', '南極に行く')
+
+    const [after] = await testDb().select().from(lists).where(eq(lists.id, 'my-list'))
+    expect(after?.updatedAt.getTime()).toBeGreaterThanOrEqual(
+      before[0]?.updatedAt.getTime() ?? Infinity,
+    )
+  })
+
+  it('🔴 未ログインでは足せない', async () => {
+    await twoUsers()
+
+    const res = await request(
+      '/api/lists/my-list/items',
+      json(new Headers(), 'POST', { text: 'x' }),
+    )
+
+    expect(res.status).toBe(401)
+    expect(await testDb().select().from(items)).toEqual([])
+  })
+
+  it('🔴 他人のリストには足せない。存在しない ID と応答が一致する', async () => {
+    const { me } = await twoUsers()
+
+    const others = await request(
+      '/api/lists/other-list/items',
+      json(me.headers, 'POST', { text: 'x' }),
+    )
+    const missing = await request(
+      '/api/lists/no-such/items',
+      json(me.headers, 'POST', { text: 'x' }),
+    )
+
+    expect(others.status).toBe(404)
+    expect(await others.text()).toBe(await missing.text())
+    expect(await testDb().select().from(items)).toEqual([])
+  })
+
+  it('🔴 上限を超えて足せない', async () => {
+    const { me } = await twoUsers()
+
+    const rows = Array.from({ length: ITEMS_PER_LIST_MAX }, (_, i) => ({
+      id: `item-${String(i)}`,
+      listId: 'my-list',
+      text: 'x',
+      position: i,
+    }))
+
+    // ⚠️ 100件を1文で insert すると **D1 が「too many SQL variables」で落ちる**
+    // （SQLite のバインド変数の上限。1行4列なので25行ずつに割る）。
+    // 取り込み API（#90）でも同じ制限を踏むので、あちらでも分ける必要がある
+    for (let i = 0; i < rows.length; i += 20) {
+      await testDb()
+        .insert(items)
+        .values(rows.slice(i, i + 20))
+    }
+
+    const res = await request(
+      '/api/lists/my-list/items',
+      json(me.headers, 'POST', { text: 'over' }),
+    )
+
+    expect(res.status).toBe(409)
+    expect(await res.json()).toEqual({ error: 'Item Limit Reached' })
+    expect(await testDb().select().from(items)).toHaveLength(ITEMS_PER_LIST_MAX)
+  })
+
+  it('上限を超える本文は拒否する', async () => {
+    const { me } = await twoUsers()
+
+    const res = await request(
+      '/api/lists/my-list/items',
+      json(me.headers, 'POST', { text: 'あ'.repeat(ITEM_TEXT_MAX_LENGTH + 1) }),
+    )
+
+    expect(res.status).toBe(400)
+    expect(await testDb().select().from(items)).toEqual([])
+  })
+
+  it('🔴 並び順を指定して割り込めない', async () => {
+    const { me } = await twoUsers()
+
+    const res = await request(
+      '/api/lists/my-list/items',
+      json(me.headers, 'POST', { text: 'x', position: 0 }),
+    )
+
+    expect(res.status).toBe(400)
+  })
+})
+
+describe('項目の変更', () => {
+  it('本文を変えられる', async () => {
+    const { me } = await twoUsers()
+    const id = await addItem(me.headers, 'my-list', '南極に行く')
+
+    const res = await request(
+      `/api/lists/my-list/items/${id}`,
+      json(me.headers, 'PATCH', { text: '北極に行く' }),
+    )
+
+    expect(res.status).toBe(200)
+
+    const [row] = await testDb().select().from(items).where(eq(items.id, id))
+    expect(row?.text).toBe('北極に行く')
+  })
+
+  it('完了にすると日時が入り、取り消すと消える', async () => {
+    const { me } = await twoUsers()
+    const id = await addItem(me.headers, 'my-list', '南極に行く')
+
+    await request(`/api/lists/my-list/items/${id}`, json(me.headers, 'PATCH', { completed: true }))
+    const [done] = await testDb().select().from(items).where(eq(items.id, id))
+    expect(done?.completedAt).toBeInstanceOf(Date)
+
+    await request(`/api/lists/my-list/items/${id}`, json(me.headers, 'PATCH', { completed: false }))
+    const [undone] = await testDb().select().from(items).where(eq(items.id, id))
+    expect(undone?.completedAt).toBeNull()
+  })
+
+  it('🔴 完了日時を送り込めない（時刻はサーバーが決める）', async () => {
+    const { me } = await twoUsers()
+    const id = await addItem(me.headers, 'my-list', '南極に行く')
+
+    // 端末の時計は狂っていることがある。「未来に叶えたこと」にさせない
+    const res = await request(
+      `/api/lists/my-list/items/${id}`,
+      json(me.headers, 'PATCH', { completedAt: 4_102_444_800_000 }),
+    )
+
+    expect(res.status).toBe(400)
+  })
+
+  it('🔴 完了しても並び順が変わらない', async () => {
+    const { me } = await twoUsers()
+    await addItem(me.headers, 'my-list', '1つ目')
+    const second = await addItem(me.headers, 'my-list', '2つ目')
+    await addItem(me.headers, 'my-list', '3つ目')
+
+    await request(
+      `/api/lists/my-list/items/${second}`,
+      json(me.headers, 'PATCH', { completed: true }),
+    )
+
+    expect(await positionsOf('my-list')).toEqual(['0:1つ目', '1:2つ目', '2:3つ目'])
+  })
+
+  it('空の本文は拒否する（黙って何もしない応答を返さない）', async () => {
+    const { me } = await twoUsers()
+    const id = await addItem(me.headers, 'my-list', '南極に行く')
+
+    const res = await request(`/api/lists/my-list/items/${id}`, json(me.headers, 'PATCH', {}))
+
+    expect(res.status).toBe(400)
+  })
+
+  it('🔴 他人のリストの項目は変えられない', async () => {
+    const { me, other } = await twoUsers()
+    const theirs = await addItem(other.headers, 'other-list', '他人の項目')
+
+    const res = await request(
+      `/api/lists/other-list/items/${theirs}`,
+      json(me.headers, 'PATCH', { text: '乗っ取り' }),
+    )
+
+    expect(res.status).toBe(404)
+
+    const [row] = await testDb().select().from(items).where(eq(items.id, theirs))
+    expect(row?.text).toBe('他人の項目')
+  })
+
+  it('🔴 自分のリストの URL に他人の項目 ID を混ぜても変えられない', async () => {
+    const { me, other } = await twoUsers()
+    const theirs = await addItem(other.headers, 'other-list', '他人の項目')
+
+    // リストの所有者チェックは通るので、項目とリストの紐付けを見ないと通ってしまう
+    const res = await request(
+      `/api/lists/my-list/items/${theirs}`,
+      json(me.headers, 'PATCH', { text: '乗っ取り' }),
+    )
+
+    expect(res.status).toBe(404)
+
+    const [row] = await testDb().select().from(items).where(eq(items.id, theirs))
+    expect(row?.text).toBe('他人の項目')
+  })
+})
+
+describe('項目の削除', () => {
+  it('🔴 消すと後ろの並び順が詰まる', async () => {
+    const { me } = await twoUsers()
+    await addItem(me.headers, 'my-list', '1つ目')
+    const second = await addItem(me.headers, 'my-list', '2つ目')
+    await addItem(me.headers, 'my-list', '3つ目')
+
+    await request(`/api/lists/my-list/items/${second}`, {
+      method: 'DELETE',
+      headers: me.headers,
+    })
+
+    // 穴が空くと「0から始まる詰まった連番」という前提が崩れる（TECH_STACK.md §7）
+    expect(await positionsOf('my-list')).toEqual(['0:1つ目', '1:3つ目'])
+  })
+
+  it('🔴 他人の項目は消せない', async () => {
+    const { me, other } = await twoUsers()
+    const theirs = await addItem(other.headers, 'other-list', '他人の項目')
+
+    const res = await request(`/api/lists/my-list/items/${theirs}`, {
+      method: 'DELETE',
+      headers: me.headers,
+    })
+
+    expect(res.status).toBe(404)
+    expect(await testDb().select().from(items).where(eq(items.id, theirs))).toHaveLength(1)
+  })
+})
+
+describe('並び替え', () => {
+  it('送った順に並び直る', async () => {
+    const { me } = await twoUsers()
+    const a = await addItem(me.headers, 'my-list', '1つ目')
+    const b = await addItem(me.headers, 'my-list', '2つ目')
+    const c = await addItem(me.headers, 'my-list', '3つ目')
+
+    const res = await request(
+      '/api/lists/my-list/items/order',
+      json(me.headers, 'PUT', { itemIds: [c, a, b] }),
+    )
+
+    expect(res.status).toBe(200)
+    expect(await positionsOf('my-list')).toEqual(['0:3つ目', '1:1つ目', '2:2つ目'])
+  })
+
+  it('🔴 項目が欠けている並びは拒否する', async () => {
+    const { me } = await twoUsers()
+    const a = await addItem(me.headers, 'my-list', '1つ目')
+    await addItem(me.headers, 'my-list', '2つ目')
+
+    const res = await request(
+      '/api/lists/my-list/items/order',
+      json(me.headers, 'PUT', { itemIds: [a] }),
+    )
+
+    expect(res.status).toBe(409)
+    expect(await positionsOf('my-list')).toEqual(['0:1つ目', '1:2つ目'])
+  })
+
+  it('🔴 他人の項目 ID を混ぜて引き込めない', async () => {
+    const { me, other } = await twoUsers()
+    const mine = await addItem(me.headers, 'my-list', '自分の項目')
+    const theirs = await addItem(other.headers, 'other-list', '他人の項目')
+
+    const res = await request(
+      '/api/lists/my-list/items/order',
+      json(me.headers, 'PUT', { itemIds: [theirs, mine] }),
+    )
+
+    expect(res.status).toBe(409)
+
+    const [row] = await testDb().select().from(items).where(eq(items.id, theirs))
+    expect(row?.listId).toBe('other-list')
+  })
+
+  it('🔴 同じ ID を並べて数を合わせられない', async () => {
+    const { me } = await twoUsers()
+    const a = await addItem(me.headers, 'my-list', '1つ目')
+    await addItem(me.headers, 'my-list', '2つ目')
+
+    const res = await request(
+      '/api/lists/my-list/items/order',
+      json(me.headers, 'PUT', { itemIds: [a, a] }),
+    )
+
+    expect(res.status).toBe(409)
+    expect(await positionsOf('my-list')).toEqual(['0:1つ目', '1:2つ目'])
+  })
+})
+
+describe('リストの取得', () => {
+  it('リストと項目を並び順で返す', async () => {
+    const { me } = await twoUsers()
+    const a = await addItem(me.headers, 'my-list', '1つ目')
+    const b = await addItem(me.headers, 'my-list', '2つ目')
+    await request('/api/lists/my-list/items/order', json(me.headers, 'PUT', { itemIds: [b, a] }))
+
+    const res = await request('/api/lists/my-list', { headers: me.headers })
+    const body = await res.json<{ list: { id: string }; items: { id: string }[] }>()
+
+    expect(body.list.id).toBe('my-list')
+    expect(body.items.map((item) => item.id)).toEqual([b, a])
+  })
+
+  it('🔴 他人のリストの項目は読めない', async () => {
+    const { me, other } = await twoUsers()
+    await addItem(other.headers, 'other-list', '他人の項目')
+
+    const res = await request('/api/lists/other-list', { headers: me.headers })
+
+    expect(res.status).toBe(404)
+  })
+
+  it('リストを消すと項目も消える', async () => {
+    const { me } = await twoUsers()
+    await addItem(me.headers, 'my-list', '1つ目')
+
+    await request('/api/lists/my-list', { method: 'DELETE', headers: me.headers })
+
+    expect(await testDb().select().from(items)).toEqual([])
+  })
+})


### PR DESCRIPTION
Closes #89

## エンドポイント

| メソッド | パス | 備考 |
|---|---|---|
| GET | `/api/lists/:listId` | **項目も返すようにした**（画面は必ず両方を要る） |
| POST | `/api/lists/:listId/items` | 末尾に足す |
| PATCH | `/api/lists/:listId/items/:itemId` | 本文 / 完了 |
| DELETE | `/api/lists/:listId/items/:itemId` | 後ろの並び順を詰める |
| PUT | `/api/lists/:listId/items/order` | 全件書き直し |

認可は `requireOwnedList` に **`requireOwnedItem` を足した。**
ハンドラは `listId` / `itemId` を受け取らず、**認可を通った行だけ**を受け取る構造を維持している。

## 判断したこと

🔴 **完了「日時」を受け取らない。** `completed` の真偽値だけを受け取り、**日時はサーバーが決める。**
端末の時計は狂っていることがあり、送られた値をそのまま入れると「未来に叶えたこと」になる。

🔴 **件数の判定・並び順の決定・挿入を1文で行う**（リストの作成と同じ理由）。
数えてから入れると、素早く2回押されたときに上限を超えるし、**同じ並び順の項目が2つできる。**

🔴 **並び替えは全 ID を受け取り、いまの項目と集合が一致することを確かめる。**
一致を見ないと、**他人の項目 ID を混ぜて自分のリストに引き込む**経路と、
抜けた項目の並び順が古いまま残る経路ができる。

**削除したら後ろの並び順を詰める。** 詰めないと `position` に穴が空き、
「0から始まる詰まった連番」という前提（`TECH_STACK.md` §7）が崩れる。削除と詰め直しは同じ `batch`。

**項目を変えたらリストの `updated_at` も新しくする。** トップで「最後に更新したリスト」を
出すため（`PRODUCT_SPEC.md` §4.3）。触らないと、項目だけ書き換えたリストが古いままになる。

## テスト（`apps/web/test/items-api.test.ts`、23件）

認可の「通らないこと」を厚めに:

- **自分のリストの URL に他人の項目 ID を混ぜても通らない**
  （リストの所有者チェックは通るので、項目とリストの紐付けを見ないと抜ける）
- 他人のリストへの追加・変更・削除が通らない。**存在しない ID と応答が一致する**
- 並び替えで**他人の項目 ID を引き込めない / 同じ ID を並べて数を合わせられない / 欠けを拒否**
- `position` や `completedAt` を送り込めない
- 上限（項目数・文字数）を超えられない

全体で **152 tests / 11 files が緑**。

## 踏んだこと（#90 に記録済み）

**100件を1文で `insert` すると D1 が `too many SQL variables` で落ちる。**
取り込み API（#90）は最大100項目を一度に入れるので、あちらで分割が要る。

🤖 Generated with [Claude Code](https://claude.com/claude-code)