### PR TITLE
リストの書き出し API（JSON）と形式

### DIFF
--- a/apps/web/src/index.ts
+++ b/apps/web/src/index.ts
@@ -1,5 +1,6 @@
 import * as Sentry from '@sentry/cloudflare'
 import {
+  buildExportFile,
   DEFAULT_LIST_TITLE,
   ITEMS_PER_LIST_MAX,
   LISTS_PER_USER_MAX,
@@ -313,6 +314,25 @@ const app = new Hono<AppEnv>()
       return c.json({ list: updated })
     },
   )
+
+  /**
+   * リストを1つ書き出す（#121）。**持ち出すのは自分のリストだけ**
+   * （`requireOwnedList` を通っている）。
+   *
+   * 形は `packages/shared` の `buildExportFile`。**版を持たせてある**ので、
+   * 形を変えたら上げること（読み込み側が断れる）。
+   *
+   * ⚠️ **形式は後から増える。** ブログへの転載用にマークダウンでも書き出す予定がある
+   * （#124）。そのときは**このルートの隣に足す**（`/export/markdown` など）。
+   * ここで分岐を増やして1本にまとめない。中身の作り方が違いすぎる
+   * （あちらは人が読むもので、読み込まない）。
+   */
+  .get('/api/lists/:listId/export', requireUser, requireOwnedList, async (c) => {
+    const list = c.get('list')
+    const rows = await selectItems(createDb(c.env.DB), list.id)
+
+    return c.json(buildExportFile({ title: list.title, items: rows }, new Date()))
+  })
 
   /** リストを削除する。 */
   .delete('/api/lists/:listId', requireUser, requireOwnedList, async (c) => {

--- a/apps/web/test/export-api.test.ts
+++ b/apps/web/test/export-api.test.ts
@@ -1,0 +1,178 @@
+import { exports } from 'cloudflare:workers'
+import {
+  EXPORT_VERSION,
+  buildExportFile,
+  exportFileName,
+  exportFileSchema,
+} from '@yaritai100list/shared'
+import { describe, expect, it } from 'vitest'
+
+import { items, lists } from '../src/db/schema'
+import { signIn, testBaseUrl, testDb } from './helpers'
+
+/**
+ * リストの書き出しのテスト（#121）。
+ *
+ * 組み立ては `packages/shared` の純関数なので、そちらは直接テストする。
+ * API 側は**認可**（他人のリストを持ち出せない）を中心に見る。
+ */
+
+const request = (path: string, init?: RequestInit) =>
+  exports.default.fetch(new Request(`${testBaseUrl()}${path}`, init))
+
+interface ExportBody {
+  version: number
+  exportedAt: string
+  list: { title: string; items: { text: string; completedAt: string | null }[] }
+}
+
+async function twoUsers() {
+  const me = await signIn('me@example.com')
+  const other = await signIn('other@example.com')
+
+  await testDb()
+    .insert(lists)
+    .values([
+      { id: 'my-list', userId: me.userId, title: '自分のリスト' },
+      { id: 'other-list', userId: other.userId, title: '他人のリスト' },
+    ])
+
+  return { me, other }
+}
+
+describe('buildExportFile', () => {
+  it('版と書き出した時刻を持つ', () => {
+    const file = buildExportFile({ title: 'x', items: [] }, new Date(1_700_000_000_000))
+
+    expect(file.version).toBe(EXPORT_VERSION)
+    expect(file.exportedAt).toBe(new Date(1_700_000_000_000).toISOString())
+  })
+
+  it('🔴 完了日時を含める（落とすと持ち出す意味が無くなる）', () => {
+    const file = buildExportFile(
+      {
+        title: 'x',
+        items: [
+          { text: '南極に行く', completedAt: new Date(1_700_000_000_000) },
+          { text: 'オーロラを見る', completedAt: null },
+        ],
+      },
+      new Date(0),
+    )
+
+    expect(file.list.items).toEqual([
+      { text: '南極に行く', completedAt: new Date(1_700_000_000_000).toISOString() },
+      { text: 'オーロラを見る', completedAt: null },
+    ])
+  })
+
+  it('渡された順のまま。並べ替えない', () => {
+    const file = buildExportFile(
+      {
+        title: 'x',
+        items: [
+          { text: 'b', completedAt: null },
+          { text: 'a', completedAt: null },
+        ],
+      },
+      new Date(0),
+    )
+
+    expect(file.list.items.map((item) => item.text)).toEqual(['b', 'a'])
+  })
+
+  it('🔴 書き出したものが、読み込み側のスキーマを通る', () => {
+    // 通らないと、自分で書き出したファイルを自分で読めない（#122）。
+    // 版・日時の形式・文字数の上限まで含めて、ここで往復を固定する
+    const file = buildExportFile(
+      { title: '2026年の目標', items: [{ text: '南極に行く', completedAt: new Date(0) }] },
+      new Date(1_700_000_000_000),
+    )
+
+    expect(exportFileSchema.safeParse(file).success).toBe(true)
+  })
+})
+
+describe('exportFileName', () => {
+  it('リスト名と日付が入る', () => {
+    expect(exportFileName('2026年の目標', new Date('2026-08-07T12:00:00.000Z'))).toBe(
+      '2026年の目標-2026-08-07.json',
+    )
+  })
+
+  it('ファイル名に使えない文字を落とす', () => {
+    expect(exportFileName('a/b:c', new Date('2026-08-07T00:00:00.000Z'))).toBe(
+      'abc-2026-08-07.json',
+    )
+  })
+
+  it('落とした結果が空なら既定の名前になる', () => {
+    expect(exportFileName('///', new Date('2026-08-07T00:00:00.000Z'))).toBe('list-2026-08-07.json')
+  })
+})
+
+describe('GET /api/lists/:listId/export', () => {
+  it('🔴 未ログインでは書き出せない', async () => {
+    await twoUsers()
+
+    const res = await request('/api/lists/my-list/export')
+
+    expect(res.status).toBe(401)
+  })
+
+  it('🔴 他人のリストは書き出せない。存在しない ID と応答が一致する', async () => {
+    const { me } = await twoUsers()
+
+    const others = await request('/api/lists/other-list/export', { headers: me.headers })
+    const missing = await request('/api/lists/no-such/export', { headers: me.headers })
+
+    expect(others.status).toBe(404)
+    expect(await others.text()).toBe(await missing.text())
+  })
+
+  it('項目が並び順で出る', async () => {
+    const { me } = await twoUsers()
+
+    await testDb()
+      .insert(items)
+      .values([
+        { id: 'i2', listId: 'my-list', text: '2つ目', position: 1 },
+        { id: 'i1', listId: 'my-list', text: '1つ目', position: 0 },
+      ])
+
+    const res = await request('/api/lists/my-list/export', { headers: me.headers })
+    const body = await res.json<ExportBody>()
+
+    expect(body.list.title).toBe('自分のリスト')
+    expect(body.list.items.map((item) => item.text)).toEqual(['1つ目', '2つ目'])
+  })
+
+  it('完了日時が入る', async () => {
+    const { me } = await twoUsers()
+
+    await testDb()
+      .insert(items)
+      .values({
+        id: 'i1',
+        listId: 'my-list',
+        text: '南極に行く',
+        position: 0,
+        completedAt: new Date(1_700_000_000_000),
+      })
+
+    const res = await request('/api/lists/my-list/export', { headers: me.headers })
+    const body = await res.json<ExportBody>()
+
+    expect(body.list.items[0]?.completedAt).toBe(new Date(1_700_000_000_000).toISOString())
+  })
+
+  it('項目が0件でも壊れない', async () => {
+    const { me } = await twoUsers()
+
+    const res = await request('/api/lists/my-list/export', { headers: me.headers })
+    const body = await res.json<ExportBody>()
+
+    expect(res.status).toBe(200)
+    expect(body.list.items).toEqual([])
+  })
+})

--- a/packages/shared/src/export.ts
+++ b/packages/shared/src/export.ts
@@ -1,0 +1,106 @@
+import { z } from 'zod'
+
+import { ITEMS_PER_LIST_MAX } from './limits'
+import { itemTextSchema, listTitleSchema } from './validation'
+
+/**
+ * リストを持ち出すときの形式（#115）。
+ *
+ * 目的は**リストの引き継ぎ**。別のアカウントへ移す、取っておく、の2つ。
+ * **1ファイル = 1リスト。** アカウント丸ごとではない。
+ *
+ * 単位を1リストにしているのは:
+ *
+ * - **読み込みが常に「1つ作る」だけ**になり、上限の扱いが既存の取り込みと同じになる
+ *   （「一部だけ入って残りが入らない」という状態が起きない）
+ * - **マークダウンでの書き出し（#124）と単位が揃う**
+ *
+ * ⚠️ **形式はこれだけではない。** ブログへの転載用にマークダウンでも書き出す予定があり、
+ * あちらは**人が読むためのもので読み込まない**。この JSON は「読み込める形式」の方。
+ */
+
+/**
+ * 形式の版。**読めない版は断る**（#122）。
+ *
+ * 形を変えるときは上げる。上げたら、**古い版を読む経路を残すか、
+ * 読めないと伝えるか**を決めること。黙って壊れた読み方をしない。
+ */
+export const EXPORT_VERSION = 1
+
+/**
+ * 書き出す項目。
+ *
+ * 🔴 **完了日時を含める。** `POST /api/lists/import`（localStorage からの引き継ぎ）が
+ * 完了日時を受け取らないのとは**逆の判断**。あちらは未ログインで印を付けられない
+ * という制約（#77）を守るためだが、こちらは**「いつ叶えたか」を落とすと
+ * 持ち出す意味が無くなる**（`PRODUCT_SPEC.md` §3 が完了を真偽値にしなかった理由）。
+ *
+ * そのぶん**読み込みの経路を分ける**。#89 の「完了日時はサーバーが決める」の
+ * 例外になるので、既存の取り込みに混ぜない。
+ */
+export const exportedItemSchema = z
+  .object({
+    text: itemTextSchema,
+    /** 完了日時（ISO 8601）。未完了なら `null` */
+    completedAt: z.iso.datetime().nullable(),
+  })
+  .strict()
+
+export const exportedListSchema = z
+  .object({
+    title: listTitleSchema,
+    items: z.array(exportedItemSchema).max(ITEMS_PER_LIST_MAX),
+  })
+  .strict()
+
+export const exportFileSchema = z
+  .object({
+    version: z.literal(EXPORT_VERSION),
+    /** 書き出した時刻。中身の判断には使わない（人が見分けるための情報） */
+    exportedAt: z.iso.datetime(),
+    list: exportedListSchema,
+  })
+  .strict()
+
+export type ExportFile = z.infer<typeof exportFileSchema>
+
+/**
+ * 書き出す内容を組み立てる。**純関数**（`TECH_STACK.md` §10）。
+ *
+ * 項目は**渡された順のまま**。並べ替えない（並び順の情報源は呼び出し側の1箇所）。
+ */
+export function buildExportFile(
+  list: { title: string; items: { text: string; completedAt: Date | null }[] },
+  exportedAt: Date,
+): ExportFile {
+  return {
+    version: EXPORT_VERSION,
+    exportedAt: exportedAt.toISOString(),
+    list: {
+      title: list.title,
+      items: list.items.map((item) => ({
+        text: item.text,
+        completedAt: item.completedAt === null ? null : item.completedAt.toISOString(),
+      })),
+    },
+  }
+}
+
+/**
+ * 書き出すファイルの名前。
+ *
+ * **日付を入れる。** 同じリストを何度も書き出したときに上書きされず、
+ * どれが新しいか分かる。
+ *
+ * ファイル名に使えない文字（`/` や `\`、制御文字など）はリスト名に入りうるので落とす。
+ * 落とした結果が空になることもある（記号だけのタイトル）ので、そのときは既定の名前にする。
+ */
+export function exportFileName(title: string, exportedAt: Date): string {
+  const date = exportedAt.toISOString().slice(0, 10)
+
+  // 経路の区切りと、OS がファイル名に使えない文字だけを落とす。
+  // 落としすぎると何のリストか分からなくなるので、日本語や記号は残す
+  const safe = title.replace(/[/\\:*?"<>|]/g, '').trim()
+
+  return `${safe === '' ? 'list' : safe}-${date}.json`
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -38,5 +38,6 @@ export const DEFAULT_LIST_TITLE = '人生でやりたいことリスト'
  */
 export const NEW_LIST_TITLE = '新しいやりたいことリスト'
 
+export * from './export'
 export * from './limits'
 export * from './validation'


### PR DESCRIPTION
Closes #121

`GET /api/lists/:listId/export`。**1ファイル = 1リスト。**
目的は**リストの引き継ぎ**で、アカウント丸ごとではない（#115 のコメント）。

```json
{
  "version": 1,
  "exportedAt": "2026-08-07T12:00:00.000Z",
  "list": {
    "title": "人生でやりたいことリスト",
    "items": [
      { "text": "南極に行く", "completedAt": null },
      { "text": "オーロラを見る", "completedAt": "2026-05-01T00:00:00.000Z" }
    ]
  }
}
```

## 判断したこと

**形式は `packages/shared` に置いた**（`src/export.ts`）。読み込み側（#122）と
同じ定義を使うため。組み立ては純関数なのでテストできる。

**版（`version`）を持たせた。** 形を変えたら上げる。
上げたら「古い版を読む経路を残すか、読めないと伝えるか」を決める、とコメントに書いた。
**黙って壊れた読み方をしない。**

🔴 **完了日時を含める。** `POST /api/lists/import`（localStorage からの引き継ぎ）が
完了日時を受け取らないのとは**逆の判断**。あちらは未ログインで印を付けられない
という制約（#77）を守るためだが、**こちらは「いつ叶えたか」を落とすと持ち出す意味が無くなる**
（`PRODUCT_SPEC.md` §3 が完了を真偽値にしなかった理由がそのまま効く）。
そのぶん**読み込みの経路を分ける**（#122）。

⚠️ **形式は後から増える。** ブログへの転載用のマークダウン（#124）は
**このルートの隣に足す**（`/export/markdown` など）。ここで分岐を増やして1本にまとめない。
中身の作り方が違いすぎる（あちらは人が読むもので、読み込まない）。

## テスト（12件）

- **他人のリストは書き出せない。** 存在しない ID と応答が一致する（`security-test`）
- 未ログインでは取れない
- 項目が並び順で出る / 完了日時が入る / 0件でも壊れない
- 🔴 **書き出したものが読み込み側のスキーマを通る。**
  通らないと、自分で書き出したファイルを自分で読めない

全体で **198 tests / 14 files が緑**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)