### PR TITLE
リストの読み込み API（JSON）

### DIFF
--- a/apps/web/src/index.ts
+++ b/apps/web/src/index.ts
@@ -2,6 +2,9 @@ import * as Sentry from '@sentry/cloudflare'
 import {
   buildExportFile,
   DEFAULT_LIST_TITLE,
+  EXPORT_VERSION,
+  exportFileSchema,
+  hasFutureCompletedAt,
   ITEMS_PER_LIST_MAX,
   LISTS_PER_USER_MAX,
   itemTextSchema,
@@ -281,6 +284,87 @@ const app = new Hono<AppEnv>()
       return c.json({ list, items: await selectItems(db, listId) }, 201)
     },
   )
+
+  /**
+   * 書き出したファイルを読み込む（#122）。**新しいリストとして作る。**
+   *
+   * 🔴 **`POST /api/lists/import`（localStorage からの引き継ぎ）とは分けてある。**
+   * あちらは**完了日時を受け取らない**（未ログインでは印を付けられないという
+   * #77 の制約を、受け取る口を作らないことで守っている）。
+   * こちらは持ち出しの復元なので完了日時を受け取る。**混ぜると制約が崩れる。**
+   *
+   * 版が違えば断る。**黙って読める部分だけ読む、ということをしない。**
+   */
+  .post('/api/lists/restore', requireUser, rateLimitCreates, async (c) => {
+    const db = createDb(c.env.DB)
+    const userId = c.get('userId')
+
+    // zValidator を通していないのは、**版だけを先に見て理由を返したい**ため。
+    // スキーマ全体で弾くと「形が違う」としか言えず、古いファイルだと分からない
+    const body: unknown = await c.req.json().catch(() => null)
+
+    const version =
+      typeof body === 'object' && body !== null && 'version' in body ? body.version : undefined
+
+    if (version !== EXPORT_VERSION) {
+      return c.json({ error: 'Unsupported Export Version' } as const, 400)
+    }
+
+    const parsed = exportFileSchema.safeParse(body)
+    if (!parsed.success) {
+      return c.json({ error: 'Bad Request' } as const, 400)
+    }
+
+    // 端末の時計もファイルも信用しない。最低限ここだけは見る
+    if (hasFutureCompletedAt(parsed.data, new Date())) {
+      return c.json({ error: 'Future Completion Date' } as const, 400)
+    }
+
+    const listId = newId()
+    const incoming = parsed.data.list
+
+    // 上限の判定と挿入を1文で（POST /api/lists と同じ理由）
+    const inserted = await db.all<{ id: string }>(sql`
+      insert into ${lists} (id, user_id, title)
+      select ${listId}, ${userId}, ${incoming.title}
+      where (select count(*) from ${lists} where ${lists.userId} = ${userId}) < ${LISTS_PER_USER_MAX}
+      returning id
+    `)
+
+    if (inserted.length === 0) {
+      return c.json({ error: 'List Limit Reached' } as const, 409)
+    }
+
+    const rows = incoming.items.map((item, position) => ({
+      id: newId(),
+      listId,
+      text: item.text,
+      position,
+      completedAt: item.completedAt === null ? null : new Date(item.completedAt),
+    }))
+
+    // 項目が0件のリストも書き出せるので、ここは空になりうる。
+    // batch は空配列を受け付けないため、入れるものがあるときだけ呼ぶ
+    if (rows.length > 0) {
+      const rest = []
+      for (let i = INSERT_CHUNK; i < rows.length; i += INSERT_CHUNK) {
+        rest.push(db.insert(items).values(rows.slice(i, i + INSERT_CHUNK)))
+      }
+
+      try {
+        await db.batch([db.insert(items).values(rows.slice(0, INSERT_CHUNK)), ...rest])
+      } catch (error) {
+        // 項目の入っていない中途半端なリストを残さない
+        await db.delete(lists).where(eq(lists.id, listId))
+        throw error
+      }
+    }
+
+    const [list] = await db.select().from(lists).where(eq(lists.id, listId))
+    if (!list) throw new Error('読み込んだリストを読み戻せなかった')
+
+    return c.json({ list, items: await selectItems(db, listId) }, 201)
+  })
 
   /**
    * リスト1件と、その項目。**`requireOwnedList` が認可を通した行だけを使う。**

--- a/apps/web/test/restore-api.test.ts
+++ b/apps/web/test/restore-api.test.ts
@@ -1,0 +1,263 @@
+import { exports } from 'cloudflare:workers'
+import {
+  EXPORT_VERSION,
+  ITEM_TEXT_MAX_LENGTH,
+  ITEMS_PER_LIST_MAX,
+  LISTS_PER_USER_MAX,
+  hasFutureCompletedAt,
+} from '@yaritai100list/shared'
+import { asc, eq } from 'drizzle-orm'
+import { describe, expect, it } from 'vitest'
+
+import { items, lists } from '../src/db/schema'
+import { signIn, testBaseUrl, testDb } from './helpers'
+
+/**
+ * 書き出したファイルの読み込みのテスト（#122）。
+ *
+ * **`POST /api/lists/import`（localStorage からの引き継ぎ）とは別の経路。**
+ * あちらが完了日時を受け取らないこと（#77）を壊していないかも、ここで見る。
+ */
+
+const request = (path: string, init?: RequestInit) =>
+  exports.default.fetch(new Request(`${testBaseUrl()}${path}`, init))
+
+/** 書き出したファイルの形。既定は最小限の中身。 */
+function exportFile(overrides: Record<string, unknown> = {}) {
+  return {
+    version: EXPORT_VERSION,
+    exportedAt: '2026-08-07T12:00:00.000Z',
+    list: { title: '2026年の目標', items: [{ text: '南極に行く', completedAt: null }] },
+    ...overrides,
+  }
+}
+
+function restore(headers: Headers, body: unknown) {
+  return request('/api/lists/restore', {
+    method: 'POST',
+    headers: { ...Object.fromEntries(headers), 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+async function itemsOf(listId: string) {
+  return testDb().select().from(items).where(eq(items.listId, listId)).orderBy(asc(items.position))
+}
+
+describe('hasFutureCompletedAt', () => {
+  const now = new Date('2026-08-07T12:00:00.000Z')
+
+  it('🔴 未来の完了日時を見つける', () => {
+    const file = {
+      version: EXPORT_VERSION as typeof EXPORT_VERSION,
+      exportedAt: now.toISOString(),
+      list: { title: 'x', items: [{ text: 'a', completedAt: '2099-01-01T00:00:00.000Z' }] },
+    }
+
+    expect(hasFutureCompletedAt(file, now)).toBe(true)
+  })
+
+  it('過去は通す（いつ叶えたかは持ち主のもの）', () => {
+    const file = {
+      version: EXPORT_VERSION as typeof EXPORT_VERSION,
+      exportedAt: now.toISOString(),
+      list: {
+        title: 'x',
+        items: [
+          { text: 'a', completedAt: '1999-01-01T00:00:00.000Z' },
+          { text: 'b', completedAt: null },
+        ],
+      },
+    }
+
+    expect(hasFutureCompletedAt(file, now)).toBe(false)
+  })
+})
+
+describe('POST /api/lists/restore', () => {
+  it('🔴 未ログインでは読み込めない', async () => {
+    const res = await restore(new Headers(), exportFile())
+
+    expect(res.status).toBe(401)
+    expect(await testDb().select().from(lists)).toEqual([])
+  })
+
+  it('新しいリストとして作られ、完了日時が復元される', async () => {
+    const me = await signIn('restorer@example.com')
+
+    const res = await restore(
+      me.headers,
+      exportFile({
+        list: {
+          title: '2026年の目標',
+          items: [
+            { text: '南極に行く', completedAt: '2026-05-01T00:00:00.000Z' },
+            { text: 'オーロラを見る', completedAt: null },
+          ],
+        },
+      }),
+    )
+
+    expect(res.status).toBe(201)
+
+    const body = await res.json<{ list: { id: string; title: string } }>()
+    expect(body.list.title).toBe('2026年の目標')
+
+    const rows = await itemsOf(body.list.id)
+    expect(rows.map((row) => row.text)).toEqual(['南極に行く', 'オーロラを見る'])
+    expect(rows[0]?.completedAt?.toISOString()).toBe('2026-05-01T00:00:00.000Z')
+    expect(rows[1]?.completedAt).toBeNull()
+  })
+
+  it('項目が0件のファイルも読み込める', async () => {
+    // 書き出せる以上、読み込めないと往復が壊れる
+    const me = await signIn('empty@example.com')
+
+    const res = await restore(me.headers, exportFile({ list: { title: '空', items: [] } }))
+
+    expect(res.status).toBe(201)
+    expect(await testDb().select().from(lists)).toHaveLength(1)
+  })
+
+  it('100件ちょうどを読み込める（D1 のバインド変数の上限を越えない）', async () => {
+    const me = await signIn('full@example.com')
+
+    const res = await restore(
+      me.headers,
+      exportFile({
+        list: {
+          title: 'いっぱい',
+          items: Array.from({ length: ITEMS_PER_LIST_MAX }, (_, i) => ({
+            text: `やりたい${String(i)}`,
+            completedAt: null,
+          })),
+        },
+      }),
+    )
+
+    expect(res.status).toBe(201)
+
+    const [row] = await testDb().select().from(lists)
+    expect(await itemsOf(row?.id ?? '')).toHaveLength(ITEMS_PER_LIST_MAX)
+  })
+
+  describe('断るもの', () => {
+    it('🔴 読めない版は理由が分かる形で断る', async () => {
+      const me = await signIn('oldversion@example.com')
+
+      const res = await restore(me.headers, exportFile({ version: 999 }))
+
+      expect(res.status).toBe(400)
+      expect(await res.json()).toEqual({ error: 'Unsupported Export Version' })
+      expect(await testDb().select().from(lists)).toEqual([])
+    })
+
+    it('🔴 未来の完了日時は断る', async () => {
+      const me = await signIn('future@example.com')
+
+      const res = await restore(
+        me.headers,
+        exportFile({
+          list: { title: 'x', items: [{ text: 'a', completedAt: '2099-01-01T00:00:00.000Z' }] },
+        }),
+      )
+
+      expect(res.status).toBe(400)
+      expect(await res.json()).toEqual({ error: 'Future Completion Date' })
+      expect(await testDb().select().from(lists)).toEqual([])
+    })
+
+    it('上限を超える本文は断る', async () => {
+      const me = await signIn('long@example.com')
+
+      const res = await restore(
+        me.headers,
+        exportFile({
+          list: {
+            title: 'x',
+            items: [{ text: 'あ'.repeat(ITEM_TEXT_MAX_LENGTH + 1), completedAt: null }],
+          },
+        }),
+      )
+
+      expect(res.status).toBe(400)
+      expect(await testDb().select().from(lists)).toEqual([])
+    })
+
+    it('🔴 知らないキーは断る', async () => {
+      const me = await signIn('extra@example.com')
+
+      const res = await restore(me.headers, exportFile({ userId: 'someone-else' }))
+
+      expect(res.status).toBe(400)
+      expect(await testDb().select().from(lists)).toEqual([])
+    })
+
+    it('JSON でない本文でも落ちない', async () => {
+      const me = await signIn('broken@example.com')
+
+      const res = await request('/api/lists/restore', {
+        method: 'POST',
+        headers: { ...Object.fromEntries(me.headers), 'content-type': 'application/json' },
+        body: '{壊れている',
+      })
+
+      expect(res.status).toBe(400)
+    })
+  })
+
+  describe('上限', () => {
+    it('🔴 上限に達していたら読み込まない', async () => {
+      const me = await signIn('limit@example.com')
+      const db = testDb()
+
+      await db.insert(lists).values(
+        Array.from({ length: LISTS_PER_USER_MAX }, (_, i) => ({
+          id: `list-${String(i)}`,
+          userId: me.userId,
+          title: 'x',
+        })),
+      )
+
+      const res = await restore(me.headers, exportFile())
+
+      expect(res.status).toBe(409)
+      expect(await res.json()).toEqual({ error: 'List Limit Reached' })
+      expect(await db.select().from(lists)).toHaveLength(LISTS_PER_USER_MAX)
+      expect(await db.select().from(items)).toEqual([])
+    })
+
+    it('🔴 既存のリストが書き換わらない', async () => {
+      const me = await signIn('existing@example.com')
+      const db = testDb()
+
+      await db.insert(lists).values({ id: 'existing', userId: me.userId, title: '既存' })
+      await db
+        .insert(items)
+        .values({ id: 'kept', listId: 'existing', text: '既存の項目', position: 0 })
+
+      await restore(me.headers, exportFile())
+
+      expect((await itemsOf('existing')).map((row) => row.text)).toEqual(['既存の項目'])
+      expect(await db.select().from(lists)).toHaveLength(2)
+    })
+  })
+
+  describe('localStorage からの取り込みとの境界', () => {
+    it('🔴 取り込みの経路は完了日時を受け取らないまま', async () => {
+      // ここが通るようになると、未ログインでは印を付けられない（#77）が
+      // 要求の組み立てだけで迂回できる
+      const me = await signIn('boundary@example.com')
+
+      const res = await request('/api/lists/import', {
+        method: 'POST',
+        headers: { ...Object.fromEntries(me.headers), 'content-type': 'application/json' },
+        body: JSON.stringify({
+          items: [{ text: 'x', completedAt: '2026-05-01T00:00:00.000Z' }],
+        }),
+      })
+
+      expect(res.status).toBe(400)
+    })
+  })
+})

--- a/packages/shared/src/export.ts
+++ b/packages/shared/src/export.ts
@@ -87,6 +87,21 @@ export function buildExportFile(
 }
 
 /**
+ * 完了日時に**未来のものが混ざっていないか**。
+ *
+ * 🔴 読み込みは「完了日時はサーバーが決める」（#89）の例外なので、
+ * **最低限ここだけは見る。** ファイルは手で編集できるし、書き出した端末の時計が
+ * 狂っていることもある。未来の日時が入ると「まだ来ていない日に叶えた」ことになる。
+ *
+ * 過去は見ない。**いつ叶えたかは持ち主のもの**で、こちらが妥当性を決める話ではない。
+ */
+export function hasFutureCompletedAt(file: ExportFile, now: Date): boolean {
+  return file.list.items.some(
+    (item) => item.completedAt !== null && Date.parse(item.completedAt) > now.getTime(),
+  )
+}
+
+/**
  * 書き出すファイルの名前。
  *
  * **日付を入れる。** 同じリストを何度も書き出したときに上書きされず、


### PR DESCRIPTION
Closes #122

`POST /api/lists/restore`。書き出したファイルを**新しいリストとして**読み込む。

## 🔴 既存の取り込みと経路を分けてある

`POST /api/lists/import`（localStorage からの引き継ぎ）は**完了日時を受け取らない。**
受け取る口を作らないことで「未ログインでは印を付けられない」（#77）を守っている。

こちらは**持ち出しの復元なので受け取る。混ぜると制約が崩れる。**
境界が保たれていること（`/import` に `completedAt` を送ると 400）をテストで固定した。

## 断るもの

| 断る理由 | 応答 |
|---|---|
| 読めない版 | 400 `Unsupported Export Version` |
| **未来の完了日時** | 400 `Future Completion Date` |
| 形が違う / 知らないキー / 上限超過 | 400 `Bad Request` |
| リストの数が上限 | 409 `List Limit Reached` |

**版だけを先に見ている。** そのために `zValidator` を通していない。
スキーマ全体で弾くと「形が違う」としか言えず、**古いファイルなのかゴミなのか分からない。**

🔴 **未来の完了日時を断る。** ファイルは手で編集できるし、書き出した端末の時計が
狂っていることもある。「まだ来ていない日に叶えた」を作らせない。
**過去は見ない**（いつ叶えたかは持ち主のもので、こちらが妥当性を決める話ではない）。

## テスト（14件）

- 未ログインでは読み込めない / 既存のリストが書き換わらない（`security-test`）
- 上限に達していたら 409 で、リストも項目も増えない
- **項目が0件のファイルも読み込める**（書き出せる以上、読めないと往復が壊れる）
- **100件ちょうどが通る**（D1 のバインド変数の上限。#89 で踏んだ）
- 壊れた JSON でも落ちない
- 🔴 **`/import` が完了日時を受け取らないままであること**

全体で **212 tests / 15 files が緑**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)