### PR TITLE
未ログインで /lists/:listId を開けないようにする、ほか2件

### DIFF
--- a/apps/web/src/client/App.tsx
+++ b/apps/web/src/client/App.tsx
@@ -1,6 +1,6 @@
 import { SERVICE_NAME } from '@yaritai100list/shared'
 import { useCallback, useEffect, useState } from 'react'
-import { Link, Route, Switch } from 'wouter'
+import { Link, Route, Switch, useLocation } from 'wouter'
 
 import { ListPage } from './ListPage'
 import { ListsPage } from './ListsPage'
@@ -17,6 +17,7 @@ import { signOutRequestInit, toSessionState, type SessionState } from './model'
  * **`/lists/xxx` を直接開いてもこの SPA が起動する。**
  */
 export function App() {
+  const [, navigate] = useLocation()
   const [session, setSession] = useState<SessionState>({ status: 'loading' })
   const [signOutFailed, setSignOutFailed] = useState(false)
 
@@ -53,7 +54,11 @@ export function App() {
 
     // サーバー側でセッションを消したので、状態を取り直す
     await loadSession()
-  }, [loadSession])
+
+    // 🔴 **トップへ戻す**（#112）。ログインが要る画面に残ると、
+    // 直前まで見えていたものが消えたように見える
+    navigate('/')
+  }, [loadSession, navigate])
 
   return (
     <div className="min-h-dvh bg-brand-soft">

--- a/apps/web/src/client/ListPage.tsx
+++ b/apps/web/src/client/ListPage.tsx
@@ -34,6 +34,54 @@ const REJECTION_MESSAGES: Record<Rejection, string> = {
 }
 
 export function ListPage({ session, listId }: { session: SessionState; listId?: string }) {
+  // 🔴 **`/lists/:listId` は未ログインでは開かせない**（#112）。
+  // 素通しすると、URL が指すリストではなく**ブラウザに保存した内容**が出てしまい、
+  // URL と画面の中身が食い違う。
+  //
+  // `useList` を呼ぶ前に返す。呼んでしまうと localStorage を読みに行く
+  if (listId !== undefined && session.status !== 'authenticated') {
+    return <SignInRequired session={session} />
+  }
+
+  return <ListPageBody session={session} listId={listId} />
+}
+
+/**
+ * ログインが要る画面に未ログインで来たとき。
+ *
+ * **`error`（確認できない）を未ログインと同じ文言にしない。**
+ * ログイン済みの人にログインを促すことになる（`toCompletionPermission` と同じ考え方）。
+ */
+function SignInRequired({ session }: { session: SessionState }) {
+  if (session.status === 'loading') return <p className="py-8 text-slate-500">読み込み中</p>
+
+  if (session.status === 'error') {
+    return (
+      <Notice tone="warn">
+        ログイン状態を確認できないため、このリストを開けません。通信を確かめてください
+      </Notice>
+    )
+  }
+
+  return (
+    <Notice tone="info">
+      このリストを見るには
+      <a href="/api/login/google" className="font-bold text-brand-deep underline">
+        Googleでログイン
+      </a>
+      してください
+    </Notice>
+  )
+}
+
+function ListPageBody({
+  session,
+  listId,
+}: {
+  session: SessionState
+  // exactOptionalPropertyTypes が有効なので、渡す側に合わせて undefined を明示する
+  listId: string | undefined
+}) {
   const controller = useList(session, listId ?? null)
   const { screen, rejection } = controller
 

--- a/apps/web/src/client/ListsPage.tsx
+++ b/apps/web/src/client/ListsPage.tsx
@@ -181,8 +181,8 @@ export function ListsPage({ session }: { session: SessionState }) {
         <div className="mt-3 rounded bg-white px-3 py-3 text-xs text-slate-700">
           <p className="font-bold text-brand-deep">取り込めていない内容があります</p>
           <p className="mt-1">
-            このブラウザに「{pendingImport.title}」（{pendingImport.items.length}件）が
-            残っています。リストを減らしてから取り込んでください。
+            このブラウザに「{pendingImport.title}」が残っています。
+            リストを減らしてから取り込んでください。
           </p>
           <button
             type="button"


### PR DESCRIPTION
Closes #112

## 1. 未ログインで `/lists/:listId` を開けないようにする

素通しすると、**URL が指すリストではなくブラウザに保存した内容が出ていた。**
URL と画面の中身が食い違う。

`useList` を**呼ぶ前に**返している（呼ぶと localStorage を読みに行くため）。

**`error`（ログイン状態を確認できない）を未ログインと同じ文言にしない。**
ログイン済みの人にログインを促すことになる（`toCompletionPermission` と同じ考え方）。

| 状態 | 表示 |
|---|---|
| 確認中 | 読み込み中 |
| 未ログイン | このリストを見るには **Googleでログイン** してください |
| 確認できない | ログイン状態を確認できないため、このリストを開けません |

⚠️ ログインの入口は `callbackURL: "/"` 固定なので、**ログイン後に元の
`/lists/:listId` へは戻らない**（トップに出る）。戻すなら別イシューにする。

## 2. 取り込みの案内から件数を消した

## 3. ログアウトしたら `/` へ移動する

ログインが要る画面（`/lists` など）に残ると、**直前まで見えていたものが
消えたように見える。**

## 確認

`typecheck` / `lint` / `format:check` / `test`（186 tests）/ `build` が緑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)