### PR TITLE
share_id を持たせる（公開用 ID）

### DIFF
--- a/apps/web/migrations/0007_add_share_id.sql
+++ b/apps/web/migrations/0007_add_share_id.sql
@@ -1,0 +1,39 @@
+-- 公開用の ID（`share_id`）を足す（#135）。
+--
+-- 🔴 **手で書いたマイグレーション。drizzle-kit の生成物は使えない。**
+-- 生成されたのは次の1文だった:
+--   ALTER TABLE `lists` ADD `share_id` text NOT NULL;
+-- SQLite は **DEFAULT の無い NOT NULL 列を ADD COLUMN できない**（0002 で踏んだのと同じ）。
+--
+-- 🔴 **テーブルを作り直す手も使えない。**
+-- 本番には既にリストと項目がある（2026-08-08 時点で 2 リスト / 113 項目）。
+-- `items` は `lists` を `ON DELETE CASCADE` で参照しているので、
+-- **`DROP TABLE lists` は項目を全部消す**（SQLite は DROP の前に暗黙の DELETE を行い、
+-- 外部キーの動作が発生する）。0002 のときは 0 行だったので作り直せた。今は違う。
+--
+-- そこで:
+--   1. NULL を許して列を足す
+--   2. 既存の行を埋める（**推測不可能な値**。連番にしない。CLAUDE.md の不変条件）
+--   3. 一意にする
+--   4. **NULL を入れられないようにトリガーで縛る**（列の NOT NULL は後から付けられない）
+--
+-- `randomblob(16)` は 128 ビット。`newShareId()`（`src/id.ts`）と**同じ形**にしてある。
+ALTER TABLE `lists` ADD `share_id` text;--> statement-breakpoint
+UPDATE `lists` SET `share_id` = lower(hex(randomblob(16))) WHERE `share_id` IS NULL;--> statement-breakpoint
+CREATE UNIQUE INDEX `lists_share_id_unique` ON `lists` (`share_id`);--> statement-breakpoint
+-- 列の宣言としては NULL 可のままなので、**DB 側の縛りはトリガーで作る。**
+-- アプリは必ず入れているが、経路が1つだけという前提に頼らない（#99 と同じ考え方）。
+CREATE TRIGGER lists_share_id_required_on_insert
+BEFORE INSERT ON lists
+FOR EACH ROW
+WHEN NEW.share_id IS NULL
+BEGIN
+	SELECT RAISE(ABORT, 'share_id is required');
+END;--> statement-breakpoint
+CREATE TRIGGER lists_share_id_required_on_update
+BEFORE UPDATE OF share_id ON lists
+FOR EACH ROW
+WHEN NEW.share_id IS NULL
+BEGIN
+	SELECT RAISE(ABORT, 'share_id is required');
+END;

--- a/apps/web/migrations/meta/0007_snapshot.json
+++ b/apps/web/migrations/meta/0007_snapshot.json
@@ -1,0 +1,519 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "72e095e1-5b96-4010-8486-c8df6c2fd563",
+  "prevId": "d732592a-f282-4b24-b947-9c118192a9b9",
+  "tables": {
+    "accounts": {
+      "name": "accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verifications": {
+      "name": "verifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "items": {
+      "name": "items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "list_id": {
+          "name": "list_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('subsec') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('subsec') * 1000)"
+        }
+      },
+      "indexes": {
+        "items_list_id_position_idx": {
+          "name": "items_list_id_position_idx",
+          "columns": [
+            "list_id",
+            "position"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "items_list_id_lists_id_fk": {
+          "name": "items_list_id_lists_id_fk",
+          "tableFrom": "items",
+          "tableTo": "lists",
+          "columnsFrom": [
+            "list_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "items_position_check": {
+          "name": "items_position_check",
+          "value": "\"items\".\"position\" >= 0"
+        }
+      }
+    },
+    "lists": {
+      "name": "lists",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "share_id": {
+          "name": "share_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'private'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('subsec') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('subsec') * 1000)"
+        }
+      },
+      "indexes": {
+        "lists_share_id_unique": {
+          "name": "lists_share_id_unique",
+          "columns": [
+            "share_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "lists_user_id_users_id_fk": {
+          "name": "lists_user_id_users_id_fk",
+          "tableFrom": "lists",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "lists_visibility_check": {
+          "name": "lists_visibility_check",
+          "value": "\"lists\".\"visibility\" in ('private', 'unlisted', 'public')"
+        }
+      }
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/apps/web/migrations/meta/_journal.json
+++ b/apps/web/migrations/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1786086462686,
       "tag": "0006_limit_lists_per_user",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "6",
+      "when": 1786152185647,
+      "tag": "0007_add_share_id",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/src/db/schema/lists.ts
+++ b/apps/web/src/db/schema/lists.ts
@@ -2,13 +2,11 @@ import { VISIBILITIES } from '@yaritai100list/shared'
 import { sql } from 'drizzle-orm'
 import { check, integer, sqliteTable, text } from 'drizzle-orm/sqlite-core'
 
+import { newShareId } from '../../id'
 import { users } from './auth'
 
 /**
  * リスト。
- *
- * ここで持たない列と、それを足すイシュー:
- * - `share_id`: 公開用の ID。#7（リストの共有）で足す
  *
  * 決めた仕様はできる限り DB の制約にする。人間がレビューしない開発では
  * 「間違っても DB が止めてくれる」ことが安全側の資産になる（TECH_STACK.md §7）。
@@ -36,6 +34,22 @@ export const lists = sqliteTable(
       .references(() => users.id, { onDelete: 'cascade' }),
 
     title: text('title').notNull(),
+
+    /**
+     * 公開用の ID。**編集用の `id` とは別の値**（`TECH_STACK.md` §7）。
+     *
+     * 🔴 **値があること = 公開されていること、ではない。**
+     * 公開しているかは `visibility` だけで決まる。
+     * 「公開したときだけ入れる」形にすると**公開の判定が2箇所になる**ので、
+     * **常に持たせる**（2026-08-08 決定、#135）。
+     *
+     * 作り直すと古い共有リンクが無効になる（`PRODUCT_SPEC.md` §5.1）。
+     *
+     * `$defaultFn` を付けてあるので、**insert で渡し忘れても必ず値が入る。**
+     * 「呼び忘れたら動かない」ではなく「忘れても正しい」に寄せている
+     * （条件付き insert を生 SQL で書いている経路だけは自分で渡す）。
+     */
+    shareId: text('share_id').notNull().unique().$defaultFn(newShareId),
 
     /**
      * 公開範囲。**既定は非公開**。公開は明示的な操作でのみ起きる（PRODUCT_SPEC.md §5.1）。

--- a/apps/web/src/id.ts
+++ b/apps/web/src/id.ts
@@ -7,10 +7,27 @@
  * `crypto.randomUUID()` は Workers でも Deno でも使える（`packages/shared` と違い
  * ここは Worker 専用だが、経路を揃えておく）。
  *
- * ⚠️ **公開用の `shareId`（#7）はここを使い回さない。**
- * あちらは人が触る URL に載るので短さと読みやすさの要求が違う。
- * 別の関数として、この隣に足すこと。
+ * 公開用の `shareId` は `newShareId()`（下）。**用途が違うので分けてある。**
  */
 export function newId(): string {
   return crypto.randomUUID()
+}
+
+/**
+ * 公開用の ID（`shareId`）。**編集用の `listId` とは別の値**（`TECH_STACK.md` §7）。
+ *
+ * 分ける理由は2つ:
+ *
+ * - **作り直すだけで共有リンクを無効にできる。**
+ *   「うっかり送った相手に見られ続ける」状態から抜ける手段（`PRODUCT_SPEC.md` §5.1）
+ * - 公開 URL から編集 URL を推測できない
+ *
+ * 16バイト（128ビット）を16進で。**総当たりで当てられる長さではない。**
+ * UUID にしないのは、URL に載る値なので区切りの `-` が邪魔なため。
+ * マイグレーション（`0007`）で既存の行に入れた値と**同じ形**にしてある。
+ */
+export function newShareId(): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(16))
+
+  return [...bytes].map((byte) => byte.toString(16).padStart(2, '0')).join('')
 }

--- a/apps/web/src/index.ts
+++ b/apps/web/src/index.ts
@@ -21,7 +21,7 @@ import { requireOwnedItem, requireOwnedList, requireUser } from './authorization
 import { createDb, type Db } from './db'
 import { items, lists } from './db/schema'
 import type { AppEnv } from './env'
-import { newId } from './id'
+import { newId, newShareId } from './id'
 import { rateLimitCreates } from './rate-limit'
 import { sentryOptions } from './sentry'
 
@@ -201,8 +201,8 @@ const app = new Hono<AppEnv>()
       const title = c.req.valid('json').title ?? DEFAULT_LIST_TITLE
 
       const inserted = await db.all<{ id: string }>(sql`
-      insert into ${lists} (id, user_id, title)
-      select ${id}, ${userId}, ${title}
+      insert into ${lists} (id, user_id, title, share_id)
+      select ${id}, ${userId}, ${title}, ${newShareId()}
       where (select count(*) from ${lists} where ${lists.userId} = ${userId}) < ${LISTS_PER_USER_MAX}
       returning id
     `)
@@ -246,8 +246,8 @@ const app = new Hono<AppEnv>()
 
       // 上限の判定と挿入を1文で（POST /api/lists と同じ理由）
       const inserted = await db.all<{ id: string }>(sql`
-      insert into ${lists} (id, user_id, title)
-      select ${listId}, ${userId}, ${title ?? DEFAULT_LIST_TITLE}
+      insert into ${lists} (id, user_id, title, share_id)
+      select ${listId}, ${userId}, ${title ?? DEFAULT_LIST_TITLE}, ${newShareId()}
       where (select count(*) from ${lists} where ${lists.userId} = ${userId}) < ${LISTS_PER_USER_MAX}
       returning id
     `)
@@ -325,8 +325,8 @@ const app = new Hono<AppEnv>()
 
     // 上限の判定と挿入を1文で（POST /api/lists と同じ理由）
     const inserted = await db.all<{ id: string }>(sql`
-      insert into ${lists} (id, user_id, title)
-      select ${listId}, ${userId}, ${incoming.title}
+      insert into ${lists} (id, user_id, title, share_id)
+      select ${listId}, ${userId}, ${incoming.title}, ${newShareId()}
       where (select count(*) from ${lists} where ${lists.userId} = ${userId}) < ${LISTS_PER_USER_MAX}
       returning id
     `)

--- a/apps/web/test/lists.test.ts
+++ b/apps/web/test/lists.test.ts
@@ -37,7 +37,7 @@ describe('lists テーブル', () => {
     // Drizzle の enum は型の上だけの話なので、型を迂回する経路（生 SQL）で
     // CHECK 制約が実際に効いていることを確認する
     const insert = env.DB.prepare(
-      "insert into lists (id, user_id, title, visibility) values ('list-1', ?, 'x', 'everyone')",
+      "insert into lists (id, user_id, title, share_id, visibility) values ('list-1', ?, 'x', 's1', 'everyone')",
     )
       .bind(userId)
       .run()
@@ -48,14 +48,16 @@ describe('lists テーブル', () => {
   describe('所有者（user_id）', () => {
     it('所有者のいないリストは作れない', async () => {
       // 型では防いでいるが、DB でも止まることを確認する
-      const insert = env.DB.prepare("insert into lists (id, title) values ('list-1', 'x')").run()
+      const insert = env.DB.prepare(
+        "insert into lists (id, title, share_id) values ('list-1', 'x', 's1')",
+      ).run()
 
       await expect(insert).rejects.toThrow(/NOT NULL constraint failed/)
     })
 
     it('存在しない利用者を所有者にできない', async () => {
       const insert = env.DB.prepare(
-        "insert into lists (id, user_id, title) values ('list-1', 'no-such-user', 'x')",
+        "insert into lists (id, user_id, title, share_id) values ('list-1', 'no-such-user', 'x', 's1')",
       ).run()
 
       await expect(insert).rejects.toThrow(/FOREIGN KEY constraint failed/)
@@ -69,6 +71,73 @@ describe('lists テーブル', () => {
       await db.delete(users).where(eq(users.id, userId))
 
       expect(await db.select().from(lists)).toEqual([])
+    })
+  })
+
+  describe('公開用の ID（share_id）', () => {
+    it('渡さなくても入る。連番ではない', async () => {
+      const db = testDb()
+      const userId = await createTestUser()
+
+      await db.insert(lists).values([
+        { id: 'list-1', userId, title: 'x' },
+        { id: 'list-2', userId, title: 'y' },
+      ])
+
+      const rows = await db.select().from(lists)
+      const shareIds = rows.map((row) => row.shareId)
+
+      expect(shareIds.every((id) => id.length >= 32)).toBe(true)
+      expect(new Set(shareIds).size).toBe(2)
+      expect(shareIds[0]).not.toMatch(/^\d+$/)
+    })
+
+    it('🔴 編集用の ID とは別の値', async () => {
+      // 同じにすると、公開 URL から編集 URL が分かってしまう（TECH_STACK.md §7）
+      const db = testDb()
+      const userId = await createTestUser()
+      await db.insert(lists).values({ id: 'list-1', userId, title: 'x' })
+
+      const [row] = await db.select().from(lists)
+
+      expect(row?.shareId).not.toBe(row?.id)
+    })
+
+    it('🔴 重複した値は DB が拒否する', async () => {
+      // 生 SQL で叩く。Drizzle 経由だと元の理由がラップされて読めない
+      const userId = await createTestUser()
+      const insert = (id: string) =>
+        env.DB.prepare('insert into lists (id, user_id, title, share_id) values (?, ?, ?, ?)')
+          .bind(id, userId, 'x', 'same')
+          .run()
+
+      await insert('list-1')
+
+      await expect(insert('list-2')).rejects.toThrow(/UNIQUE constraint failed/)
+    })
+
+    it('🔴 空（NULL）では入れられない', async () => {
+      // 列の宣言は NULL 可のままなので、DB 側の縛りはトリガーで作っている
+      // （既存の行があるためテーブルを作り直せなかった。マイグレーション 0007）
+      const userId = await createTestUser()
+
+      const insert = env.DB.prepare('insert into lists (id, user_id, title) values (?, ?, ?)')
+        .bind('list-1', userId, 'x')
+        .run()
+
+      await expect(insert).rejects.toThrow(/share_id is required/)
+    })
+
+    it('🔴 後から NULL にもできない', async () => {
+      const db = testDb()
+      const userId = await createTestUser()
+      await db.insert(lists).values({ id: 'list-1', userId, title: 'x' })
+
+      const update = env.DB.prepare('update lists set share_id = null where id = ?')
+        .bind('list-1')
+        .run()
+
+      await expect(update).rejects.toThrow(/share_id is required/)
     })
   })
 
@@ -87,8 +156,10 @@ describe('lists テーブル', () => {
       const userId = await createTestUser()
       await fill(userId, LISTS_PER_USER_MAX)
 
-      const insert = env.DB.prepare('insert into lists (id, user_id, title) values (?, ?, ?)')
-        .bind('over', userId, 'x')
+      const insert = env.DB.prepare(
+        'insert into lists (id, user_id, title, share_id) values (?, ?, ?, ?)',
+      )
+        .bind('over', userId, 'x', 'over-share')
         .run()
 
       await expect(insert).rejects.toThrow(/lists per user limit reached/)
@@ -106,8 +177,10 @@ describe('lists テーブル', () => {
       await testDb().insert(lists).values({ id: 'last', userId, title: 'x' })
       expect(await testDb().select({ n: count() }).from(lists)).toEqual([{ n: LISTS_PER_USER_MAX }])
 
-      const insert = env.DB.prepare('insert into lists (id, user_id, title) values (?, ?, ?)')
-        .bind('over', userId, 'x')
+      const insert = env.DB.prepare(
+        'insert into lists (id, user_id, title, share_id) values (?, ?, ?, ?)',
+      )
+        .bind('over', userId, 'x', 'over-share')
         .run()
 
       await expect(insert).rejects.toThrow(/lists per user limit reached/)


### PR DESCRIPTION
Closes #135

編集用の `listId` とは別の公開用 ID（`TECH_STACK.md` §7）。
**作り直すと古い共有リンクが無効になる**（`PRODUCT_SPEC.md` §5.1）ための土台。

## 常に持たせる

公開したときだけ入れる（nullable）形にすると、**「値がある = 公開されている」と
読めてしまい、公開の判定が2箇所になる。**
公開しているかは `visibility` だけで決める、とコメントに書いた。

## 🔴 マイグレーションは手で書いた（生成物が使えない）

drizzle-kit が出したのは `ALTER TABLE lists ADD share_id text NOT NULL;` の1文。
**SQLite は DEFAULT の無い NOT NULL 列を ADD COLUMN できない**（0002 で踏んだのと同じ）。

**テーブルを作り直す手も使えない。**
本番には既に **2 リスト / 113 項目**があり、`items` は `lists` を
`ON DELETE CASCADE` で参照している。**`DROP TABLE lists` は項目を全部消す**
（SQLite は DROP の前に暗黙の DELETE を行い、外部キーの動作が発生する）。
0002 のときは 0 行だったので作り直せた。**今は違う。**

そこで:

1. NULL を許して列を足す
2. 既存の行を埋める（`lower(hex(randomblob(16)))`。**推測不可能な値**）
3. 一意にする
4. **NULL を入れられないようトリガーで縛る**（列の NOT NULL は後から付けられない）

## 渡し忘れても入る

スキーマに `$defaultFn(newShareId)` を付けた。**insert で渡し忘れても必ず値が入る。**
条件付き insert を生 SQL で書いている3経路（作成・取り込み・読み込み）だけは自分で渡す。

`newShareId()` は16バイトを16進で。**マイグレーションで埋めた値と同じ形**にしてある。
UUID にしないのは、URL に載る値なので `-` が邪魔なため。

## テスト（`lists.test.ts` に5件、全体 224 tests）

- 渡さなくても入る / 連番でない / **編集用の ID とは別の値**
- **重複を DB が拒否する**
- **NULL では入れられない / 後から NULL にもできない**（トリガー）

## デプロイ

CD が `migrate → deploy` の順で走るので、**本番の2行はマージ時に自動で埋まる。**

🤖 Generated with [Claude Code](https://claude.com/claude-code)