### PR TITLE
/share/:shareId の公開ページ（SSR）

### DIFF
--- a/apps/web/src/index.ts
+++ b/apps/web/src/index.ts
@@ -7,12 +7,13 @@ import {
   hasFutureCompletedAt,
   ITEMS_PER_LIST_MAX,
   LISTS_PER_USER_MAX,
+  SHARED_VISIBILITIES,
   itemTextSchema,
   listTitleSchema,
   visibilitySchema,
 } from '@yaritai100list/shared'
 import { zValidator } from '@hono/zod-validator'
-import { and, asc, eq, gt, sql } from 'drizzle-orm'
+import { and, asc, eq, gt, inArray, sql } from 'drizzle-orm'
 import { Hono } from 'hono'
 import { z } from 'zod'
 
@@ -23,6 +24,7 @@ import { items, lists } from './db/schema'
 import type { AppEnv } from './env'
 import { newId, newShareId } from './id'
 import { rateLimitCreates } from './rate-limit'
+import { renderSharePage, renderShareNotFound } from './share'
 import { sentryOptions } from './sentry'
 
 /**
@@ -590,6 +592,52 @@ const app = new Hono<AppEnv>()
       return c.json({ items: await selectItems(db, listId) })
     },
   )
+
+  /**
+   * 共有公開ページ（#137）。**ログインは要らない。**
+   *
+   * 🔴 **`wrangler.jsonc` の `run_worker_first` に `/share/*` を入れてある。**
+   * 入れ忘れると Worker に届かず、SPA の index.html が返る
+   * （**404 にならないので気づきにくい**）。
+   *
+   * 🔴 **公開してよい範囲を列挙して絞る**（`SHARED_VISIBILITIES`）。
+   * 「非公開以外」で書くと、後から公開範囲を1つ足したときに黙って公開される。
+   *
+   * 🔴 **非公開のリストと、存在しない ID で同じものを返す。**
+   * 出し分けると「その ID は存在するが非公開」と分かってしまう。
+   *
+   * 渡すのは**タイトルと項目だけ。** 作者は渡さない（`PRODUCT_SPEC.md` §5.1）。
+   */
+  .get('/share/:shareId', async (c) => {
+    const db = createDb(c.env.DB)
+
+    const [list] = await db
+      .select()
+      .from(lists)
+      .where(
+        and(
+          eq(lists.shareId, c.req.param('shareId')),
+          inArray(lists.visibility, [...SHARED_VISIBILITIES]),
+        ),
+      )
+      .limit(1)
+
+    if (!list) {
+      return c.html(renderShareNotFound(), 404)
+    }
+
+    const rows = await selectItems(db, list.id)
+
+    return c.html(
+      renderSharePage({
+        title: list.title,
+        items: rows.map((item) => ({
+          text: item.text,
+          completedAt: item.completedAt === null ? null : item.completedAt.getTime(),
+        })),
+      }),
+    )
+  })
 
   /**
    * Better Auth の全エンドポイント（セッション取得、サインアウト、コールバック等）。

--- a/apps/web/src/share.ts
+++ b/apps/web/src/share.ts
@@ -1,0 +1,180 @@
+import { SERVICE_NAME } from '@yaritai100list/shared'
+import { html, raw } from 'hono/html'
+// 型は `hono/html` から出ていないので、実体のある場所から取る
+import type { HtmlEscapedString } from 'hono/utils/html'
+
+/**
+ * 共有公開ページの中身（#137）。
+ *
+ * **描画だけをここに置く。** 認可（非公開を弾く）は呼び出し側で済ませ、
+ * ここには**見せてよいデータだけ**が渡ってくる（`CLAUDE.md` の不変条件と同じ考え方）。
+ *
+ * 🔴 **作者を出さない**（`PRODUCT_SPEC.md` §5.1）。
+ * 渡す型に作者の情報が無いので、**書こうと思っても書けない。**
+ *
+ * JSX ではなく `hono/html` を使っている。理由は2つ:
+ *
+ * - **`${}` が自動でエスケープされる。** 利用者が書いた文字がそのまま入るので、
+ *   ここを取り違えると XSS になる。既定で安全な方を選ぶ
+ * - JSX にすると Worker 側の tsconfig に `jsxImportSource: hono/jsx` が要る。
+ *   **クライアントは React の JSX** なので、1つの Vite プロジェクトで2種類の JSX を
+ *   扱うことになり、ビルド設定が壊れやすい
+ */
+
+/**
+ * このページのスタイル。**1ファイルに閉じている。**
+ *
+ * SPA は Tailwind を通るが（`src/client/index.css`）、**ここはビルドを通らない**ので
+ * 使えない。外部の CSS を参照しようにも、ビルド後のファイル名にはハッシュが付く。
+ *
+ * ⚠️ **色の値がここと `index.css` の2箇所にある。** 変えるときは両方。
+ * 増やさないこと（3箇所目を作るくらいなら、生成する仕組みを入れる）。
+ */
+const PAGE_STYLE = `
+  :root { --brand: #ffa2ab; --brand-soft: #fff5f6; --brand-deep: #b34452; --ink: #0f172a; }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; padding: 1rem; background: var(--brand-soft); color: var(--ink);
+    font-family: system-ui, -apple-system, "Hiragino Kaku Gothic ProN", sans-serif;
+    line-height: 1.6;
+  }
+  main { max-width: 28rem; margin: 0 auto; }
+  h1 { font-size: 1.25rem; margin: 0; }
+  .count { color: var(--brand-deep); font-weight: 700; margin: .25rem 0 1rem; }
+  ol { list-style: none; margin: 0; padding: 0; }
+  li {
+    display: flex; align-items: baseline; gap: .5rem;
+    padding: .4rem 0; border-bottom: 1px solid color-mix(in srgb, var(--brand) 40%, transparent);
+  }
+  .number { color: #64748b; font-size: .7rem; font-variant-numeric: tabular-nums; width: 2rem; text-align: right; }
+  .text { flex: 1; min-width: 0; overflow-wrap: anywhere; }
+  li.done .text { text-decoration: line-through; color: #94a3b8; }
+  li.done .number { color: var(--brand-deep); }
+  .date { color: var(--brand-deep); font-size: .65rem; font-variant-numeric: tabular-nums; }
+  footer { margin-top: 2rem; text-align: center; font-size: .7rem; }
+  footer a { color: var(--brand-deep); }
+`
+
+export interface SharedItem {
+  text: string
+  /** 完了日時（epoch ms）。未完了なら `null` */
+  completedAt: number | null
+}
+
+export interface SharedList {
+  title: string
+  items: SharedItem[]
+}
+
+/**
+ * 完了日を**日本時間**で描く。
+ *
+ * サーバーで描くので**閲覧者の時間帯が分からない。**
+ * マークダウン（#124）はクライアントで整形して避けたが、
+ * このページは JavaScript 無しで読めることを優先しているので、ここで決め打つ。
+ * 日本語のサービスなので日本時間にする。
+ */
+function formatCompletedAt(completedAt: number): string {
+  return new Intl.DateTimeFormat('ja-JP', {
+    timeZone: 'Asia/Tokyo',
+    dateStyle: 'medium',
+  }).format(new Date(completedAt))
+}
+
+/**
+ * ページの外枠。**共有ページと「見つからない」で同じものを使う。**
+ *
+ * 見た目を揃えるためだけでなく、**片方にだけ何かを足してしまう事故**を防ぐため。
+ */
+function layout(options: {
+  title: string
+  description: string
+  body: HtmlEscapedString | Promise<HtmlEscapedString>
+}) {
+  return html`<!doctype html>
+    <html lang="ja">
+      <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>${options.title}</title>
+        <meta name="description" content="${options.description}" />
+
+        <!-- OGP。画像（og:image）は #8 で足す -->
+        <meta property="og:type" content="website" />
+        <meta property="og:title" content="${options.title}" />
+        <meta property="og:description" content="${options.description}" />
+        <meta name="twitter:card" content="summary" />
+
+        <!--
+          🔴 検索には載せない（PRODUCT_SPEC.md §5.1）。
+          「URL を知っている人だけ」が前提なので、たどり着ける経路を増やさない。
+          SNS のカードは og: のメタタグを読むので、noindex でも壊れない
+        -->
+        <meta name="robots" content="noindex, nofollow" />
+
+        <style>
+          ${raw(PAGE_STYLE)}
+        </style>
+      </head>
+      <body>
+        <main>${options.body}</main>
+      </body>
+    </html>`
+}
+
+/**
+ * 共有ページ。**読み取り専用。編集の入口を出さない**（`PRODUCT_SPEC.md` §5.1）。
+ *
+ * 未入力の枠は出さない。**書いたものだけを見せる**
+ * （100行の空欄を人に見せる意味がない。マークダウン #124 と同じ判断）。
+ */
+export function renderSharePage(list: SharedList): HtmlEscapedString | Promise<HtmlEscapedString> {
+  const completed = list.items.filter((item) => item.completedAt !== null).length
+  const description = `${String(completed)} / ${String(list.items.length)} 達成`
+
+  return layout({
+    title: `${list.title}｜${SERVICE_NAME}`,
+    description,
+    body: html`
+      <h1>${list.title}</h1>
+      <p class="count">${description}</p>
+
+      <ol>
+        ${list.items.map(
+          (item, index) => html`
+            <li class="${item.completedAt === null ? '' : 'done'}">
+              <span class="number">${String(index + 1).padStart(3, '0')}</span>
+              <span class="text">${item.text}</span>
+              ${
+                item.completedAt === null
+                  ? raw('')
+                  : html`<span class="date">${formatCompletedAt(item.completedAt)}</span>`
+              }
+            </li>
+          `,
+        )}
+      </ol>
+
+      <footer><a href="/">${SERVICE_NAME}</a></footer>
+    `,
+  })
+}
+
+/**
+ * 見つからないとき。
+ *
+ * 🔴 **非公開のリストと、存在しない ID で同じものを返す。**
+ * 出し分けると「その ID は存在するが非公開」と分かってしまい、
+ * 推測不可能な ID にしている意味が薄れる（`requireOwnedList` と同じ考え方）。
+ */
+export function renderShareNotFound(): HtmlEscapedString | Promise<HtmlEscapedString> {
+  return layout({
+    title: `見つかりません｜${SERVICE_NAME}`,
+    description: 'このページは見つかりませんでした',
+    body: html`
+      <h1>見つかりません</h1>
+      <p>このリンクは無効になっているか、公開されていません。</p>
+      <footer><a href="/">${SERVICE_NAME}</a></footer>
+    `,
+  })
+}

--- a/apps/web/test/share-page.test.ts
+++ b/apps/web/test/share-page.test.ts
@@ -1,0 +1,211 @@
+import { exports } from 'cloudflare:workers'
+import { eq } from 'drizzle-orm'
+import { describe, expect, it } from 'vitest'
+
+import { items, lists } from '../src/db/schema'
+import { createTestUser, testBaseUrl, testDb } from './helpers'
+
+/**
+ * 共有公開ページのテスト（#137）。
+ *
+ * 🔴 見るのは **「見えてはいけないものが見えないこと」** が中心。
+ * 公開の判定はサーバー側にしかない（`CLAUDE.md` の不変条件）。
+ */
+
+const request = (path: string) => exports.default.fetch(new Request(`${testBaseUrl()}${path}`))
+
+/** 公開範囲を指定してリストを1つ作る。 */
+async function createList(options: {
+  visibility: 'private' | 'unlisted' | 'public'
+  title?: string
+  shareId?: string
+  email?: string
+}) {
+  const db = testDb()
+  const userId = await createTestUser(options.email ?? `${crypto.randomUUID()}@example.com`)
+  const id = crypto.randomUUID()
+  const shareId = options.shareId ?? crypto.randomUUID().replaceAll('-', '')
+
+  await db.insert(lists).values({
+    id,
+    userId,
+    title: options.title ?? '2026年の目標',
+    shareId,
+    visibility: options.visibility,
+  })
+
+  return { id, shareId, userId }
+}
+
+async function addItems(listId: string, rows: { text: string; completedAt?: Date }[]) {
+  await testDb()
+    .insert(items)
+    .values(
+      rows.map((row, position) => ({
+        id: crypto.randomUUID(),
+        listId,
+        text: row.text,
+        position,
+        completedAt: row.completedAt ?? null,
+      })),
+    )
+}
+
+describe('公開されているリスト', () => {
+  it('リンク限定公開なら見える', async () => {
+    const list = await createList({ visibility: 'unlisted' })
+    await addItems(list.id, [{ text: '南極に行く' }])
+
+    const res = await request(`/share/${list.shareId}`)
+    const body = await res.text()
+
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toContain('text/html')
+    expect(body).toContain('2026年の目標')
+    expect(body).toContain('南極に行く')
+  })
+
+  it('全公開でも見える（リストの見え方は同じ）', async () => {
+    const list = await createList({ visibility: 'public' })
+
+    expect((await request(`/share/${list.shareId}`)).status).toBe(200)
+  })
+
+  it('完了マークと完了日時が出る', async () => {
+    const list = await createList({ visibility: 'unlisted' })
+    await addItems(list.id, [
+      { text: '南極に行く', completedAt: new Date('2026-05-01T00:00:00.000Z') },
+      { text: 'オーロラを見る' },
+    ])
+
+    const body = await (await request(`/share/${list.shareId}`)).text()
+
+    expect(body).toContain('done')
+    // 日本時間で描く（サーバーは閲覧者の時間帯を知らない）
+    expect(body).toContain('2026')
+    expect(body).toContain('1 / 2 達成')
+  })
+
+  it('項目を並び順で出す', async () => {
+    const list = await createList({ visibility: 'unlisted' })
+    await addItems(list.id, [{ text: '1つ目' }, { text: '2つ目' }])
+
+    const body = await (await request(`/share/${list.shareId}`)).text()
+
+    expect(body.indexOf('1つ目')).toBeLessThan(body.indexOf('2つ目'))
+  })
+
+  it('🔴 読み取り専用。編集の入口を出さない', async () => {
+    const list = await createList({ visibility: 'unlisted' })
+    await addItems(list.id, [{ text: '南極に行く' }])
+
+    const body = await (await request(`/share/${list.shareId}`)).text()
+
+    expect(body).not.toContain('<form')
+    expect(body).not.toContain('<input')
+    expect(body).not.toContain('<button')
+  })
+
+  it('🔴 作者の情報が一切含まれない', async () => {
+    // PRODUCT_SPEC.md §5.1。どの公開面にも作者を出さない
+    const list = await createList({ visibility: 'public', email: 'owner@example.com' })
+    await addItems(list.id, [{ text: '南極に行く' }])
+
+    const body = await (await request(`/share/${list.shareId}`)).text()
+
+    expect(body).not.toContain('owner@example.com')
+    expect(body).not.toContain(list.userId)
+  })
+
+  it('🔴 編集用の ID が含まれない', async () => {
+    // 公開ページから編集用の URL を推測させない（TECH_STACK.md §7）
+    const list = await createList({ visibility: 'public' })
+
+    const body = await (await request(`/share/${list.shareId}`)).text()
+
+    expect(body).not.toContain(list.id)
+  })
+
+  it('🔴 利用者が書いた文字がそのまま HTML にならない', async () => {
+    const list = await createList({ visibility: 'public', title: '<script>alert(1)</script>' })
+    await addItems(list.id, [{ text: '<img src=x onerror=alert(1)>' }])
+
+    const body = await (await request(`/share/${list.shareId}`)).text()
+
+    expect(body).not.toContain('<script>alert(1)</script>')
+    expect(body).not.toContain('<img src=x')
+    expect(body).toContain('&lt;script&gt;')
+  })
+
+  it('検索に載せない', async () => {
+    // 「URL を知っている人だけ」が前提なので、たどり着ける経路を増やさない
+    const list = await createList({ visibility: 'public' })
+
+    const body = await (await request(`/share/${list.shareId}`)).text()
+
+    expect(body).toContain('noindex')
+  })
+
+  it('項目が0件でも壊れない', async () => {
+    const list = await createList({ visibility: 'unlisted' })
+
+    const res = await request(`/share/${list.shareId}`)
+
+    expect(res.status).toBe(200)
+    expect(await res.text()).toContain('0 / 0 達成')
+  })
+})
+
+describe('見えてはいけないもの', () => {
+  it('🔴 非公開は share_id を知っていても見えない', async () => {
+    const list = await createList({ visibility: 'private' })
+    await addItems(list.id, [{ text: '見えてはいけない' }])
+
+    const res = await request(`/share/${list.shareId}`)
+    const body = await res.text()
+
+    expect(res.status).toBe(404)
+    expect(body).not.toContain('見えてはいけない')
+    expect(body).not.toContain('2026年の目標')
+  })
+
+  it('🔴 非公開と、存在しない ID で応答が完全に一致する', async () => {
+    // 出し分けると「その ID は存在するが非公開」と分かってしまう
+    const list = await createList({ visibility: 'private' })
+
+    const hidden = await request(`/share/${list.shareId}`)
+    const missing = await request('/share/no-such-share-id')
+
+    expect(hidden.status).toBe(missing.status)
+    expect(await hidden.text()).toBe(await missing.text())
+  })
+
+  it('🔴 再発行した後は、古い URL から見えない', async () => {
+    const list = await createList({ visibility: 'public', shareId: 'old-share-id' })
+    await addItems(list.id, [{ text: '南極に行く' }])
+
+    expect((await request('/share/old-share-id')).status).toBe(200)
+
+    await testDb().update(lists).set({ shareId: 'new-share-id' }).where(eq(lists.id, list.id))
+
+    expect((await request('/share/old-share-id')).status).toBe(404)
+    expect((await request('/share/new-share-id')).status).toBe(200)
+  })
+
+  it('🔴 非公開に戻すと見えなくなる', async () => {
+    const list = await createList({ visibility: 'public' })
+
+    expect((await request(`/share/${list.shareId}`)).status).toBe(200)
+
+    await testDb().update(lists).set({ visibility: 'private' }).where(eq(lists.id, list.id))
+
+    expect((await request(`/share/${list.shareId}`)).status).toBe(404)
+  })
+
+  it('🔴 編集用の ID を渡しても見えない', async () => {
+    // share_id で引いているので当たらない。面が分かれていることの確認
+    const list = await createList({ visibility: 'public' })
+
+    expect((await request(`/share/${list.id}`)).status).toBe(404)
+  })
+})

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -41,7 +41,7 @@
   //
   // 予定しているサーバー側のルート（PRODUCT_SPEC.md §7 の URL 表）:
   // - /api/*            JSON API・認証のコールバック（このコミットで有効）
-  // - /share/:shareId   共有公開ページの SSR（#7）
+  // - /share/:shareId   共有公開ページの SSR（#137 で有効）
   // - /og/:shareId      OGP 画像（#8）
   // - /export/:listId   ダウンロード画像（#9）
   //
@@ -49,7 +49,7 @@
   // 静的ファイルの配信まで Worker の実行回数を消費するため、無料枠に効く。
   "assets": {
     "not_found_handling": "single-page-application",
-    "run_worker_first": ["/api/*"],
+    "run_worker_first": ["/api/*", "/share/*"],
   },
 
   // 作成系（リスト・項目・取り込み）のレート制限。**コンソールではなくここで設定する。**

--- a/packages/shared/src/validation.ts
+++ b/packages/shared/src/validation.ts
@@ -20,6 +20,15 @@ export type Visibility = (typeof VISIBILITIES)[number]
 export const visibilitySchema = z.enum(VISIBILITIES)
 
 /**
+ * 共有ページで**見せてよい**公開範囲（#137）。
+ *
+ * 🔴 **「非公開以外」ではなく、許可するものを列挙する。**
+ * 除外で書くと、後から公開範囲を1つ足したときに**黙って公開される。**
+ * ここに足す判断を必ず通す形にしておく。
+ */
+export const SHARED_VISIBILITIES = ['unlisted', 'public'] as const
+
+/**
  * 文字数は **UTF-16 のコード単位**で数える（`String.prototype.length`）。
  *
  * 見た目の文字数（書記素）で数える方が利用者の直感には近いが、


### PR DESCRIPTION
Closes #137

ログイン不要で読める、**読み取り専用**の公開ページ。

## 🔴 気をつけたこと

**`wrangler.jsonc` の `run_worker_first` に `/share/*` を足した。**
忘れると Worker に届かず SPA の index.html が返る。**404 にならないので気づきにくい**
（`wrangler.jsonc` に元から警告が書いてあった箇所）。

**公開してよい範囲を列挙して絞る**（`SHARED_VISIBILITIES = ['unlisted', 'public']`）。
「非公開以外」で書くと、**後から公開範囲を1つ足したときに黙って公開される。**
`packages/shared` に置いて、足す判断を必ず通す形にした。

**非公開と、存在しない ID で応答を完全に一致させる。**
出し分けると「その ID は存在するが非公開」と分かり、推測不可能な ID の意味が薄れる。

**作者を渡さない。** 描画に渡す型（`SharedList`）に作者が無いので、
**書こうと思っても書けない。** レスポンスに `userId` もメールも編集用 ID も含まれない
ことをテストで固定した。

## 判断したこと

**JSX ではなく `hono/html`。**

- **`${}` が既定でエスケープされる。** 利用者が書いた文字がそのまま入るので、
  取り違えると XSS になる。安全側が既定の方を選ぶ（`<script>` を入れるテストあり）
- JSX にすると Worker 側に `jsxImportSource: hono/jsx` が要る。
  **クライアントは React の JSX** なので、1つの Vite で2種類の JSX を扱うと壊れやすい

**完了日は日本時間で描く。** サーバーは閲覧者の時間帯を知らない。
マークダウン（#124）はクライアントで整形して避けたが、
**このページは JavaScript 無しで読めることを優先**したので決め打った。

**検索に載せない**（`noindex`）。「URL を知っている人だけ」が前提なので、
たどり着ける経路を増やさない。SNS のカードは og: を読むので壊れない。

**未入力の枠は出さない。** 100行の空欄を人に見せる意味がない（#124 と同じ判断）。

**OGP は og:title / og:description まで。** 画像（`og:image`）は #8。

⚠️ **色の値が `share.ts` と `index.css` の2箇所になった。**
SSR は Tailwind を通らず、ビルド後の CSS はファイル名にハッシュが付くため参照できない。
コメントに「変えるときは両方」と書いた。

## テスト（15件、全体 251 tests / 17 files）

見えてはいけないものを中心に:

- **非公開は `share_id` を知っていても見えない**
- **非公開と存在しない ID で応答が完全に一致する**
- **再発行後は古い URL から見えない / 非公開に戻すと見えなくなる**
- **編集用の ID を渡しても見えない**
- **作者の情報・編集用 ID が一切含まれない**
- **利用者が書いた文字がそのまま HTML にならない**
- 読み取り専用（`form` / `input` / `button` が無い）

⚠️ 見た目と、別のブラウザ（ログアウト状態）からの確認は利用者に依頼する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)