### PR TITLE
ログアウト後にリストのタイトルが残るのを直す

### DIFF
--- a/apps/web/src/client/App.tsx
+++ b/apps/web/src/client/App.tsx
@@ -122,6 +122,10 @@ export function App() {
             )}
 
             <ListEditor
+              // 🔴 **開いているリストが変われば作り直す**（#102）。
+              // 入力欄の下書きは各コンポーネントが持っているので、
+              // 作り直さないと**ログアウトしても前のタイトルが残る**
+              key={screen.key}
               list={screen.list}
               // 未ログインでは「やった」印を付けられない（PRODUCT_SPEC.md §2）。
               // 判定は model.ts の純関数。ここでは status を見比べない
@@ -236,7 +240,8 @@ function StorageNotice({
         <a href="/api/login/google" className="font-bold text-brand-deep underline">
           Googleでログイン
         </a>
-        すると、端末を変えても見れるようになります。ずっと残したい方はログインしてください
+        すると、保存したリストを見られます。端末を変えても見られるので、
+        ずっと残したい方はログインしてください
       </Notice>
     )
   }

--- a/apps/web/src/client/useList.ts
+++ b/apps/web/src/client/useList.ts
@@ -40,7 +40,15 @@ export type ListScreen =
   | { status: 'broken' }
   /** サーバーから取れなかった。**未ログインと混ぜない**（書いたものを失わせない） */
   | { status: 'failed' }
-  | { status: 'ready'; list: LocalList; source: ListSource }
+  /**
+   * 表示できる状態。
+   *
+   * `key` は**どのリストを開いているかの識別子**（ローカルなら `'local'`、
+   * サーバーならその `listId`）。画面はこれを React の `key` に使い、
+   * **別のリストに切り替わったら入力欄の下書きを作り直す。**
+   * 無いと、ログアウトしたのに前のタイトルが入力欄に残る（#102 で踏んだ）。
+   */
+  | { status: 'ready'; key: string; list: LocalList; source: ListSource }
 
 /**
  * ブラウザの保存を取り込めたか。
@@ -150,7 +158,12 @@ export function useList(session: SessionState): ListController {
       }
 
       const body = await res.json()
-      setScreen({ status: 'ready', list: toLocalList(body.list, body.items), source: 'server' })
+      setScreen({
+        status: 'ready',
+        key: body.list.id,
+        list: toLocalList(body.list, body.items),
+        source: 'server',
+      })
     } catch {
       setScreen({ status: 'failed' })
     }
@@ -207,7 +220,7 @@ export function useList(session: SessionState): ListController {
 
       if (stored === null) {
         setStorage({ status: 'unavailable' })
-        setScreen({ status: 'ready', list: createEmptyList(), source: 'local' })
+        setScreen({ status: 'ready', key: 'local', list: createEmptyList(), source: 'local' })
         return
       }
 
@@ -219,6 +232,7 @@ export function useList(session: SessionState): ListController {
 
       setScreen({
         status: 'ready',
+        key: 'local',
         list: stored.status === 'loaded' ? stored.list : createEmptyList(),
         source: 'local',
       })
@@ -238,7 +252,7 @@ export function useList(session: SessionState): ListController {
       }
 
       setRejection(null)
-      setScreen({ status: 'ready', list: result.list, source: 'local' })
+      setScreen({ status: 'ready', key: 'local', list: result.list, source: 'local' })
       if (storage.status !== 'unavailable') writeStored(result.list)
 
       return true
@@ -291,7 +305,7 @@ export function useList(session: SessionState): ListController {
 
     startOver: () => {
       // ここでは保存を消さない。最初の編集で上書きされる
-      setScreen({ status: 'ready', list: createEmptyList(), source: 'local' })
+      setScreen({ status: 'ready', key: 'local', list: createEmptyList(), source: 'local' })
     },
 
     renameList: async (title) =>


### PR DESCRIPTION
Closes #102

本番（`a5129adf`）を見て見つかった2件。

## 1. ログアウトしてもタイトルが前のまま

**入力欄の下書きは各コンポーネントが `useState` で持っている。**
保存先が切り替わっても `ListEditor` は作り直されないので、
`title` の prop が変わっても下書きが追随せず、**古い値が残っていた。**

開いているリストの識別子（ローカルなら `'local'`、サーバーなら `listId`）を
`ready` の状態に持たせ、**React の `key`** にした。
別のリストに切り替わったら下書きごと作り直される。

`useEffect` で prop を state に同期させる形にしなかったのは、
同じ問題が**タイトル以外の入力欄でも起きる**ため。`key` なら一度で全部に効く。

## 2. 未ログインの画面の案内

ログアウトすると画面が空のリストになる。**取り込みのときに localStorage を
消しているので正しい挙動**だが、消えたように見える。

案内を「**Googleでログイン**すると、保存したリストを見られます。
端末を変えても見られるので、ずっと残したい方はログインしてください」に変えた。

## 確認

`typecheck` / `lint` / `format:check` / `test`（177 tests）が緑。
⚠️ ログインを伴う経路なので、**動作確認は利用者に依頼する。**

🤖 Generated with [Claude Code](https://claude.com/claude-code)