### PR TITLE
書き出しを別画面にして、2つの形式の用途を分かるようにする

### DIFF
--- a/apps/web/src/client/App.tsx
+++ b/apps/web/src/client/App.tsx
@@ -2,6 +2,7 @@ import { SERVICE_NAME } from '@yaritai100list/shared'
 import { useCallback, useEffect, useState } from 'react'
 import { Link, Route, Switch, useLocation } from 'wouter'
 
+import { ExportPage } from './ExportPage'
 import { ListPage } from './ListPage'
 import { ListsPage } from './ListsPage'
 import { Notice } from './Notice'
@@ -95,6 +96,12 @@ export function App() {
               signOutFailed={signOutFailed}
               onSignOut={() => void signOut()}
             />
+          </Route>
+
+          {/* :listId より先に置かなくても段数が違うので当たらないが、
+              関係のある経路を近くに並べておく */}
+          <Route path="/lists/:listId/export">
+            {(params) => <ExportPage session={session} listId={params.listId} />}
           </Route>
 
           <Route path="/lists/:listId">

--- a/apps/web/src/client/ExportPage.tsx
+++ b/apps/web/src/client/ExportPage.tsx
@@ -1,0 +1,199 @@
+import {
+  buildMarkdown,
+  exportFileName,
+  exportFileSchema,
+  type ExportFile,
+} from '@yaritai100list/shared'
+import { useCallback, useEffect, useState } from 'react'
+import { Link } from 'wouter'
+
+import { api } from './api'
+import { Notice } from './Notice'
+import { type SessionState } from './model'
+
+/**
+ * リストを書き出す画面（#131）。
+ *
+ * 一覧に `JSON` と `MD` のボタンを並べていたが、**どちらが何のためのものか
+ * 分からなかった。** 形式ごとに何ができるのかを、押す前に読める形にする。
+ *
+ * | 形式 | 用途 | 読み込める |
+ * |---|---|---|
+ * | JSON | このアプリに読み込み直す（別のアカウントへ移す・取っておく） | **できる** |
+ * | マークダウン | ブログなどにそのまま貼る | しない |
+ *
+ * 🔴 **マークダウンはここで作る。** サーバーは閲覧者の時間帯を知らないので、
+ * 達成日を UTC のまま日付にすると1日ずれる（#124）。
+ */
+
+type State =
+  | { status: 'loading' }
+  | { status: 'failed' }
+  | { status: 'ready'; file: ExportFile; markdown: string }
+
+export function ExportPage({ session, listId }: { session: SessionState; listId: string }) {
+  // ログインが要る画面。**未ログインでは開かせない**（#112 と同じ扱い）
+  if (session.status !== 'authenticated') {
+    return <SignInRequired session={session} />
+  }
+
+  return <ExportPageBody listId={listId} />
+}
+
+function SignInRequired({ session }: { session: SessionState }) {
+  if (session.status === 'loading') return <p className="py-8 text-slate-500">読み込み中</p>
+
+  if (session.status === 'error') {
+    return (
+      <Notice tone="warn">
+        ログイン状態を確認できないため、この画面を開けません。通信を確かめてください
+      </Notice>
+    )
+  }
+
+  return (
+    <Notice tone="info">
+      書き出すには
+      <a href="/api/login/google" className="font-bold text-brand-deep underline">
+        Googleでログイン
+      </a>
+      してください
+    </Notice>
+  )
+}
+
+function ExportPageBody({ listId }: { listId: string }) {
+  const [state, setState] = useState<State>({ status: 'loading' })
+  const [copied, setCopied] = useState(false)
+
+  const load = useCallback(async () => {
+    try {
+      const res = await api.api.lists[':listId'].export.$get({ param: { listId } })
+      if (!res.ok) {
+        setState({ status: 'failed' })
+        return
+      }
+
+      const parsed = exportFileSchema.safeParse(await res.json())
+      if (!parsed.success) {
+        setState({ status: 'failed' })
+        return
+      }
+
+      setState({
+        status: 'ready',
+        file: parsed.data,
+        // 日付の整形だけを渡す。中身の組み立ては shared の純関数（テストしてある）
+        markdown: buildMarkdown(parsed.data, (iso) => new Date(iso).toLocaleDateString('ja-JP')),
+      })
+    } catch {
+      setState({ status: 'failed' })
+    }
+  }, [listId])
+
+  useEffect(() => {
+    void load()
+  }, [load])
+
+  if (state.status === 'loading') return <p className="py-8 text-slate-500">読み込み中</p>
+
+  if (state.status === 'failed') {
+    return (
+      <Notice tone="warn">
+        このリストを読み込めませんでした。通信を確かめて、開き直してください
+      </Notice>
+    )
+  }
+
+  const { file, markdown } = state
+
+  const download = (content: string, type: string, extension: 'json' | 'md') => {
+    const url = URL.createObjectURL(new Blob([content], { type }))
+    const anchor = document.createElement('a')
+
+    anchor.href = url
+    anchor.download = exportFileName(file.list.title, new Date(), extension)
+    anchor.click()
+
+    // 解放しないとページを閉じるまでメモリに残る
+    URL.revokeObjectURL(url)
+  }
+
+  const copyMarkdown = async () => {
+    try {
+      await navigator.clipboard.writeText(markdown)
+      setCopied(true)
+    } catch {
+      // 権限が無い環境がある。**黙って失敗しない。**
+      // 下に中身を出してあるので、選んでコピーはできる
+      setCopied(false)
+    }
+  }
+
+  return (
+    <div>
+      <Link href="/lists" className="text-xs text-brand-deep underline">
+        ← すべてのリスト
+      </Link>
+
+      <h1 className="mt-2 text-xl font-bold text-slate-900">書き出す</h1>
+      <p className="mt-1 text-sm text-slate-600">{file.list.title}</p>
+
+      <section className="mt-6 rounded bg-white px-3 py-3">
+        <h2 className="font-bold text-slate-900">このアプリに読み込み直す（JSON）</h2>
+        <p className="mt-1 text-xs text-slate-600">
+          <strong>このアプリで読み込むための</strong>ファイルです。
+          別のアカウントへ移したいときや、手元に取っておきたいときに使います。
+          <br />
+          読み込みは「すべてのリスト」の
+          <strong>「ファイルからリストを読み込む」</strong>から。
+        </p>
+
+        <button
+          type="button"
+          onClick={() => {
+            download(JSON.stringify(file, null, 2), 'application/json', 'json')
+          }}
+          className="mt-3 w-full rounded bg-brand-deep px-3 py-2 text-white"
+        >
+          JSON をダウンロード
+        </button>
+      </section>
+
+      <section className="mt-4 rounded bg-white px-3 py-3">
+        <h2 className="font-bold text-slate-900">ブログなどに貼る（マークダウン）</h2>
+        <p className="mt-1 text-xs text-slate-600">
+          下の内容を<strong>そのまま貼れます</strong>。
+          <br />
+          <strong>このアプリに読み込むことはできません。</strong>
+          戻せる形で持ち出したいときは JSON を使ってください。
+        </p>
+
+        {/* 貼る前に中身を確かめられるようにする。「そのまま貼れる」を言葉で言うより早い */}
+        <pre className="mt-3 max-h-64 overflow-auto rounded bg-brand-soft px-2 py-2 text-[11px] whitespace-pre-wrap text-slate-700">
+          {markdown}
+        </pre>
+
+        <div className="mt-3 flex gap-2">
+          <button
+            type="button"
+            onClick={() => void copyMarkdown()}
+            className="flex-1 rounded bg-brand-deep px-3 py-2 text-white"
+          >
+            {copied ? 'コピーしました' : 'コピー'}
+          </button>
+
+          <button
+            type="button"
+            onClick={() => {
+              download(markdown, 'text/markdown', 'md')
+            }}
+            className="flex-1 rounded border border-brand px-3 py-2 text-brand-deep"
+          >
+            ダウンロード
+          </button>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/apps/web/src/client/ListsPage.tsx
+++ b/apps/web/src/client/ListsPage.tsx
@@ -1,10 +1,4 @@
-import {
-  buildMarkdown,
-  exportFileName,
-  exportFileSchema,
-  LISTS_PER_USER_MAX,
-  NEW_LIST_TITLE,
-} from '@yaritai100list/shared'
+import { LISTS_PER_USER_MAX, NEW_LIST_TITLE } from '@yaritai100list/shared'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { Link, useLocation } from 'wouter'
 
@@ -124,51 +118,6 @@ export function ListsPage({
 
     const body = await res.json()
     if ('list' in body) navigate(`/lists/${body.list.id}`)
-  }
-
-  /**
-   * リストをファイルに書き出す（#121 / #124）。
-   *
-   * 取得は API、保存はブラウザの仕事なので**ここで DOM を触る。**
-   * 中身とファイル名の組み立ては `packages/shared` の純関数（テストしてある）。
-   *
-   * 🔴 **マークダウンはサーバーで作らない。** 達成日を**画面と同じ時間帯**で
-   * 出したいが、サーバーは閲覧者の時間帯を知らない。UTC のまま日付にすると1日ずれる。
-   * JSON（時刻をそのまま持つ）を受け取って、**ここで整形する。**
-   */
-  const exportList = async (list: RemoteList, format: 'json' | 'md') => {
-    setMessage(null)
-
-    const res = await api.api.lists[':listId'].export.$get({ param: { listId: list.id } })
-
-    if (!res.ok) {
-      setMessage({ tone: 'warn', text: '書き出せませんでした。通信を確かめてください' })
-      return
-    }
-
-    const body: unknown = await res.json()
-    const parsed = exportFileSchema.safeParse(body)
-
-    if (!parsed.success) {
-      setMessage({ tone: 'warn', text: '書き出せませんでした（応答の形が想定と違います）' })
-      return
-    }
-
-    const content =
-      format === 'json'
-        ? JSON.stringify(parsed.data, null, 2)
-        : buildMarkdown(parsed.data, (iso) => new Date(iso).toLocaleDateString('ja-JP'))
-
-    const type = format === 'json' ? 'application/json' : 'text/markdown'
-    const url = URL.createObjectURL(new Blob([content], { type }))
-    const anchor = document.createElement('a')
-
-    anchor.href = url
-    anchor.download = exportFileName(list.title, new Date(), format)
-    anchor.click()
-
-    // 解放しないとページを閉じるまでメモリに残る
-    URL.revokeObjectURL(url)
   }
 
   /** 書き出したファイルを読み込む（#122）。**新しいリストとして増える。** */
@@ -303,7 +252,6 @@ export function ListsPage({
             key={list.id}
             number={formatItemNumber(index + 1)}
             list={list}
-            onExport={exportList}
             onDelete={deleteList}
           />
         ))}
@@ -355,12 +303,10 @@ export function ListsPage({
 function ListRow({
   number,
   list,
-  onExport,
   onDelete,
 }: {
   number: string
   list: RemoteList
-  onExport: (list: RemoteList, format: 'json' | 'md') => Promise<void>
   onDelete: (listId: string) => Promise<void>
 }) {
   const [confirming, setConfirming] = useState(false)
@@ -379,28 +325,16 @@ function ListRow({
         </Link>
 
         {/*
-          書き出しは2つの形式（#124）。**JSON は読み込める、MD は人が読むもの。**
-          用途が違うので、選ばせずにどちらか一方にはしない
+          形式が2つある（JSON とマークダウン）ので、**選ぶのは別画面**（#131）。
+          行にボタンを並べただけでは、どちらが何のためのものか分からなかった
         */}
-        <button
-          type="button"
-          aria-label={`${list.title} を JSON で書き出す（読み込める形式）`}
-          title="読み込める形式で書き出す"
-          onClick={() => void onExport(list, 'json')}
-          className="shrink-0 px-1 text-[10px] text-slate-400"
+        <Link
+          href={`/lists/${list.id}/export`}
+          aria-label={`${list.title} を書き出す`}
+          className="shrink-0 px-1 text-xs text-brand-deep underline"
         >
-          JSON
-        </button>
-
-        <button
-          type="button"
-          aria-label={`${list.title} をマークダウンで書き出す（転載用）`}
-          title="ブログなどへの転載用"
-          onClick={() => void onExport(list, 'md')}
-          className="shrink-0 px-1 text-[10px] text-slate-400"
-        >
-          MD
-        </button>
+          書き出す
+        </Link>
 
         <button
           type="button"


### PR DESCRIPTION
Closes #131

一覧の行に `JSON` と `MD` のボタンを並べていたが、
**どちらが何のためのものか分からなかった**（利用者の指摘）。

`/lists/:listId/export` を作り、**押す前に読める形**にした。
一覧の行は「書き出す」の1つだけになり、行も片付いた。

```
← すべてのリスト

書き出す
2026年の目標

┌─ このアプリに読み込み直す（JSON）─────────────┐
│ このアプリで読み込むためのファイルです。       │
│ 別のアカウントへ移したいときや、               │
│ 手元に取っておきたいときに使います。           │
│ 読み込みは「すべてのリスト」の                 │
│ 「ファイルからリストを読み込む」から。         │
│ [ JSON をダウンロード ]                        │
└────────────────────────────────────────────────┘

┌─ ブログなどに貼る（マークダウン）─────────────┐
│ 下の内容をそのまま貼れます。                   │
│ このアプリに読み込むことはできません。         │
│ 戻せる形で持ち出したいときは JSON を。         │
│ ┌────────────────────────────────────────────┐ │
│ │ ## 2026年の目標                            │ │
│ │                                            │ │
│ │ 1 / 2 達成済み                             │ │
│ │                                            │ │
│ │ - [x] 南極に行く（2026/5/1 達成）          │ │
│ │ - [ ] オーロラを見る                       │ │
│ └────────────────────────────────────────────┘ │
│ [ コピー ] [ ダウンロード ]                    │
└────────────────────────────────────────────────┘
```

## 判断したこと

**マークダウンは中身をそのまま見せた。**
「そのまま貼れます」と書くより、**貼るものを見せる方が早い。**
コピーが権限で失敗する環境もあるが、**中身が出ているので選んでコピーできる**
（黙って失敗して終わり、にならない）。

**それぞれの説明に「できないこと」を書いた。**
マークダウンは読み込めない、戻したいなら JSON、と対で示さないと選べない。

**未ログインでは開けない**（`/lists/:listId` と同じ扱い。#112）。
`error`（確認できない）と未ログインで文言を分けるのも同じ。

## 確認

`typecheck` / `lint` / `format:check` / `test`（220 tests）/ `build` が緑。
`npm run dev` で `/lists/abc/export` が SPA として返ることを確認した。
⚠️ 見た目と実際の貼り付けは利用者に確認を依頼する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)