### PR TITLE
マークダウンの数字を「達成済み / 入力済み」にする

### DIFF
--- a/apps/web/test/export-api.test.ts
+++ b/apps/web/test/export-api.test.ts
@@ -111,7 +111,7 @@ describe('buildMarkdown', () => {
       new Date(0),
     )
 
-  it('見出し・埋まり具合・チェックリストで出る', () => {
+  it('見出し・達成の数・チェックリストで出る', () => {
     const markdown = buildMarkdown(
       file([
         { text: '南極に行く', completedAt: '2026-05-01T00:00:00.000Z' },
@@ -124,13 +124,30 @@ describe('buildMarkdown', () => {
       [
         '## 2026年の目標',
         '',
-        `2 / ${String(ITEMS_PER_LIST_MAX)}`,
+        '1 / 2 達成済み',
         '',
         '- [x] 南極に行く（2026-05-01 達成）',
         '- [ ] オーロラを見る',
         '',
       ].join('\n'),
     )
+  })
+
+  it('🔴 数字は「達成済み / 入力済み」。画面の埋まり具合とは意図が違う', () => {
+    // 画面は「まだ埋まっていない」という動機を出すために 入力済み / 100 を出すが、
+    // 転載を読む人が知りたいのは**どれだけ叶えたか**（#129）
+    const markdown = buildMarkdown(
+      file([
+        { text: 'a', completedAt: '2026-05-01T00:00:00.000Z' },
+        { text: 'b', completedAt: '2026-05-02T00:00:00.000Z' },
+        { text: 'c', completedAt: null },
+      ]),
+      formatDate,
+    )
+
+    expect(markdown).toContain('2 / 3 達成済み')
+    // 分母は 100 ではなく、実際に書いた数
+    expect(markdown).not.toContain(String(ITEMS_PER_LIST_MAX))
   })
 
   it('🔴 見出しは `##`（転載先の記事にはすでに `#` がある）', () => {

--- a/packages/shared/src/export.ts
+++ b/packages/shared/src/export.ts
@@ -141,19 +141,23 @@ export function exportFileName(
  * - **未入力の枠は出さない。** 100行の空行は転載に向かない
  * - **達成日は出す。** 消すのは簡単だが、**出さなかったものは後から足せない。**
  *   「いつ叶えたか」はこのアプリが真偽値にしなかった理由そのもの（`PRODUCT_SPEC.md` §3）
- * - **埋まり具合（23 / 100）を出す。** 100という枠がコンセプトの核なので、
- *   一覧だけ貼られると意味が半分になる
+ * - 🔴 **数字は「達成済み / 入力済み」**（2026-08-08、#129）。
+ *   **画面の「23 / 100」（埋まり具合）とは意図が違う。揃えない。**
+ *   画面は「まだ埋まっていない」という動機を出すためのものだが、
+ *   転載を読む人が知りたいのは**どれだけ叶えたか**。分母も 100 ではなく
+ *   **実際に書いた数**にする（書いていない枠を数に入れても意味がない）
  *
  * `formatDate` を外から受け取るのは**時間帯のため。**
  * 完了日時は UTC で持っているので、そのまま日付にすると閲覧者の日付と1日ずれうる。
  * **画面と同じ見え方にするため、ブラウザの時間帯で整形したものを渡す。**
  */
 export function buildMarkdown(file: ExportFile, formatDate: (isoDate: string) => string): string {
+  const completed = file.list.items.filter((item) => item.completedAt !== null).length
+
   const lines = [
     `## ${file.list.title}`,
     '',
-    // 上限は packages/shared の定数。ここに数字を書かない
-    `${String(file.list.items.length)} / ${String(ITEMS_PER_LIST_MAX)}`,
+    `${String(completed)} / ${String(file.list.items.length)} 達成済み`,
     '',
   ]
 


### PR DESCRIPTION
Closes #129

```diff
  ## 2026年の目標

- 2 / 100
+ 1 / 2 達成済み

  - [x] 南極に行く（2026/5/1 達成）
  - [ ] オーロラを見る
```

🔴 **画面の「23 / 100」（埋まり具合）とは意図が違うので、揃えない。**

画面のあれは「まだ埋まっていない」という動機を出すためのもの（`PRODUCT_SPEC.md` §3）。
**転載を読む人が知りたいのは、どれだけ叶えたか。**
分母も 100 ではなく**実際に書いた数**にした（書いていない枠を数に入れても意味がない）。

違う理由はコードのコメントに残した。次に読む人が「画面と違う、直そう」と思わないように。

## テスト

「達成済み / 入力済み」であることと、**分母に 100 が出ないこと**を固定した
（全体 **220 tests / 15 files が緑**）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)