### PR TITLE
クライアントの保存先をログイン状態で切り替える

### DIFF
--- a/apps/web/src/client/App.tsx
+++ b/apps/web/src/client/App.tsx
@@ -8,46 +8,19 @@ import { useCallback, useEffect, useState } from 'react'
 
 import { ListEditor } from './ListEditor'
 import {
-  addItem,
-  createEmptyList,
-  LIST_STORAGE_KEY,
-  parseStoredList,
-  removeItem,
-  renameList,
-  serializeList,
-  setItemCompletedAt,
   signOutRequestInit,
   toCompletionPermission,
   toSessionState,
-  updateItemText,
-  type Item,
-  type ListResult,
-  type LocalList,
   type SessionState,
 } from './model'
+import { useList, type ImportOutcome, type ListController, type Rejection } from './useList'
 
 /**
- * 未ログインでも書ける画面（#4）。
+ * 画面の入口。
  *
- * **判定と計算は `model.ts` の純関数に置く**（`TECH_STACK.md` §10 の方針）。
- * ここに残すのは、localStorage との読み書き・取得の配線・描画だけ。
+ * **判定と変換は `model.ts` の純関数**（`TECH_STACK.md` §10）、
+ * **読み書きの配線は `useList.ts`**。ここに残すのは描画と、セッションの取得だけ。
  */
-
-/**
- * 保存の状態。**「読めなかった」を「まだ何も無い」に混ぜない。**
- *
- * 混ぜると、読めなかっただけの保存に空リストを上書きして
- * 利用者の書いたものを消す（`parseStoredList` の注意書きと同じ話）。
- */
-type StorageState =
-  | { status: 'loading' }
-  | { status: 'ok' }
-  /** 保存はあるが読めない。**利用者が了解するまで書き込まない。** */
-  | { status: 'broken' }
-  /** localStorage 自体が使えない（プライベートブラウズなど）。書けるが残らない。 */
-  | { status: 'unavailable' }
-  /** 書き込みに失敗した（容量など）。**黙って失敗しない。** */
-  | { status: 'save-failed' }
 
 /**
  * 断られた理由ごとの文言。
@@ -56,22 +29,21 @@ type StorageState =
  * 長すぎて弾かれた人に「1文字以上入力してください」と出しても、何を直せばいいのか
  * 分からない。文字数は `packages/shared` の定数から出す（ここに数字を書かない）。
  */
-const ERROR_MESSAGES = {
+const REJECTION_MESSAGES: Record<Rejection, string> = {
   'text-empty': 'やりたいことを入力してください',
   'text-too-long': `やりたいことは${String(ITEM_TEXT_MAX_LENGTH)}文字までです`,
   'title-empty': 'タイトルを入力してください',
   'title-too-long': `タイトルは${String(LIST_TITLE_MAX_LENGTH)}文字までです`,
   'list-full': `${String(ITEMS_PER_LIST_MAX)}件まで書けます。減らすと続けて書けます`,
   'not-found': '対象の項目が見つかりませんでした',
-} as const
+  'server-error': '保存できませんでした。通信を確かめて、もう一度試してください',
+}
 
 export function App() {
   const [session, setSession] = useState<SessionState>({ status: 'loading' })
   const [signOutFailed, setSignOutFailed] = useState(false)
 
-  const [list, setList] = useState<LocalList | null>(null)
-  const [storage, setStorage] = useState<StorageState>({ status: 'loading' })
-  const [error, setError] = useState<string | null>(null)
+  const controller = useList(session)
 
   // --- セッション（#3 で入れた配線。消さないこと） ---
 
@@ -108,61 +80,7 @@ export function App() {
     await loadSession()
   }, [loadSession])
 
-  // --- localStorage ---
-
-  useEffect(() => {
-    let raw: string | null
-
-    try {
-      raw = window.localStorage.getItem(LIST_STORAGE_KEY)
-    } catch {
-      // 保存できないだけで、書くことはできる。空のリストで始める
-      setList(createEmptyList())
-      setStorage({ status: 'unavailable' })
-      return
-    }
-
-    const stored = parseStoredList(raw)
-
-    if (stored.status === 'broken') {
-      // **リストを作らない。** 作ると最初の編集で保存を上書きしてしまう
-      setStorage({ status: 'broken' })
-      return
-    }
-
-    setList(stored.status === 'loaded' ? stored.list : createEmptyList())
-    setStorage({ status: 'ok' })
-  }, [])
-
-  /**
-   * 変更を反映して保存する。**保存は変更のたびにここだけで行う。**
-   *
-   * `useEffect` で `list` を監視して保存すると、読み込み直後にも走るため、
-   * 「読めなかった保存」を上書きする経路ができてしまう。
-   */
-  const applyResult = useCallback(
-    (result: ListResult): boolean => {
-      if (!result.ok) {
-        setError(ERROR_MESSAGES[result.reason])
-        return false
-      }
-
-      setError(null)
-      setList(result.list)
-
-      if (storage.status === 'unavailable') return true
-
-      try {
-        window.localStorage.setItem(LIST_STORAGE_KEY, serializeList(result.list))
-        setStorage({ status: 'ok' })
-      } catch {
-        setStorage({ status: 'save-failed' })
-      }
-
-      return true
-    },
-    [storage.status],
-  )
+  const { screen, rejection } = controller
 
   return (
     <div className="min-h-dvh bg-brand-soft">
@@ -180,49 +98,39 @@ export function App() {
           onSignOut={() => void signOut()}
         />
 
-        {storage.status === 'loading' && <p className="py-8 text-slate-500">読み込み中</p>}
+        <ImportNotice outcome={controller.importOutcome} />
 
-        {storage.status === 'broken' && (
-          <BrokenStorageNotice
-            onStartOver={() => {
-              // ここでは保存を消さない。最初の編集で上書きされる
-              setList(createEmptyList())
-              setStorage({ status: 'ok' })
-            }}
-          />
+        {screen.status === 'loading' && <p className="py-8 text-slate-500">読み込み中</p>}
+
+        {screen.status === 'broken' && <BrokenStorageNotice onStartOver={controller.startOver} />}
+
+        {screen.status === 'failed' && (
+          <Notice tone="warn">
+            リストを読み込めませんでした。書き換えて失わないよう、編集を止めています。
+            通信を確かめて、ページを開き直してください
+          </Notice>
         )}
 
-        {list && (
+        {screen.status === 'ready' && (
           <>
-            <StorageNotice storage={storage} session={session} />
+            <StorageNotice controller={controller} session={session} />
 
-            {error !== null && (
+            {rejection !== null && (
               <p role="alert" className="mb-2 rounded bg-white px-3 py-2 text-sm text-brand-deep">
-                {error}
+                {REJECTION_MESSAGES[rejection]}
               </p>
             )}
 
             <ListEditor
-              list={list}
+              list={screen.list}
               // 未ログインでは「やった」印を付けられない（PRODUCT_SPEC.md §2）。
               // 判定は model.ts の純関数。ここでは status を見比べない
               completion={toCompletionPermission(session)}
-              onRenameList={(title) => applyResult(renameList(list, title))}
-              onAddItem={(text) => applyResult(addItem(list, { id: crypto.randomUUID(), text }))}
-              onUpdateItemText={(id, text) => applyResult(updateItemText(list, id, text))}
-              onToggleItem={(item: Item) => {
-                // 案内を出すのは ListEditor だが、**印を付けない判断はここでもする。**
-                // 配線を間違えたときに、黙って未ログインの完了が保存される方が重い
-                if (!toCompletionPermission(session).allowed) return
-
-                // 完了日時は**呼び出し側で作る**（model.ts に時計を持ち込まない）
-                applyResult(
-                  setItemCompletedAt(list, item.id, item.completedAt === null ? Date.now() : null),
-                )
-              }}
-              onRemoveItem={(id) => {
-                applyResult(removeItem(list, id))
-              }}
+              onRenameList={controller.renameList}
+              onAddItem={controller.addItem}
+              onUpdateItemText={controller.updateItemText}
+              onToggleItem={controller.toggleItem}
+              onRemoveItem={controller.removeItem}
             />
           </>
         )}
@@ -268,12 +176,46 @@ function SessionArea({
 }
 
 /**
- * 「保存されていない可能性がある」ことを伝える導線（`PRODUCT_SPEC.md` §4.1）。
+ * ブラウザに書いていた内容を取り込めたかの案内（`PRODUCT_SPEC.md` §2）。
  *
- * ログインの動機付けなので、**未ログインのときだけログインの入口を出す。**
- * ログイン済みでもいまは localStorage にしか保存していない（サーバーへの保存は #5）。
+ * 🔴 **取り込めなかったことを黙らない。** ブラウザ側のデータは消していないので、
+ * リストを整理すれば取り込める、と分かるようにする。
  */
-function StorageNotice({ storage, session }: { storage: StorageState; session: SessionState }) {
+function ImportNotice({ outcome }: { outcome: ImportOutcome }) {
+  if (outcome === 'imported') {
+    return (
+      <Notice tone="info">このブラウザに書いていた内容を、新しいリストとして取り込みました</Notice>
+    )
+  }
+
+  if (outcome === 'limit-reached') {
+    return (
+      <Notice tone="warn">
+        リストの数が上限のため、このブラウザに書いていた内容を取り込めませんでした。
+        内容はこのブラウザに残してあります。リストを整理してから開き直すと取り込めます
+      </Notice>
+    )
+  }
+
+  return null
+}
+
+/**
+ * どこに保存されているかの案内。
+ *
+ * ログイン中は**サーバーに保存されている**ので、ログインを促さない。
+ */
+function StorageNotice({
+  controller,
+  session,
+}: {
+  controller: ListController
+  session: SessionState
+}) {
+  const { screen, storage } = controller
+
+  if (screen.status === 'ready' && screen.source === 'server') return null
+
   if (storage.status === 'unavailable') {
     return (
       <Notice tone="warn">
@@ -299,8 +241,6 @@ function StorageNotice({ storage, session }: { storage: StorageState; session: S
     )
   }
 
-  // ログイン済みでも、いまの保存先は localStorage だけ（サーバーへの保存は #5）。
-  // ログインを促す文言は出さない
   return <Notice tone="info">いまはこのブラウザにだけ保存されています</Notice>
 }
 

--- a/apps/web/src/client/ListEditor.tsx
+++ b/apps/web/src/client/ListEditor.tsx
@@ -13,18 +13,21 @@ import { filledCount, toSlots, type CompletionPermission, type Item, type LocalL
  * 何が正しい値かは `model.ts` の純関数が決める（`TECH_STACK.md` §10）。
  * このファイルはテストしない。
  *
- * 変更を伝える関数は**受理されたかを真偽値で返す。** 入力欄は受理されたときだけ
- * 下書きを捨てる。捨ててから拒否されると、利用者が書いた文字が黙って消える。
+ * 変更を伝える関数は**受理されたかを返す。** 入力欄は受理されたときだけ下書きを捨てる。
+ * 捨ててから拒否されると、利用者が書いた文字が黙って消える。
+ *
+ * ログイン中はサーバーへの往復になるので**非同期**（`Promise<boolean>`）。
+ * 保存先が localStorage かサーバーかを、この画面は区別しない。
  */
 interface ListEditorProps {
   list: LocalList
   /** 「やった」印を付けられるか。判定は `model.ts` の `toCompletionPermission`。 */
   completion: CompletionPermission
-  onRenameList: (title: string) => boolean
-  onAddItem: (text: string) => boolean
-  onUpdateItemText: (id: string, text: string) => boolean
-  onToggleItem: (item: Item) => void
-  onRemoveItem: (id: string) => void
+  onRenameList: (title: string) => Promise<boolean>
+  onAddItem: (text: string) => Promise<boolean>
+  onUpdateItemText: (id: string, text: string) => Promise<boolean>
+  onToggleItem: (item: Item) => Promise<boolean>
+  onRemoveItem: (id: string) => Promise<boolean>
 }
 
 export function ListEditor({
@@ -109,7 +112,7 @@ export function ListEditor({
               onToggle={(item) => {
                 if (completion.allowed) {
                   setPromptedId(null)
-                  onToggleItem(item)
+                  void onToggleItem(item)
                   return
                 }
 
@@ -118,7 +121,7 @@ export function ListEditor({
                 // もう一度押すと閉じる（案内を消す手段がこれしかない）
                 setPromptedId((current) => (current === item.id ? null : item.id))
               }}
-              onRemove={onRemoveItem}
+              onRemove={(id) => void onRemoveItem(id)}
             />
           ) : index === nextIndex ? (
             // key を固定して**同じ入力欄を使い回す**。項目を足すと1つ下へ移るが、
@@ -133,12 +136,18 @@ export function ListEditor({
   )
 }
 
-function ListTitleField({ title, onRename }: { title: string; onRename: (t: string) => boolean }) {
+function ListTitleField({
+  title,
+  onRename,
+}: {
+  title: string
+  onRename: (t: string) => Promise<boolean>
+}) {
   const [draft, setDraft] = useState(title)
 
-  const commit = () => {
+  const commit = async () => {
     if (draft === title) return
-    if (!onRename(draft)) setDraft(title) // 拒否されたら見えている値を実際の値に戻す
+    if (!(await onRename(draft))) setDraft(title) // 拒否されたら見えている値を実際の値に戻す
   }
 
   return (
@@ -151,7 +160,7 @@ function ListTitleField({ title, onRename }: { title: string; onRename: (t: stri
       onChange={(e) => {
         setDraft(e.target.value)
       }}
-      onBlur={commit}
+      onBlur={() => void commit()}
       onKeyDown={(e) => {
         if (isCommitKey(e)) e.currentTarget.blur()
       }}
@@ -198,16 +207,16 @@ function ItemRow({
   item: Item
   completion: CompletionPermission
   prompted: boolean
-  onCommit: (id: string, text: string) => boolean
+  onCommit: (id: string, text: string) => Promise<boolean>
   onToggle: (item: Item) => void
   onRemove: (id: string) => void
 }) {
   const [draft, setDraft] = useState(item.text)
   const done = item.completedAt !== null
 
-  const commit = () => {
+  const commit = async () => {
     if (draft === item.text) return
-    if (!onCommit(item.id, draft)) setDraft(item.text)
+    if (!(await onCommit(item.id, draft))) setDraft(item.text)
   }
 
   return (
@@ -251,7 +260,7 @@ function ItemRow({
           onChange={(e) => {
             setDraft(e.target.value)
           }}
-          onBlur={commit}
+          onBlur={() => void commit()}
           onKeyDown={(e) => {
             if (isCommitKey(e)) e.currentTarget.blur()
           }}
@@ -331,17 +340,17 @@ function PromptBox({ children }: { children: React.ReactNode }) {
   )
 }
 
-function NextRow({ number, onAdd }: { number: string; onAdd: (text: string) => boolean }) {
+function NextRow({ number, onAdd }: { number: string; onAdd: (text: string) => Promise<boolean> }) {
   const [draft, setDraft] = useState('')
 
-  const commit = () => {
+  const commit = async () => {
     // 空白だけの入力は「書いていない」として扱う。エラーを出す場面ではない
     if (draft.trim() === '') {
       setDraft('')
       return
     }
 
-    if (onAdd(draft)) setDraft('')
+    if (await onAdd(draft)) setDraft('')
   }
 
   return (
@@ -357,10 +366,10 @@ function NextRow({ number, onAdd }: { number: string; onAdd: (text: string) => b
         onChange={(e) => {
           setDraft(e.target.value)
         }}
-        onBlur={commit}
+        onBlur={() => void commit()}
         onKeyDown={(e) => {
           // Enter で続けて書ける。この入力欄は使い回されるのでフォーカスは外れない
-          if (isCommitKey(e)) commit()
+          if (isCommitKey(e)) void commit()
         }}
         className={`${TEXT_INPUT} text-slate-900 placeholder:text-slate-400`}
       />

--- a/apps/web/src/client/model.ts
+++ b/apps/web/src/client/model.ts
@@ -372,3 +372,81 @@ export function parseStoredList(raw: string | null): StoredListResult {
 
   return { status: 'loaded', list: parsed.data }
 }
+
+// ---------------------------------------------------------------------------
+// サーバーとのやりとり（#5 / #91）
+// ---------------------------------------------------------------------------
+
+/**
+ * サーバーから返るリストのうち、画面が使う部分。
+ *
+ * **日時は文字列。** `c.json()` を通ると `Date` は ISO 文字列になるので、
+ * `Date` として扱わない（`new Date(...)` を通すのはここだけにする）。
+ */
+export interface RemoteList {
+  id: string
+  title: string
+  updatedAt: string
+}
+
+export interface RemoteItem {
+  id: string
+  text: string
+  completedAt: string | null
+}
+
+/**
+ * トップで開くリストを選ぶ。**最後に更新したもの**（`PRODUCT_SPEC.md` §4.3）。
+ *
+ * リストを1つしか持っていない人に、選ぶ操作を作らないための決まり。
+ * 1つも無ければ `null`（呼び出し側が作る）。
+ */
+export function pickCurrentListId(lists: RemoteList[]): string | null {
+  let current: RemoteList | null = null
+
+  for (const list of lists) {
+    if (!current || Date.parse(list.updatedAt) > Date.parse(current.updatedAt)) {
+      current = list
+    }
+  }
+
+  return current?.id ?? null
+}
+
+/**
+ * サーバーの応答を画面の形に直す。
+ *
+ * 項目は**サーバーが並び順で返す**ので、ここでは並べ替えない
+ * （並び順の情報源を2つにしない）。
+ */
+export function toLocalList(list: { title: string }, items: RemoteItem[]): LocalList {
+  return {
+    title: list.title,
+    items: items.map((item) => ({
+      id: item.id,
+      text: item.text,
+      completedAt: item.completedAt === null ? null : Date.parse(item.completedAt),
+    })),
+  }
+}
+
+/**
+ * 取り込み（`POST /api/lists/import`）に送る内容。
+ *
+ * **完了の状態は送らない。** 未ログインでは印を付けられないので（#77）
+ * ブラウザ側に完了した項目は存在せず、サーバーも受け取らない。
+ */
+export function toImportBody(list: LocalList): { title: string; items: { text: string }[] } {
+  return { title: list.title, items: list.items.map((item) => ({ text: item.text })) }
+}
+
+/**
+ * 取り込むべきものがあるか。**1項目も書いていなければ取り込まない**
+ * （`PRODUCT_SPEC.md` §2）。
+ *
+ * サーバーでも弾いているが（`min(1)`）、**空で呼ばないのは画面側の責任**。
+ * 呼んでしまうと 400 になり、「失敗した」と見える。
+ */
+export function hasAnythingToImport(stored: StoredListResult): boolean {
+  return stored.status === 'loaded' && stored.list.items.length > 0
+}

--- a/apps/web/src/client/useList.ts
+++ b/apps/web/src/client/useList.ts
@@ -1,0 +1,341 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+import { api } from './api'
+import {
+  addItem,
+  createEmptyList,
+  hasAnythingToImport,
+  LIST_STORAGE_KEY,
+  parseStoredList,
+  pickCurrentListId,
+  removeItem,
+  renameList,
+  serializeList,
+  toImportBody,
+  toLocalList,
+  updateItemText,
+  type Item,
+  type ListResult,
+  type LocalList,
+  type SessionState,
+} from './model'
+
+/**
+ * リストの読み書きの配線。**判定と変換は `model.ts` の純関数に置く**
+ * （`TECH_STACK.md` §10）。ここに残すのは通信と localStorage との出入りだけで、
+ * このファイルはテストしない。
+ *
+ * 保存先はログイン状態で変わる（`PRODUCT_SPEC.md` §2）:
+ *
+ * - 未ログイン: localStorage。1つだけ
+ * - ログイン中: サーバー。トップでは**最後に更新したリスト**を開く
+ */
+
+/** どこに保存しているか。画面の案内を切り替えるために出す。 */
+export type ListSource = 'local' | 'server'
+
+export type ListScreen =
+  | { status: 'loading' }
+  /** ローカルの保存が読めない。**利用者が了解するまで書き込まない。** */
+  | { status: 'broken' }
+  /** サーバーから取れなかった。**未ログインと混ぜない**（書いたものを失わせない） */
+  | { status: 'failed' }
+  | { status: 'ready'; list: LocalList; source: ListSource }
+
+/**
+ * ブラウザの保存を取り込めたか。
+ *
+ * `limit-reached` のときは**ブラウザ側を消さない。**
+ * 整理すれば取り込める、と伝える必要がある（`PRODUCT_SPEC.md` §2）。
+ */
+export type ImportOutcome = 'none' | 'imported' | 'limit-reached'
+
+/** localStorage が使えるか（プライベートブラウズなどで例外になる）。 */
+type LocalStorage = { status: 'ok' } | { status: 'unavailable' } | { status: 'save-failed' }
+
+export interface ListController {
+  screen: ListScreen
+  storage: LocalStorage
+  importOutcome: ImportOutcome
+  /** 直前の操作が断られた理由。画面で文言にする */
+  rejection: Rejection | null
+  startOver: () => void
+  renameList: (title: string) => Promise<boolean>
+  addItem: (text: string) => Promise<boolean>
+  updateItemText: (id: string, text: string) => Promise<boolean>
+  toggleItem: (item: Item) => Promise<boolean>
+  removeItem: (id: string) => Promise<boolean>
+}
+
+/**
+ * 断られた理由。**ローカルの検証結果とサーバーの応答を同じ形にまとめる。**
+ * 画面はどちらに保存しているかを気にせず文言を出せる。
+ */
+export type Rejection = Extract<ListResult, { ok: false }>['reason'] | 'server-error'
+
+export function useList(session: SessionState): ListController {
+  const [screen, setScreen] = useState<ListScreen>({ status: 'loading' })
+  const [storage, setStorage] = useState<LocalStorage>({ status: 'ok' })
+  const [importOutcome, setImportOutcome] = useState<ImportOutcome>('none')
+  const [rejection, setRejection] = useState<Rejection | null>(null)
+
+  /** ログイン中に開いているリスト。未ログインなら null */
+  const listId = useRef<string | null>(null)
+
+  /**
+   * 取り込みは**一度だけ**走らせる。
+   *
+   * React は開発時に効果を2回呼ぶ（StrictMode）。守らないと**リストが2つできる。**
+   */
+  const imported = useRef(false)
+
+  // --- localStorage ---
+
+  const readStored = useCallback(() => {
+    try {
+      return parseStoredList(window.localStorage.getItem(LIST_STORAGE_KEY))
+    } catch {
+      return null // localStorage 自体が使えない
+    }
+  }, [])
+
+  const writeStored = useCallback((list: LocalList) => {
+    try {
+      window.localStorage.setItem(LIST_STORAGE_KEY, serializeList(list))
+      setStorage({ status: 'ok' })
+    } catch {
+      setStorage({ status: 'save-failed' })
+    }
+  }, [])
+
+  // --- サーバー ---
+
+  /** ログイン中の表示を作り直す。**取得できなければ `failed`。空リストで塗り潰さない。** */
+  const loadFromServer = useCallback(async (): Promise<void> => {
+    try {
+      if (listId.current === null) {
+        const res = await api.api.lists.$get()
+        if (!res.ok) {
+          setScreen({ status: 'failed' })
+          return
+        }
+
+        const { lists } = await res.json()
+        listId.current = pickCurrentListId(lists)
+
+        // 1つも持っていない人には作る（トップを開いたらすぐ書ける状態にする）
+        if (listId.current === null) {
+          const created = await api.api.lists.$post({ json: {} })
+          if (!created.ok) {
+            setScreen({ status: 'failed' })
+            return
+          }
+
+          const body = await created.json()
+          if (!('list' in body)) {
+            setScreen({ status: 'failed' })
+            return
+          }
+
+          listId.current = body.list.id
+        }
+      }
+
+      const res = await api.api.lists[':listId'].$get({ param: { listId: listId.current } })
+      if (!res.ok) {
+        // 開いていたリストが消えている場合もここに来る。次は選び直す
+        listId.current = null
+        setScreen({ status: 'failed' })
+        return
+      }
+
+      const body = await res.json()
+      setScreen({ status: 'ready', list: toLocalList(body.list, body.items), source: 'server' })
+    } catch {
+      setScreen({ status: 'failed' })
+    }
+  }, [])
+
+  /**
+   * ブラウザの保存をサーバーへ取り込む（`PRODUCT_SPEC.md` §2）。
+   *
+   * 🔴 **取り込めたときだけブラウザ側を消す。** 上限で断られたときに消すと、
+   * 書いたものが戻らない。
+   */
+  const importStored = useCallback(async (): Promise<void> => {
+    const stored = readStored()
+    if (stored === null || !hasAnythingToImport(stored)) return
+    if (stored.status !== 'loaded') return
+
+    const res = await api.api.lists.import.$post({ json: toImportBody(stored.list) })
+
+    if (res.status === 409) {
+      setImportOutcome('limit-reached')
+      return
+    }
+
+    if (!res.ok) return // 取り込めなかった。ブラウザ側は残したまま次の機会に
+
+    // 二重管理を避けるため、取り込めたらブラウザ側は消す
+    try {
+      window.localStorage.removeItem(LIST_STORAGE_KEY)
+    } catch {
+      // 消せなくても取り込みは済んでいる。次回はサーバーを見るので実害は無い
+    }
+
+    setImportOutcome('imported')
+  }, [readStored])
+
+  // --- 起動時 ---
+
+  useEffect(() => {
+    if (session.status === 'loading') return
+
+    const start = async () => {
+      if (session.status === 'authenticated') {
+        if (!imported.current) {
+          imported.current = true
+          await importStored()
+        }
+
+        await loadFromServer()
+        return
+      }
+
+      // 未ログイン（`error` のときも書けるようにする。ローカルなら失うものが無い）
+      const stored = readStored()
+
+      if (stored === null) {
+        setStorage({ status: 'unavailable' })
+        setScreen({ status: 'ready', list: createEmptyList(), source: 'local' })
+        return
+      }
+
+      if (stored.status === 'broken') {
+        // **リストを作らない。** 作ると最初の編集で保存を上書きしてしまう
+        setScreen({ status: 'broken' })
+        return
+      }
+
+      setScreen({
+        status: 'ready',
+        list: stored.status === 'loaded' ? stored.list : createEmptyList(),
+        source: 'local',
+      })
+    }
+
+    void start()
+  }, [session.status, importStored, loadFromServer, readStored])
+
+  // --- 操作 ---
+
+  /** ローカルの純関数の結果を反映して保存する。 */
+  const applyLocal = useCallback(
+    (result: ListResult): boolean => {
+      if (!result.ok) {
+        setRejection(result.reason)
+        return false
+      }
+
+      setRejection(null)
+      setScreen({ status: 'ready', list: result.list, source: 'local' })
+      if (storage.status !== 'unavailable') writeStored(result.list)
+
+      return true
+    },
+    [storage.status, writeStored],
+  )
+
+  /**
+   * サーバーへの1操作。**成功したら取り直す。**
+   *
+   * 削除で後ろの並び順が詰まるなど、応答だけでは画面を正しく作れない場合がある。
+   * 往復は増えるが、**表示が DB とずれない**ことを優先する。
+   */
+  const applyServer = useCallback(
+    // Hono RPC が返すのは `Response` そのものではないので、見たい2つだけを型にする
+    async (
+      send: (listId: string) => Promise<{ ok: boolean; status: number }>,
+    ): Promise<boolean> => {
+      const id = listId.current
+      if (id === null) return false
+
+      try {
+        const res = await send(id)
+
+        if (!res.ok) {
+          setRejection(res.status === 409 ? 'list-full' : 'server-error')
+          return false
+        }
+
+        setRejection(null)
+        await loadFromServer()
+
+        return true
+      } catch {
+        setRejection('server-error')
+        return false
+      }
+    },
+    [loadFromServer],
+  )
+
+  const onServer = screen.status === 'ready' && screen.source === 'server'
+  const list = screen.status === 'ready' ? screen.list : null
+
+  return {
+    screen,
+    storage,
+    importOutcome,
+    rejection,
+
+    startOver: () => {
+      // ここでは保存を消さない。最初の編集で上書きされる
+      setScreen({ status: 'ready', list: createEmptyList(), source: 'local' })
+    },
+
+    renameList: async (title) =>
+      onServer
+        ? applyServer((id) =>
+            api.api.lists[':listId'].$patch({ param: { listId: id }, json: { title } }),
+          )
+        : list !== null && applyLocal(renameList(list, title)),
+
+    addItem: async (text) =>
+      onServer
+        ? applyServer((id) =>
+            api.api.lists[':listId'].items.$post({ param: { listId: id }, json: { text } }),
+          )
+        : list !== null && applyLocal(addItem(list, { id: crypto.randomUUID(), text })),
+
+    updateItemText: async (itemId, text) =>
+      onServer
+        ? applyServer((id) =>
+            api.api.lists[':listId'].items[':itemId'].$patch({
+              param: { listId: id, itemId },
+              json: { text },
+            }),
+          )
+        : list !== null && applyLocal(updateItemText(list, itemId, text)),
+
+    toggleItem: async (item) =>
+      onServer
+        ? applyServer((id) =>
+            api.api.lists[':listId'].items[':itemId'].$patch({
+              param: { listId: id, itemId: item.id },
+              json: { completed: item.completedAt === null },
+            }),
+          )
+        : // 未ログインでは完了にできない（#77）。ここへは来ない
+          false,
+
+    removeItem: async (itemId) =>
+      onServer
+        ? applyServer((id) =>
+            api.api.lists[':listId'].items[':itemId'].$delete({
+              param: { listId: id, itemId },
+            }),
+          )
+        : list !== null && applyLocal(removeItem(list, itemId)),
+  }
+}

--- a/apps/web/test/client-model.test.ts
+++ b/apps/web/test/client-model.test.ts
@@ -11,13 +11,17 @@ import {
   createEmptyList,
   filledCount,
   formatItemNumber,
+  hasAnythingToImport,
   moveItem,
+  pickCurrentListId,
   parseStoredList,
   removeItem,
   renameList,
   serializeList,
   setItemCompletedAt,
   toCompletionPermission,
+  toImportBody,
+  toLocalList,
   toSessionState,
   toSlots,
   updateItemText,
@@ -332,6 +336,77 @@ describe('toSlots / formatItemNumber / filledCount', () => {
     const list = expectOk(setItemCompletedAt(listOf('1つ目', '2つ目', '3つ目'), 'i1', 1))
 
     expect(filledCount(list)).toBe(3)
+  })
+})
+
+describe('pickCurrentListId', () => {
+  it('🔴 最後に更新したリストを選ぶ', () => {
+    // リストを1つしか持っていない人に選ぶ操作を作らないための決まり（PRODUCT_SPEC.md §4.3）
+    const id = pickCurrentListId([
+      { id: 'old', title: 'a', updatedAt: '2026-08-01T00:00:00.000Z' },
+      { id: 'newest', title: 'b', updatedAt: '2026-08-07T00:00:00.000Z' },
+      { id: 'middle', title: 'c', updatedAt: '2026-08-05T00:00:00.000Z' },
+    ])
+
+    expect(id).toBe('newest')
+  })
+
+  it('1つも無ければ null（呼び出し側が作る）', () => {
+    expect(pickCurrentListId([])).toBeNull()
+  })
+})
+
+describe('toLocalList', () => {
+  it('サーバーの応答を画面の形に直す。完了日時は数値になる', () => {
+    const list = toLocalList({ title: '2026年の目標' }, [
+      { id: 'i1', text: '南極に行く', completedAt: '2026-08-07T00:00:00.000Z' },
+      { id: 'i2', text: 'オーロラを見る', completedAt: null },
+    ])
+
+    expect(list).toEqual({
+      title: '2026年の目標',
+      items: [
+        { id: 'i1', text: '南極に行く', completedAt: Date.parse('2026-08-07T00:00:00.000Z') },
+        { id: 'i2', text: 'オーロラを見る', completedAt: null },
+      ],
+    })
+  })
+
+  it('🔴 並べ替えない（並び順の情報源をサーバーに1本化する）', () => {
+    const list = toLocalList({ title: 'x' }, [
+      { id: 'i2', text: '2番目に入っている', completedAt: null },
+      { id: 'i1', text: '1番目に入っている', completedAt: null },
+    ])
+
+    expect(list.items.map((item) => item.id)).toEqual(['i2', 'i1'])
+  })
+})
+
+describe('toImportBody / hasAnythingToImport', () => {
+  it('本文だけを送る', () => {
+    const list = listOf('南極に行く', 'オーロラを見る')
+
+    expect(toImportBody(list)).toEqual({
+      title: DEFAULT_LIST_TITLE,
+      items: [{ text: '南極に行く' }, { text: 'オーロラを見る' }],
+    })
+  })
+
+  it('🔴 完了の状態を送らない（未ログインでは印を付けられないため）', () => {
+    const completed = expectOk(setItemCompletedAt(listOf('南極に行く'), 'i1', 1_700_000_000_000))
+
+    // 送る口を作ると #77 の制約を迂回できてしまう
+    expect(toImportBody(completed).items).toEqual([{ text: '南極に行く' }])
+  })
+
+  it('🔴 1項目も無ければ取り込まない', () => {
+    expect(hasAnythingToImport({ status: 'loaded', list: createEmptyList() })).toBe(false)
+    expect(hasAnythingToImport({ status: 'empty' })).toBe(false)
+    expect(hasAnythingToImport({ status: 'broken' })).toBe(false)
+  })
+
+  it('1項目でもあれば取り込む', () => {
+    expect(hasAnythingToImport({ status: 'loaded', list: listOf('南極に行く') })).toBe(true)
   })
 })
 


### PR DESCRIPTION
Closes #91

未ログインは localStorage、ログイン中はサーバー（`PRODUCT_SPEC.md` §2）。

## 構成

| ファイル | 役割 | テスト |
|---|---|---|
| `model.ts` | 判定と変換（純関数） | **する** |
| `useList.ts` | 読み書きの配線（通信・localStorage） | しない |
| `App.tsx` | 描画とセッションの取得 | しない |

`TECH_STACK.md` §10 の方針どおり、テストできる形を `model.ts` に寄せた。
足した純関数は `pickCurrentListId` / `toLocalList` / `toImportBody` / `hasAnythingToImport`。

## 引き継ぎ

🔴 **取り込めたときだけブラウザ側を消す。** 上限（409）で断られたときに消すと、
**書いたものが戻らない。** 残したうえで「リストを整理してから開き直すと取り込めます」と出す。

**取り込みは一度だけ走らせる。** React は開発時に効果を2回呼ぶので、
守らないと**リストが2つできる**（`useRef` で止めている）。

**1項目も無ければ呼ばない**（`hasAnythingToImport`）。呼ぶと 400 になり「失敗した」と見える。

## そのほか判断したこと

- **トップでは最後に更新したリストを開く**（`PRODUCT_SPEC.md` §4.3）。1つも無ければ作る
- **サーバーから取れないときは `failed`。空リストで塗り潰さない**
  （空を出して書かせると、取れなかっただけの中身を上書きしうる）
- **サーバーへの操作は成功したら取り直す。** 削除で後ろの並び順が詰まるなど、
  応答だけでは画面を正しく作れない。往復は増えるが**表示が DB とずれない**方を採った
- ログイン中は「このブラウザにだけ保存されています」を出さない
- `ListEditor` の変更を伝える関数を `Promise<boolean>` にした。
  **保存先がどちらかを画面は区別しない**

## 確認

- `typecheck` / `lint` / `format:check` / `test`（**173 tests / 12 files**）/ `build` が緑
- ⚠️ **ログインしての動作確認は利用者にしかできない**（本番のセッション Cookie を
  AI 側では作れない）。マージ後にデプロイして確認を依頼する

🤖 Generated with [Claude Code](https://claude.com/claude-code)