### PR TITLE
共有の画面（公開範囲の切替・リンクのコピー・再発行）

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,5 +9,8 @@
       "Bash(npm run lint)",
       "Bash(npm test)"
     ]
+  },
+  "enabledPlugins": {
+    "code-review@claude-plugins-official": true
   }
 }

--- a/apps/web/src/client/App.tsx
+++ b/apps/web/src/client/App.tsx
@@ -5,6 +5,7 @@ import { Link, Route, Switch, useLocation } from 'wouter'
 import { ExportPage } from './ExportPage'
 import { ListPage } from './ListPage'
 import { ListsPage } from './ListsPage'
+import { SharePage } from './SharePage'
 import { Notice } from './Notice'
 import { signOutRequestInit, toSessionState, type SessionState } from './model'
 
@@ -102,6 +103,10 @@ export function App() {
               関係のある経路を近くに並べておく */}
           <Route path="/lists/:listId/export">
             {(params) => <ExportPage session={session} listId={params.listId} />}
+          </Route>
+
+          <Route path="/lists/:listId/share">
+            {(params) => <SharePage session={session} listId={params.listId} />}
           </Route>
 
           <Route path="/lists/:listId">

--- a/apps/web/src/client/ListsPage.tsx
+++ b/apps/web/src/client/ListsPage.tsx
@@ -329,6 +329,14 @@ function ListRow({
           行にボタンを並べただけでは、どちらが何のためのものか分からなかった
         */}
         <Link
+          href={`/lists/${list.id}/share`}
+          aria-label={`${list.title} の共有設定`}
+          className="shrink-0 px-1 text-xs text-brand-deep underline"
+        >
+          共有
+        </Link>
+
+        <Link
           href={`/lists/${list.id}/export`}
           aria-label={`${list.title} を書き出す`}
           className="shrink-0 px-1 text-xs text-brand-deep underline"

--- a/apps/web/src/client/SharePage.tsx
+++ b/apps/web/src/client/SharePage.tsx
@@ -1,0 +1,257 @@
+import { type Visibility } from '@yaritai100list/shared'
+import { useCallback, useEffect, useState } from 'react'
+import { Link } from 'wouter'
+
+import { api } from './api'
+import { Notice } from './Notice'
+import { shareUrl, type SessionState } from './model'
+
+/**
+ * リストの共有設定（#138）。
+ *
+ * 公開範囲は3段階だが、**リストの見え方は2値**（非公開か、URL を知っていれば見えるか）。
+ * 全公開との差は**項目が取り入れ面に出るかどうかだけ**（`PRODUCT_SPEC.md` §5.1）。
+ * 選ぶ人にはそれが分からないので、**選択肢ごとに何が起きるかを書く。**
+ */
+
+interface ListState {
+  id: string
+  title: string
+  shareId: string
+  visibility: Visibility
+}
+
+type State = { status: 'loading' } | { status: 'failed' } | { status: 'ready'; list: ListState }
+
+/** 選択肢の説明。**「何ができるか」だけでなく「何が起きるか」を書く。** */
+const CHOICES: { value: Visibility; label: string; description: string }[] = [
+  {
+    value: 'private',
+    label: '非公開',
+    description: '自分だけが見られます。リンクを渡しても開けません',
+  },
+  {
+    value: 'unlisted',
+    label: 'リンクを知っている人だけ',
+    description: 'URL を渡した人が見られます。検索には出ません',
+  },
+  {
+    value: 'public',
+    label: '全体に公開',
+    description:
+      'URL を渡した人が見られます。さらに、書いた項目が「やりたいことを探す場所」に出ます（この場所は準備中です）',
+  },
+]
+
+export function SharePage({ session, listId }: { session: SessionState; listId: string }) {
+  // ログインが要る画面。**未ログインでは開かせない**（#112 と同じ扱い）
+  if (session.status !== 'authenticated') {
+    return <SignInRequired session={session} />
+  }
+
+  return <SharePageBody listId={listId} />
+}
+
+function SignInRequired({ session }: { session: SessionState }) {
+  if (session.status === 'loading') return <p className="py-8 text-slate-500">読み込み中</p>
+
+  if (session.status === 'error') {
+    return (
+      <Notice tone="warn">
+        ログイン状態を確認できないため、この画面を開けません。通信を確かめてください
+      </Notice>
+    )
+  }
+
+  return (
+    <Notice tone="info">
+      共有の設定をするには
+      <a href="/api/login/google" className="font-bold text-brand-deep underline">
+        Googleでログイン
+      </a>
+      してください
+    </Notice>
+  )
+}
+
+function SharePageBody({ listId }: { listId: string }) {
+  const [state, setState] = useState<State>({ status: 'loading' })
+  const [message, setMessage] = useState<string | null>(null)
+  const [copied, setCopied] = useState(false)
+  const [confirmingRegenerate, setConfirmingRegenerate] = useState(false)
+
+  const load = useCallback(async () => {
+    try {
+      const res = await api.api.lists[':listId'].$get({ param: { listId } })
+      if (!res.ok) {
+        setState({ status: 'failed' })
+        return
+      }
+
+      const { list } = await res.json()
+      setState({ status: 'ready', list })
+    } catch {
+      setState({ status: 'failed' })
+    }
+  }, [listId])
+
+  useEffect(() => {
+    void load()
+  }, [load])
+
+  if (state.status === 'loading') return <p className="py-8 text-slate-500">読み込み中</p>
+
+  if (state.status === 'failed') {
+    return (
+      <Notice tone="warn">
+        このリストを読み込めませんでした。通信を確かめて、開き直してください
+      </Notice>
+    )
+  }
+
+  const { list } = state
+  const url = shareUrl(window.location.origin, list.shareId)
+
+  const changeVisibility = async (visibility: Visibility) => {
+    setMessage(null)
+    setCopied(false)
+
+    const res = await api.api.lists[':listId'].$patch({ param: { listId }, json: { visibility } })
+
+    if (!res.ok) {
+      setMessage('公開範囲を変えられませんでした。通信を確かめてください')
+      return
+    }
+
+    await load()
+  }
+
+  const regenerate = async () => {
+    setMessage(null)
+    setCopied(false)
+    setConfirmingRegenerate(false)
+
+    const res = await api.api.lists[':listId']['share-id'].$post({ param: { listId } })
+
+    if (!res.ok) {
+      setMessage('作り直せませんでした。通信を確かめてください')
+      return
+    }
+
+    setMessage('新しいリンクにしました。前のリンクはもう開けません')
+    await load()
+  }
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(url)
+      setCopied(true)
+    } catch {
+      // 権限が無い環境がある。**黙って失敗しない。** URL は下に出してあるので選べる
+      setMessage('コピーできませんでした。下の URL を選んでコピーしてください')
+    }
+  }
+
+  return (
+    <div>
+      <Link href="/lists" className="text-xs text-brand-deep underline">
+        ← すべてのリスト
+      </Link>
+
+      <h1 className="mt-2 text-xl font-bold text-slate-900">共有</h1>
+      <p className="mt-1 text-sm text-slate-600">{list.title}</p>
+
+      {message !== null && (
+        <div role="status" className="mt-3">
+          <Notice tone="info">{message}</Notice>
+        </div>
+      )}
+
+      <section className="mt-6 rounded bg-white px-3 py-3">
+        <h2 className="font-bold text-slate-900">だれが見られるか</h2>
+
+        <ul className="mt-2">
+          {CHOICES.map((choice) => (
+            <li key={choice.value} className="border-t border-brand/30 first:border-t-0">
+              <label className="flex cursor-pointer gap-2 py-2">
+                <input
+                  type="radio"
+                  name="visibility"
+                  className="mt-1 shrink-0"
+                  checked={list.visibility === choice.value}
+                  onChange={() => void changeVisibility(choice.value)}
+                />
+                <span className="min-w-0">
+                  <span className="text-sm text-slate-900">{choice.label}</span>
+                  <span className="block text-xs text-slate-600">{choice.description}</span>
+                </span>
+              </label>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      {/*
+        🔴 **非公開のときは URL を出さない**（#138）。
+        出すと「このリンクを渡せば見える」と誤解する。実際は開けない
+      */}
+      {list.visibility === 'private' ? (
+        <Notice tone="info">
+          非公開なので、共有できる URL はありません。上で公開範囲を変えると出ます
+        </Notice>
+      ) : (
+        <section className="mt-4 rounded bg-white px-3 py-3">
+          <h2 className="font-bold text-slate-900">共有する URL</h2>
+
+          <p className="mt-2 rounded bg-brand-soft px-2 py-2 text-[11px] break-all text-slate-700">
+            {url}
+          </p>
+
+          <button
+            type="button"
+            onClick={() => void copy()}
+            className="mt-3 w-full rounded bg-brand-deep px-3 py-2 text-white"
+          >
+            {copied ? 'コピーしました' : 'URL をコピー'}
+          </button>
+
+          <p className="mt-4 text-xs text-slate-600">
+            渡した相手に見せたくなくなったら、リンクを作り直せます。
+            <strong>作り直すと、いまの URL は開けなくなります。</strong>
+          </p>
+
+          {confirmingRegenerate ? (
+            <div className="mt-2 flex gap-2">
+              <button
+                type="button"
+                onClick={() => void regenerate()}
+                className="flex-1 rounded bg-brand-deep px-3 py-2 text-white"
+              >
+                作り直す
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  setConfirmingRegenerate(false)
+                }}
+                className="flex-1 rounded border border-brand px-3 py-2 text-slate-600"
+              >
+                やめる
+              </button>
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={() => {
+                setConfirmingRegenerate(true)
+              }}
+              className="mt-2 w-full rounded border border-brand px-3 py-2 text-brand-deep"
+            >
+              リンクを作り直す
+            </button>
+          )}
+        </section>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/client/model.ts
+++ b/apps/web/src/client/model.ts
@@ -448,6 +448,17 @@ export function toLocalList(list: { title: string }, items: RemoteItem[]): Local
 }
 
 /**
+ * 共有ページの URL。**組み立てはここ1箇所**（#138）。
+ *
+ * 画面の複数箇所で組み立てると、`/share/` を書き間違えたときに片方だけ直る。
+ * オリジンを引数で受け取るのは、`window` を `model.ts` に持ち込まないため
+ * （ここは workerd でテストする層。`TECH_STACK.md` §10）。
+ */
+export function shareUrl(origin: string, shareId: string): string {
+  return `${origin}/share/${shareId}`
+}
+
+/**
  * 取り込み（`POST /api/lists/import`）に送る内容。
  *
  * **完了の状態は送らない。** 未ログインでは印を付けられないので（#77）

--- a/apps/web/test/client-model.test.ts
+++ b/apps/web/test/client-model.test.ts
@@ -18,6 +18,7 @@ import {
   removeItem,
   renameList,
   serializeList,
+  shareUrl,
   sortListsByCreated,
   setItemCompletedAt,
   toCompletionPermission,
@@ -354,6 +355,17 @@ describe('pickCurrentListId', () => {
 
   it('1つも無ければ null（呼び出し側が作る）', () => {
     expect(pickCurrentListId([])).toBeNull()
+  })
+})
+
+describe('shareUrl', () => {
+  it('共有ページの URL を組み立てる', () => {
+    expect(shareUrl('https://example.com', 'abc123')).toBe('https://example.com/share/abc123')
+  })
+
+  it('組み立ては1箇所（画面で書き分けない）', () => {
+    // 複数箇所で組み立てると、/share/ を書き間違えたときに片方だけ直る
+    expect(shareUrl('http://localhost:5173', 'x')).toContain('/share/')
   })
 })
 


### PR DESCRIPTION
Closes #138

`/lists/:listId/share`。一覧の行からは「共有」で遷移する。

```
← すべてのリスト

共有
2026年の目標

┌─ だれが見られるか ─────────────────────────┐
│ ○ 非公開                                   │
│   自分だけが見られます。                   │
│   リンクを渡しても開けません               │
│ ● リンクを知っている人だけ                 │
│   URL を渡した人が見られます。検索には出ません │
│ ○ 全体に公開                               │
│   URL を渡した人が見られます。さらに、     │
│   書いた項目が「やりたいことを探す場所」に │
│   出ます（この場所は準備中です）           │
└────────────────────────────────────────────┘

┌─ 共有する URL ─────────────────────────────┐
│ https://.../share/8f3a...                  │
│ [ URL をコピー ]                           │
│                                            │
│ 渡した相手に見せたくなくなったら、リンクを │
│ 作り直せます。作り直すと、いまの URL は    │
│ 開けなくなります。                         │
│ [ リンクを作り直す ]                       │
└────────────────────────────────────────────┘
```

## 判断したこと

**選択肢ごとに「何が起きるか」を書いた。**
公開範囲は3段階だが、**リストの見え方は2値**（非公開か、URL を知っていれば見えるか）。
全公開との差は**項目が取り入れ面に出るかどうかだけ**で、選ぶ人には分からない。

**全公開の説明に「（この場所は準備中です）」と書いた。**
取り入れ面（#10）はまだ無い。**無いものを「出ます」とだけ書くと嘘になる。**

🔴 **非公開のときは URL を出さない。**
出すと「このリンクを渡せば見える」と誤解するが、実際は開けない。

**再発行は確認を挟む。** 押す前に「いまの URL は開けなくなります」と伝える。
削除の確認（#106）と同じ形にした。

**URL の組み立ては `model.ts` の純関数**（`shareUrl`）。
複数箇所で組み立てると、`/share/` を書き間違えたときに片方だけ直る。
`window` を持ち込まないようオリジンは引数で受け取る（テストできる層に置くため）。

## 確認

`typecheck` / `lint` / `format:check` / `test`（**253 tests**）/ `build` が緑。

⚠️ **利用者に確認を依頼したいこと**（ログインが要るので私からは確かめられない）:

- 公開範囲を「リンクを知っている人だけ」にして、**別のブラウザ（ログアウト状態）で
  URL を開くと見えるか**
- **非公開に戻すと見えなくなるか**
- **リンクを作り直すと、前の URL が開けなくなるか**

🤖 Generated with [Claude Code](https://claude.com/claude-code)