### PR TITLE
画面の幅を広げる

### DIFF
--- a/apps/web/src/client/App.tsx
+++ b/apps/web/src/client/App.tsx
@@ -64,9 +64,17 @@ export function App() {
 
   return (
     <div className="min-h-dvh bg-brand-soft">
-      {/* モバイル縦1カラムを主対象にする（PRODUCT_SPEC.md §4.5）。
-          広い画面では中央に寄せるだけで、列は増やさない */}
-      <div className="mx-auto max-w-md px-4 pb-24">
+      {/*
+        モバイル縦1カラムを主対象にする（PRODUCT_SPEC.md §4.5）。
+        広い画面では中央に寄せるだけで、**列は増やさない。**
+
+        🔴 **幅を決めるのはここ1箇所。** 画面ごとに別の幅を書かない（#143）。
+
+        `max-w-xl`（36rem）。`max-w-md`（28rem）では項目の入力欄が窮屈だった。
+        ⚠️ **効くのは広い画面だけ。** よくある電話の横幅（約 24rem）は
+        どちらの上限より狭いので、モバイルの見え方は変わらない
+      */}
+      <div className="mx-auto max-w-xl px-4 pb-24">
         <header className="-mx-4 mb-4 flex items-baseline justify-between bg-brand px-4 py-3">
           <Link href="/" className="text-xs font-bold text-slate-900">
             {SERVICE_NAME}


### PR DESCRIPTION
Closes #143

`max-w-md`（28rem）→ **`max-w-xl`（36rem）**。

`App.tsx` の1箇所を変えただけで、全画面に効く。
**幅を決める場所は1つのまま**にしてある（画面ごとに別の幅を書かない）。

## ⚠️ 効くのは広い画面だけ

**よくある電話の横幅は約 24rem（390px）** で、`max-w-md`（28rem）よりも狭い。
つまり**モバイルでは元から上限に当たっておらず、見え方は変わらない。**
今回広くなるのはタブレットと PC。

「狭い」と感じたのが PC でなら解消しますが、**電話で狭いと感じていた場合は
この変更では変わりません。** その場合は原因が別（余白・文字サイズ・要素の詰まり）なので、
どこが狭く見えたか教えてください。

この点はコメントにも残した（次に読む人が「広げたのに変わらない」と混乱しないように）。

## 確認

`typecheck` / `lint` / `format:check` / `test`（253 tests）/ `build` が緑。
見た目はテストで担保できないので、**目視は利用者に依頼する**（`TECH_STACK.md` §10）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)