### PR TITLE
マークダウンのダウンロードボタンを外す

### DIFF
--- a/apps/web/src/client/ExportPage.tsx
+++ b/apps/web/src/client/ExportPage.tsx
@@ -107,12 +107,13 @@ function ExportPageBody({ listId }: { listId: string }) {
 
   const { file, markdown } = state
 
-  const download = (content: string, type: string, extension: 'json' | 'md') => {
-    const url = URL.createObjectURL(new Blob([content], { type }))
+  const downloadJson = () => {
+    const content = JSON.stringify(file, null, 2)
+    const url = URL.createObjectURL(new Blob([content], { type: 'application/json' }))
     const anchor = document.createElement('a')
 
     anchor.href = url
-    anchor.download = exportFileName(file.list.title, new Date(), extension)
+    anchor.download = exportFileName(file.list.title, new Date())
     anchor.click()
 
     // 解放しないとページを閉じるまでメモリに残る
@@ -151,9 +152,7 @@ function ExportPageBody({ listId }: { listId: string }) {
 
         <button
           type="button"
-          onClick={() => {
-            download(JSON.stringify(file, null, 2), 'application/json', 'json')
-          }}
+          onClick={downloadJson}
           className="mt-3 w-full rounded bg-brand-deep px-3 py-2 text-white"
         >
           JSON をダウンロード
@@ -174,25 +173,17 @@ function ExportPageBody({ listId }: { listId: string }) {
           {markdown}
         </pre>
 
-        <div className="mt-3 flex gap-2">
-          <button
-            type="button"
-            onClick={() => void copyMarkdown()}
-            className="flex-1 rounded bg-brand-deep px-3 py-2 text-white"
-          >
-            {copied ? 'コピーしました' : 'コピー'}
-          </button>
-
-          <button
-            type="button"
-            onClick={() => {
-              download(markdown, 'text/markdown', 'md')
-            }}
-            className="flex-1 rounded border border-brand px-3 py-2 text-brand-deep"
-          >
-            ダウンロード
-          </button>
-        </div>
+        {/*
+          ダウンロードは置かない（#133）。**貼るためのものなので、
+          ファイルとして持っておく理由が薄い**（取っておきたいなら JSON がある）
+        */}
+        <button
+          type="button"
+          onClick={() => void copyMarkdown()}
+          className="mt-3 w-full rounded bg-brand-deep px-3 py-2 text-white"
+        >
+          {copied ? 'コピーしました' : 'コピー'}
+        </button>
       </section>
     </div>
   )

--- a/apps/web/test/export-api.test.ts
+++ b/apps/web/test/export-api.test.ts
@@ -197,12 +197,6 @@ describe('exportFileName', () => {
   it('落とした結果が空なら既定の名前になる', () => {
     expect(exportFileName('///', new Date('2026-08-07T00:00:00.000Z'))).toBe('list-2026-08-07.json')
   })
-
-  it('マークダウンなら拡張子が変わる', () => {
-    expect(exportFileName('目標', new Date('2026-08-07T00:00:00.000Z'), 'md')).toBe(
-      '目標-2026-08-07.md',
-    )
-  })
 })
 
 describe('GET /api/lists/:listId/export', () => {

--- a/packages/shared/src/export.ts
+++ b/packages/shared/src/export.ts
@@ -110,18 +110,14 @@ export function hasFutureCompletedAt(file: ExportFile, now: Date): boolean {
  * ファイル名に使えない文字（`/` や `\`、制御文字など）はリスト名に入りうるので落とす。
  * 落とした結果が空になることもある（記号だけのタイトル）ので、そのときは既定の名前にする。
  */
-export function exportFileName(
-  title: string,
-  exportedAt: Date,
-  extension: 'json' | 'md' = 'json',
-): string {
+export function exportFileName(title: string, exportedAt: Date): string {
   const date = exportedAt.toISOString().slice(0, 10)
 
   // 経路の区切りと、OS がファイル名に使えない文字だけを落とす。
   // 落としすぎると何のリストか分からなくなるので、日本語や記号は残す
   const safe = title.replace(/[/\\:*?"<>|]/g, '').trim()
 
-  return `${safe === '' ? 'list' : safe}-${date}.${extension}`
+  return `${safe === '' ? 'list' : safe}-${date}.json`
 }
 
 /**


### PR DESCRIPTION
Closes #133

**コピーがあればダウンロードは要らない**（利用者の指摘）。
マークダウンは**貼るためのもの**なので、ファイルとして持っておく理由が薄い
（取っておきたいなら JSON がある）。

あわせて、**使われなくなる `exportFileName` の拡張子の引数とそのテストも外した。**
残しておくと「マークダウンもファイルにできるのかな」と読めてしまう。
必要になったら足す。

## 確認

`typecheck` / `lint` / `format:check` / `test`（219 tests）/ `build` が緑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)