### PR TITLE
localStorage からの引き継ぎ API

### DIFF
--- a/apps/web/src/index.ts
+++ b/apps/web/src/index.ts
@@ -72,6 +72,35 @@ const reorderItemsSchema = z
   .object({ itemIds: z.array(z.string()).max(ITEMS_PER_LIST_MAX) })
   .strict()
 
+/**
+ * localStorage からの取り込みで受け取る内容（`PRODUCT_SPEC.md` §2）。
+ *
+ * 🔴 **完了の状態を受け取らない。** 未ログインでは「やった」印を付けられないので
+ * （#77）、ブラウザ側に完了した項目は存在しない。受け取る口を作ると、
+ * **その制約を要求の組み立てだけで迂回できてしまう。**
+ *
+ * **1項目も無いものは取り込まない**という規則があるので、`min(1)` で弾く。
+ * 画面側でも呼ぶ前に判定するが（#91）、規則はサーバーにも置く。
+ */
+const importListSchema = z
+  .object({
+    title: listTitleSchema.optional(),
+    items: z
+      .array(z.object({ text: itemTextSchema }).strict())
+      .min(1)
+      .max(ITEMS_PER_LIST_MAX),
+  })
+  .strict()
+
+/**
+ * 一度の `insert` に入れる項目の数。
+ *
+ * ⚠️ **D1 は1文あたりのバインド変数に上限がある**（100件を1文で入れると
+ * `too many SQL variables` で落ちる。#89 で踏んだ）。1行4列なので20行ずつに割る。
+ * 分けても `batch` に渡せば1トランザクションのまま。
+ */
+const INSERT_CHUNK = 20
+
 /** そのリストの項目を並び順で取る。 */
 function selectItems(db: Db, listId: string) {
   return db.select().from(items).where(eq(items.listId, listId)).orderBy(asc(items.position))
@@ -177,6 +206,66 @@ const app = new Hono<AppEnv>()
     if (!list) throw new Error('作ったリストを読み戻せなかった')
 
     return c.json({ list }, 201)
+  })
+
+  /**
+   * ブラウザに書いていたリストを取り込む（`PRODUCT_SPEC.md` §2「ログイン時の引き継ぎ」）。
+   *
+   * 規則をそのまま実装している:
+   *
+   * - **常に新しいリストとして足す。** すでに持っているリストへのマージはしない
+   *   （意図しない混ざりを防ぐ）。1つ目かどうかで挙動を変える必要は無い
+   * - **1項目も無いものは取り込まない**（`importListSchema` の `min(1)`）
+   * - **上限に達していたら取り込まない。** 409 を返して、
+   *   ブラウザ側のデータを消さずに残せるようにする（勝手に捨てない）
+   *
+   * リストを作れたのに項目が入らない、という中途半端な状態を残さないため、
+   * **項目の挿入が失敗したらリストを消してから投げ直す。**
+   */
+  .post('/api/lists/import', requireUser, zValidator('json', importListSchema), async (c) => {
+    const db = createDb(c.env.DB)
+    const userId = c.get('userId')
+    const listId = newId()
+    const { title, items: incoming } = c.req.valid('json')
+
+    // 上限の判定と挿入を1文で（POST /api/lists と同じ理由）
+    const inserted = await db.all<{ id: string }>(sql`
+      insert into ${lists} (id, user_id, title)
+      select ${listId}, ${userId}, ${title ?? DEFAULT_LIST_TITLE}
+      where (select count(*) from ${lists} where ${lists.userId} = ${userId}) < ${LISTS_PER_USER_MAX}
+      returning id
+    `)
+
+    if (inserted.length === 0) {
+      return c.json({ error: 'List Limit Reached' } as const, 409)
+    }
+
+    const rows = incoming.map((item, position) => ({
+      id: newId(),
+      listId,
+      text: item.text,
+      position,
+    }))
+
+    const rest = []
+    for (let i = INSERT_CHUNK; i < rows.length; i += INSERT_CHUNK) {
+      rest.push(db.insert(items).values(rows.slice(i, i + INSERT_CHUNK)))
+    }
+
+    try {
+      // batch の型は「1つ以上」を要求する。先頭を分けて渡すことで、
+      // 空配列になりえないことを型でも示す（項目が1件以上あることは検証済み）
+      await db.batch([db.insert(items).values(rows.slice(0, INSERT_CHUNK)), ...rest])
+    } catch (error) {
+      // 項目の無い空のリストを残さない
+      await db.delete(lists).where(eq(lists.id, listId))
+      throw error
+    }
+
+    const [list] = await db.select().from(lists).where(eq(lists.id, listId))
+    if (!list) throw new Error('取り込んだリストを読み戻せなかった')
+
+    return c.json({ list, items: await selectItems(db, listId) }, 201)
   })
 
   /**

--- a/apps/web/test/import-api.test.ts
+++ b/apps/web/test/import-api.test.ts
@@ -1,0 +1,213 @@
+import { exports } from 'cloudflare:workers'
+import {
+  DEFAULT_LIST_TITLE,
+  ITEM_TEXT_MAX_LENGTH,
+  ITEMS_PER_LIST_MAX,
+  LISTS_PER_USER_MAX,
+} from '@yaritai100list/shared'
+import { asc, eq } from 'drizzle-orm'
+import { describe, expect, it } from 'vitest'
+
+import { items, lists } from '../src/db/schema'
+import { signIn, testBaseUrl, testDb } from './helpers'
+
+/**
+ * localStorage からの取り込み API のテスト（#90）。
+ *
+ * 規則は `PRODUCT_SPEC.md` §2「ログイン時の引き継ぎ」。
+ * **勝手に上限を超えさせない／勝手に捨てない**が要点なので、
+ * 「取り込まれないこと」と「既存が書き換わらないこと」を厚めに固定する。
+ */
+
+const request = (path: string, init?: RequestInit) =>
+  exports.default.fetch(new Request(`${testBaseUrl()}${path}`, init))
+
+function importList(headers: Headers, body: unknown) {
+  return request('/api/lists/import', {
+    method: 'POST',
+    headers: { ...Object.fromEntries(headers), 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+/** そのリストの項目を並び順で読む。 */
+async function textsOf(listId: string) {
+  const rows = await testDb()
+    .select()
+    .from(items)
+    .where(eq(items.listId, listId))
+    .orderBy(asc(items.position))
+
+  return rows.map((row) => row.text)
+}
+
+describe('POST /api/lists/import', () => {
+  it('🔴 未ログインでは取り込めない', async () => {
+    const res = await importList(new Headers(), { items: [{ text: '南極に行く' }] })
+
+    expect(res.status).toBe(401)
+    expect(await testDb().select().from(lists)).toEqual([])
+  })
+
+  it('リストと項目が作られ、並び順が保たれる', async () => {
+    const me = await signIn('importer@example.com')
+
+    const res = await importList(me.headers, {
+      title: '2026年の目標',
+      items: [{ text: '1つ目' }, { text: '2つ目' }, { text: '3つ目' }],
+    })
+
+    expect(res.status).toBe(201)
+
+    const body = await res.json<{ list: { id: string; title: string } }>()
+    expect(body.list.title).toBe('2026年の目標')
+    expect(await textsOf(body.list.id)).toEqual(['1つ目', '2つ目', '3つ目'])
+  })
+
+  it('タイトルを省略すると既定のタイトルになる', async () => {
+    const me = await signIn('notitle@example.com')
+
+    await importList(me.headers, { items: [{ text: 'x' }] })
+
+    const [row] = await testDb().select().from(lists)
+    expect(row?.title).toBe(DEFAULT_LIST_TITLE)
+  })
+
+  it('取り込んだ項目は未完了で始まる', async () => {
+    const me = await signIn('fresh@example.com')
+
+    await importList(me.headers, { items: [{ text: 'x' }] })
+
+    const [row] = await testDb().select().from(items)
+    expect(row?.completedAt).toBeNull()
+  })
+
+  it('🔴 完了の状態を送り込めない（未ログインでは印を付けられないため）', async () => {
+    const me = await signIn('completed@example.com')
+
+    // 受け取る口を作ると、#77 の制約を要求の組み立てだけで迂回できてしまう
+    const res = await importList(me.headers, {
+      items: [{ text: 'x', completedAt: 1_700_000_000_000 }],
+    })
+
+    expect(res.status).toBe(400)
+    expect(await testDb().select().from(lists)).toEqual([])
+  })
+
+  it('🔴 空のリストは取り込まれない', async () => {
+    const me = await signIn('empty@example.com')
+
+    const res = await importList(me.headers, { items: [] })
+
+    expect(res.status).toBe(400)
+    expect(await testDb().select().from(lists)).toEqual([])
+  })
+
+  it('100件ちょうどを取り込める（D1 のバインド変数の上限を越えない）', async () => {
+    const me = await signIn('full@example.com')
+
+    // 1文で入れると too many SQL variables で落ちる。分割していることの確認（#89）
+    const res = await importList(me.headers, {
+      items: Array.from({ length: ITEMS_PER_LIST_MAX }, (_, i) => ({
+        text: `やりたい${String(i)}`,
+      })),
+    })
+
+    expect(res.status).toBe(201)
+
+    const [row] = await testDb().select().from(lists)
+    expect(await textsOf(row?.id ?? '')).toHaveLength(ITEMS_PER_LIST_MAX)
+  })
+
+  it('上限を超える件数は拒否する', async () => {
+    const me = await signIn('over@example.com')
+
+    const res = await importList(me.headers, {
+      items: Array.from({ length: ITEMS_PER_LIST_MAX + 1 }, () => ({ text: 'x' })),
+    })
+
+    expect(res.status).toBe(400)
+    expect(await testDb().select().from(lists)).toEqual([])
+  })
+
+  it('上限を超える本文は拒否する', async () => {
+    const me = await signIn('long@example.com')
+
+    const res = await importList(me.headers, {
+      items: [{ text: 'あ'.repeat(ITEM_TEXT_MAX_LENGTH + 1) }],
+    })
+
+    expect(res.status).toBe(400)
+    // 1件でも通らなければ、リストも作らない
+    expect(await testDb().select().from(lists)).toEqual([])
+  })
+
+  describe('すでにリストを持っている場合', () => {
+    it('🔴 既存のリストにマージせず、新しいリストとして足す', async () => {
+      const me = await signIn('has-list@example.com')
+      const db = testDb()
+
+      await db.insert(lists).values({ id: 'existing', userId: me.userId, title: '既存' })
+      await db
+        .insert(items)
+        .values({ id: 'kept', listId: 'existing', text: '既存の項目', position: 0 })
+
+      await importList(me.headers, { items: [{ text: '取り込んだ項目' }] })
+
+      // 意図しない混ざりを防ぐ（PRODUCT_SPEC.md §2）
+      expect(await textsOf('existing')).toEqual(['既存の項目'])
+      expect(await db.select().from(lists)).toHaveLength(2)
+    })
+
+    it('🔴 上限に達していたら取り込まない', async () => {
+      const me = await signIn('limit@example.com')
+      const db = testDb()
+
+      await db.insert(lists).values(
+        Array.from({ length: LISTS_PER_USER_MAX }, (_, i) => ({
+          id: `list-${String(i)}`,
+          userId: me.userId,
+          title: 'x',
+        })),
+      )
+
+      const res = await importList(me.headers, { items: [{ text: '取り込めない' }] })
+
+      // 勝手に上限を超えさせない。ブラウザ側を消さずに残せるよう理由を返す
+      expect(res.status).toBe(409)
+      expect(await res.json()).toEqual({ error: 'List Limit Reached' })
+      expect(await db.select().from(lists)).toHaveLength(LISTS_PER_USER_MAX)
+      expect(await db.select().from(items)).toEqual([])
+    })
+
+    it('🔴 他人が上限まで持っていても、自分は取り込める', async () => {
+      const other = await signIn('other@example.com')
+      const db = testDb()
+
+      await db.insert(lists).values(
+        Array.from({ length: LISTS_PER_USER_MAX }, (_, i) => ({
+          id: `other-${String(i)}`,
+          userId: other.userId,
+          title: 'x',
+        })),
+      )
+
+      const me = await signIn('me@example.com')
+
+      expect((await importList(me.headers, { items: [{ text: 'x' }] })).status).toBe(201)
+    })
+  })
+
+  it('🔴 知らないキーは拒否する', async () => {
+    const me = await signIn('extra@example.com')
+
+    // userId や visibility を送り込む経路を塞ぐ
+    const res = await importList(me.headers, {
+      userId: 'someone-else',
+      items: [{ text: 'x' }],
+    })
+
+    expect(res.status).toBe(400)
+    expect(await testDb().select().from(lists)).toEqual([])
+  })
+})


### PR DESCRIPTION
Closes #90

`POST /api/lists/import`。`PRODUCT_SPEC.md` §2「ログイン時の引き継ぎ」の規則をそのまま実装した。

| 規則 | 実装 |
|---|---|
| 既存のリストにマージしない | **常に新しいリストとして足す。** 1つ目かどうかで挙動を変えない |
| 1項目も無ければ取り込まない | Zod の `min(1)`（400） |
| 上限に達していたら取り込まない | **409。** ブラウザ側を消さずに残せるよう理由を返す |

🔴 **完了の状態を受け取らない。** 未ログインでは「やった」印を付けられない（#77）ので、
ブラウザ側に完了した項目は存在しない。**受け取る口を作ると、その制約を
要求の組み立てだけで迂回できてしまう。**

## D1 のバインド変数の上限

⚠️ **100件を1文で `insert` すると `too many SQL variables` で落ちる**（#89 で踏んだ）。
20行ずつに割り、`batch` に渡して1トランザクションのままにしている。

**項目の挿入に失敗したらリストを消してから投げ直す。**
リストだけできて項目が入っていない、という中途半端な状態を残さないため。

## テスト（`apps/web/test/import-api.test.ts`、13件）

「取り込まれないこと」と「既存が書き換わらないこと」を厚めに:

- **既存のリストにマージされない**（既存の項目が元のまま）
- **上限に達していたら 409 で、リストも項目も1件も増えない**
- **他人が上限まで持っていても自分は取り込める**
- 完了の状態・`userId` を送り込めない
- 空・件数超過・文字数超過を拒否し、**そのときリストも作らない**
- **100件ちょうどが通る**（分割していることの確認）

全体で **165 tests / 12 files が緑**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)