### PR TITLE
ログアウトを「すべてのリスト」の下部へ移す

### DIFF
--- a/apps/web/src/client/App.tsx
+++ b/apps/web/src/client/App.tsx
@@ -78,12 +78,7 @@ export function App() {
           )}
         </header>
 
-        <SessionArea
-          session={session}
-          signOutFailed={signOutFailed}
-          onRetry={() => void loadSession()}
-          onSignOut={() => void signOut()}
-        />
+        <SessionArea session={session} onRetry={() => void loadSession()} />
 
         <Switch>
           {/* トップは一覧ではなく**最後に更新したリスト**（PRODUCT_SPEC.md §4.3）。
@@ -93,7 +88,13 @@ export function App() {
           </Route>
 
           <Route path="/lists">
-            <ListsPage session={session} />
+            {/* ログアウトはここに置く。日常的に押すものではないので、
+                編集画面には出さない（#114） */}
+            <ListsPage
+              session={session}
+              signOutFailed={signOutFailed}
+              onSignOut={() => void signOut()}
+            />
           </Route>
 
           <Route path="/lists/:listId">
@@ -114,17 +115,13 @@ export function App() {
   )
 }
 
-function SessionArea({
-  session,
-  signOutFailed,
-  onRetry,
-  onSignOut,
-}: {
-  session: SessionState
-  signOutFailed: boolean
-  onRetry: () => void
-  onSignOut: () => void
-}) {
+/**
+ * ログイン状態の表示。**ログアウトのボタンはここに置かない**（#114）。
+ *
+ * 日常的に押すものではないうえ、編集画面から誤って押すと
+ * リストが消えたように見える。置き場所は `/lists` の一番下。
+ */
+function SessionArea({ session, onRetry }: { session: SessionState; onRetry: () => void }) {
   return (
     <div className="mb-2 text-right text-xs text-slate-600">
       {session.status === 'error' && (
@@ -136,16 +133,7 @@ function SessionArea({
         </p>
       )}
 
-      {session.status === 'authenticated' && (
-        <p>
-          ログイン中{' '}
-          <button type="button" onClick={onSignOut} className="underline">
-            ログアウト
-          </button>
-        </p>
-      )}
-
-      {signOutFailed && <p className="text-brand-deep">ログアウトに失敗しました</p>}
+      {session.status === 'authenticated' && <p>ログイン中</p>}
     </div>
   )
 }

--- a/apps/web/src/client/ListsPage.tsx
+++ b/apps/web/src/client/ListsPage.tsx
@@ -31,7 +31,15 @@ type State = { status: 'loading' } | { status: 'failed' } | { status: 'ready'; l
 /** 直前の操作の結果。**黙って失敗させない**ために画面へ出す。 */
 type Message = { tone: 'info' | 'warn'; text: string } | null
 
-export function ListsPage({ session }: { session: SessionState }) {
+export function ListsPage({
+  session,
+  signOutFailed,
+  onSignOut,
+}: {
+  session: SessionState
+  signOutFailed: boolean
+  onSignOut: () => void
+}) {
   const [, navigate] = useLocation()
   const [state, setState] = useState<State>({ status: 'loading' })
   const [message, setMessage] = useState<Message>(null)
@@ -228,6 +236,20 @@ export function ListsPage({ session }: { session: SessionState }) {
       >
         新しいリストを作る
       </button>
+
+      {/*
+        ログアウトの置き場所（#114）。**編集画面には出さない。**
+        日常的に押すものではないうえ、誤って押すとリストが消えたように見える。
+        それでも消さないのは、アカウントを間違えたときに直せなくなるため
+        （`TECH_STACK.md` §9 の「サーバー側から失効できる」出口でもある）。
+      */}
+      <div className="mt-12 border-t border-brand/40 pt-4 text-center">
+        <button type="button" onClick={onSignOut} className="text-xs text-slate-500 underline">
+          ログアウト
+        </button>
+
+        {signOutFailed && <p className="mt-1 text-xs text-brand-deep">ログアウトに失敗しました</p>}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
Closes #114

ログアウトが**全画面の右上に常時出ていた**が、日常的に押すボタンではない。
編集画面から誤って押すと、リストが消えたように見える（#102 で報告された混乱の一因）。

- `/lists`（すべてのリスト）の**一番下**へ移した。あそこは管理の場所
- ヘッダには「ログイン中」の表示だけ残した

## 消さない理由

- **アカウントを間違えたときに直せない。** 複数の Google アカウントを持つ人が
  意図しない方でログインすると、移す手段が無くなる
- **共有端末**で他人のリストが開きっぱなしになる
- `TECH_STACK.md` §9 の「セッションはサーバー側から失効できる方式にする」に対して、
  画面に出口が無いのは噛み合わない

**アカウントを移せるようにするには、リストの書き出しと読み込みが要る。**
これは #115 にタスクとして立てた（Post-MVP、まだ着手しない）。

## 確認

`typecheck` / `lint` / `format:check` / `test`（186 tests）/ `build` が緑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)