### PR TITLE
マークダウンで書き出す（ブログなどへの転載用）

### DIFF
--- a/apps/web/src/client/ListsPage.tsx
+++ b/apps/web/src/client/ListsPage.tsx
@@ -1,4 +1,10 @@
-import { exportFileName, LISTS_PER_USER_MAX, NEW_LIST_TITLE } from '@yaritai100list/shared'
+import {
+  buildMarkdown,
+  exportFileName,
+  exportFileSchema,
+  LISTS_PER_USER_MAX,
+  NEW_LIST_TITLE,
+} from '@yaritai100list/shared'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { Link, useLocation } from 'wouter'
 
@@ -121,12 +127,16 @@ export function ListsPage({
   }
 
   /**
-   * リストをファイルに書き出す（#121）。
+   * リストをファイルに書き出す（#121 / #124）。
    *
    * 取得は API、保存はブラウザの仕事なので**ここで DOM を触る。**
-   * ファイル名の組み立ては `packages/shared` の純関数（テストしてある）。
+   * 中身とファイル名の組み立ては `packages/shared` の純関数（テストしてある）。
+   *
+   * 🔴 **マークダウンはサーバーで作らない。** 達成日を**画面と同じ時間帯**で
+   * 出したいが、サーバーは閲覧者の時間帯を知らない。UTC のまま日付にすると1日ずれる。
+   * JSON（時刻をそのまま持つ）を受け取って、**ここで整形する。**
    */
-  const exportList = async (list: RemoteList) => {
+  const exportList = async (list: RemoteList, format: 'json' | 'md') => {
     setMessage(null)
 
     const res = await api.api.lists[':listId'].export.$get({ param: { listId: list.id } })
@@ -136,11 +146,25 @@ export function ListsPage({
       return
     }
 
-    const url = URL.createObjectURL(new Blob([await res.text()], { type: 'application/json' }))
+    const body: unknown = await res.json()
+    const parsed = exportFileSchema.safeParse(body)
+
+    if (!parsed.success) {
+      setMessage({ tone: 'warn', text: '書き出せませんでした（応答の形が想定と違います）' })
+      return
+    }
+
+    const content =
+      format === 'json'
+        ? JSON.stringify(parsed.data, null, 2)
+        : buildMarkdown(parsed.data, (iso) => new Date(iso).toLocaleDateString('ja-JP'))
+
+    const type = format === 'json' ? 'application/json' : 'text/markdown'
+    const url = URL.createObjectURL(new Blob([content], { type }))
     const anchor = document.createElement('a')
 
     anchor.href = url
-    anchor.download = exportFileName(list.title, new Date())
+    anchor.download = exportFileName(list.title, new Date(), format)
     anchor.click()
 
     // 解放しないとページを閉じるまでメモリに残る
@@ -336,7 +360,7 @@ function ListRow({
 }: {
   number: string
   list: RemoteList
-  onExport: (list: RemoteList) => Promise<void>
+  onExport: (list: RemoteList, format: 'json' | 'md') => Promise<void>
   onDelete: (listId: string) => Promise<void>
 }) {
   const [confirming, setConfirming] = useState(false)
@@ -354,14 +378,28 @@ function ListRow({
           <span className="min-w-0 flex-1 truncate text-slate-900">{list.title}</span>
         </Link>
 
+        {/*
+          書き出しは2つの形式（#124）。**JSON は読み込める、MD は人が読むもの。**
+          用途が違うので、選ばせずにどちらか一方にはしない
+        */}
         <button
           type="button"
-          aria-label={`${list.title} を書き出す`}
-          title="書き出す"
-          onClick={() => void onExport(list)}
-          className="shrink-0 px-1 text-sm text-slate-400"
+          aria-label={`${list.title} を JSON で書き出す（読み込める形式）`}
+          title="読み込める形式で書き出す"
+          onClick={() => void onExport(list, 'json')}
+          className="shrink-0 px-1 text-[10px] text-slate-400"
         >
-          ⤓
+          JSON
+        </button>
+
+        <button
+          type="button"
+          aria-label={`${list.title} をマークダウンで書き出す（転載用）`}
+          title="ブログなどへの転載用"
+          onClick={() => void onExport(list, 'md')}
+          className="shrink-0 px-1 text-[10px] text-slate-400"
+        >
+          MD
         </button>
 
         <button

--- a/apps/web/test/export-api.test.ts
+++ b/apps/web/test/export-api.test.ts
@@ -1,7 +1,9 @@
 import { exports } from 'cloudflare:workers'
 import {
   EXPORT_VERSION,
+  ITEMS_PER_LIST_MAX,
   buildExportFile,
+  buildMarkdown,
   exportFileName,
   exportFileSchema,
 } from '@yaritai100list/shared'
@@ -93,6 +95,75 @@ describe('buildExportFile', () => {
   })
 })
 
+describe('buildMarkdown', () => {
+  /** 時間帯に左右されないよう、テストでは日付部分をそのまま使う */
+  const formatDate = (iso: string) => iso.slice(0, 10)
+
+  const file = (items: { text: string; completedAt: string | null }[]) =>
+    buildExportFile(
+      {
+        title: '2026年の目標',
+        items: items.map((item) => ({
+          text: item.text,
+          completedAt: item.completedAt === null ? null : new Date(item.completedAt),
+        })),
+      },
+      new Date(0),
+    )
+
+  it('見出し・埋まり具合・チェックリストで出る', () => {
+    const markdown = buildMarkdown(
+      file([
+        { text: '南極に行く', completedAt: '2026-05-01T00:00:00.000Z' },
+        { text: 'オーロラを見る', completedAt: null },
+      ]),
+      formatDate,
+    )
+
+    expect(markdown).toBe(
+      [
+        '## 2026年の目標',
+        '',
+        `2 / ${String(ITEMS_PER_LIST_MAX)}`,
+        '',
+        '- [x] 南極に行く（2026-05-01 達成）',
+        '- [ ] オーロラを見る',
+        '',
+      ].join('\n'),
+    )
+  })
+
+  it('🔴 見出しは `##`（転載先の記事にはすでに `#` がある）', () => {
+    expect(buildMarkdown(file([]), formatDate).startsWith('## ')).toBe(true)
+  })
+
+  it('🔴 番号を振らない', () => {
+    const markdown = buildMarkdown(file([{ text: '南極に行く', completedAt: null }]), formatDate)
+
+    expect(markdown).not.toContain('001')
+    expect(markdown).not.toMatch(/^1\./m)
+  })
+
+  it('🔴 未入力の枠を出さない（100行の空行は転載に向かない）', () => {
+    const markdown = buildMarkdown(file([{ text: '南極に行く', completedAt: null }]), formatDate)
+
+    expect(markdown.split('\n').filter((line) => line.startsWith('- '))).toHaveLength(1)
+  })
+
+  it('末尾が改行で終わる（貼った先で次の行とくっつかない）', () => {
+    expect(buildMarkdown(file([]), formatDate).endsWith('\n')).toBe(true)
+  })
+
+  it('日付の整形を外から受け取る（時間帯を画面と揃えるため）', () => {
+    const markdown = buildMarkdown(
+      file([{ text: 'x', completedAt: '2026-05-01T15:00:00.000Z' }]),
+      () => '2026年5月2日',
+    )
+
+    expect(markdown).toContain('（2026年5月2日 達成）')
+  })
+})
+
 describe('exportFileName', () => {
   it('リスト名と日付が入る', () => {
     expect(exportFileName('2026年の目標', new Date('2026-08-07T12:00:00.000Z'))).toBe(
@@ -108,6 +179,12 @@ describe('exportFileName', () => {
 
   it('落とした結果が空なら既定の名前になる', () => {
     expect(exportFileName('///', new Date('2026-08-07T00:00:00.000Z'))).toBe('list-2026-08-07.json')
+  })
+
+  it('マークダウンなら拡張子が変わる', () => {
+    expect(exportFileName('目標', new Date('2026-08-07T00:00:00.000Z'), 'md')).toBe(
+      '目標-2026-08-07.md',
+    )
   })
 })
 

--- a/packages/shared/src/export.ts
+++ b/packages/shared/src/export.ts
@@ -110,12 +110,60 @@ export function hasFutureCompletedAt(file: ExportFile, now: Date): boolean {
  * ファイル名に使えない文字（`/` や `\`、制御文字など）はリスト名に入りうるので落とす。
  * 落とした結果が空になることもある（記号だけのタイトル）ので、そのときは既定の名前にする。
  */
-export function exportFileName(title: string, exportedAt: Date): string {
+export function exportFileName(
+  title: string,
+  exportedAt: Date,
+  extension: 'json' | 'md' = 'json',
+): string {
   const date = exportedAt.toISOString().slice(0, 10)
 
   // 経路の区切りと、OS がファイル名に使えない文字だけを落とす。
   // 落としすぎると何のリストか分からなくなるので、日本語や記号は残す
   const safe = title.replace(/[/\\:*?"<>|]/g, '').trim()
 
-  return `${safe === '' ? 'list' : safe}-${date}.json`
+  return `${safe === '' ? 'list' : safe}-${date}.${extension}`
+}
+
+/**
+ * マークダウンで書き出す（#124）。**ブログなどへの転載用。**
+ *
+ * 🔴 **これは読み込まない。人が読むためのもの。**
+ * 往復させたいなら JSON（`buildExportFile`）を使う。
+ *
+ * 決めたこと（2026-08-08、#124）:
+ *
+ * - **見出しは `##`。** 転載先の記事にはすでに記事タイトル（`#`）があることが多い。
+ *   独立した文書として見ると `#` が正しいが、**貼る側が下げるより、貼られる側に合わせる**
+ * - **チェックリスト（`- [x]`）で完了を表す。** GitHub / Zenn / Qiita では
+ *   チェックボックスとして描かれ、対応していない場所でも文字として意味が通る
+ * - **番号は振らない。** 未入力の枠を出さないので「001〜100」の連番という意味が薄れるし、
+ *   転載先で番号がずれると直すのが面倒になる
+ * - **未入力の枠は出さない。** 100行の空行は転載に向かない
+ * - **達成日は出す。** 消すのは簡単だが、**出さなかったものは後から足せない。**
+ *   「いつ叶えたか」はこのアプリが真偽値にしなかった理由そのもの（`PRODUCT_SPEC.md` §3）
+ * - **埋まり具合（23 / 100）を出す。** 100という枠がコンセプトの核なので、
+ *   一覧だけ貼られると意味が半分になる
+ *
+ * `formatDate` を外から受け取るのは**時間帯のため。**
+ * 完了日時は UTC で持っているので、そのまま日付にすると閲覧者の日付と1日ずれうる。
+ * **画面と同じ見え方にするため、ブラウザの時間帯で整形したものを渡す。**
+ */
+export function buildMarkdown(file: ExportFile, formatDate: (isoDate: string) => string): string {
+  const lines = [
+    `## ${file.list.title}`,
+    '',
+    // 上限は packages/shared の定数。ここに数字を書かない
+    `${String(file.list.items.length)} / ${String(ITEMS_PER_LIST_MAX)}`,
+    '',
+  ]
+
+  for (const item of file.list.items) {
+    const mark = item.completedAt === null ? '- [ ]' : '- [x]'
+    const done = item.completedAt === null ? '' : `（${formatDate(item.completedAt)} 達成）`
+
+    lines.push(`${mark} ${item.text}${done}`)
+  }
+
+  // 末尾を改行で終える。貼り付けた先で次の行とくっつかない
+  return `${lines.join('\n')}\n`
 }


### PR DESCRIPTION
Closes #124

`/lists` の各行に **JSON** と **MD** の2つを置いた。
**用途が違うので、どちらか一方にはしない**（JSON は読み込める、MD は人が読むもの）。

## 出力

```markdown
## 2026年の目標

2 / 100

- [x] 南極に行く（2026/5/1 達成）
- [ ] オーロラを見る
```

## 決めたこと

| 論点 | 決定 | 理由 |
|---|---|---|
| 見出しの深さ | **`##`** | 転載先の記事にはすでに記事タイトル（`#`）がある。**貼る側が下げるより、貼られる側に合わせる** |
| 完了の表し方 | **チェックリスト `- [x]`** | GitHub / Zenn / Qiita ではチェックボックスになり、対応していない場所でも文字として意味が通る |
| 番号 | **振らない** | 未入力の枠を出さないので連番の意味が薄れる。転載先でずれると直すのが面倒 |
| 未入力の枠 | **出さない** | 100行の空行は転載に向かない |
| 達成日 | **出す** | **消すのは簡単だが、出さなかったものは後から足せない。**「いつ叶えたか」は完了を真偽値にしなかった理由そのもの（`PRODUCT_SPEC.md` §3） |
| 埋まり具合 | **出す** | 100という枠がコンセプトの核。一覧だけ貼られると意味が半分になる |

## 🔴 マークダウンはサーバーで作らない

#121 では「このルートの隣に足す」と書いたが、**クライアントで作る**ことにした。

**達成日を画面と同じ時間帯で出したいが、サーバーは閲覧者の時間帯を知らない。**
完了日時は UTC で持っているので、サーバーでそのまま日付にすると**1日ずれる**
（画面は `toLocaleDateString('ja-JP')` で出している）。

JSON（時刻をそのまま持つ）を受け取り、クライアントで整形する。
組み立ては `buildMarkdown(file, formatDate)` という**純関数**で、
日付の整形だけを外から受け取るのでテストできる。

## テスト（7件追加、全体 219 tests / 15 files）

- 見出し・埋まり具合・チェックリストの形
- **番号を振らない / 未入力の枠を出さない**
- 末尾が改行で終わる（貼った先で次の行とくっつかない）
- **日付の整形を外から受け取る**（時間帯を画面と揃えられる）

⚠️ 実際に貼って読めるかは利用者に確認を依頼する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)