### PR TITLE
共有への導線を足す（リストの画面から / URL から）

### DIFF
--- a/apps/web/src/client/ListPage.tsx
+++ b/apps/web/src/client/ListPage.tsx
@@ -4,6 +4,8 @@ import {
   LIST_TITLE_MAX_LENGTH,
 } from '@yaritai100list/shared'
 
+import { Link } from 'wouter'
+
 import { ListEditor } from './ListEditor'
 import { Notice } from './Notice'
 import { toCompletionPermission, type SessionState } from './model'
@@ -103,6 +105,23 @@ function ListPageBody({
       {screen.status === 'ready' && (
         <>
           <StorageNotice controller={controller} session={session} />
+
+          {/*
+            共有への導線（#153）。**`/` でも出す。**
+            開いているリストの ID は `screen.key`（サーバーのときは `listId`）。
+
+            未ログイン（`source === 'local'`）では出さない。共有はログインが要る
+          */}
+          {screen.source === 'server' && (
+            <p className="mb-2 text-right">
+              <Link
+                href={`/lists/${screen.key}/share`}
+                className="text-xs text-brand-deep underline"
+              >
+                共有の設定
+              </Link>
+            </p>
+          )}
 
           {rejection !== null && (
             <p role="alert" className="mb-2 rounded bg-white px-3 py-2 text-sm text-brand-deep">

--- a/apps/web/src/client/SharePage.tsx
+++ b/apps/web/src/client/SharePage.tsx
@@ -202,8 +202,20 @@ function SharePageBody({ listId }: { listId: string }) {
         <section className="mt-4 rounded bg-white px-3 py-3">
           <h2 className="font-bold text-slate-900">共有する URL</h2>
 
-          <p className="mt-2 rounded bg-brand-soft px-2 py-2 text-[11px] break-all text-slate-700">
+          {/*
+            URL そのものを開けるようにする（#153）。**渡す前に見え方を確かめられる。**
+            別のタブで開くのは、設定の画面に戻れなくなると不便なため
+          */}
+          <a
+            href={url}
+            target="_blank"
+            rel="noreferrer"
+            className="mt-2 block rounded bg-brand-soft px-2 py-2 text-[11px] break-all text-brand-deep underline"
+          >
             {url}
+          </a>
+          <p className="mt-1 text-xs text-slate-500">
+            押すと、渡した相手に見える画面が別のタブで開きます
           </p>
 
           <button


### PR DESCRIPTION
Closes #153

## 1. リストの画面から共有の設定へ

いままでは「すべてのリスト」を経由しないと辿り着けなかった。

**`/`（最後に更新したリスト）でも出る。** 開いているリストの ID は
`useList` の `screen.key`（サーバーのときは `listId`）で分かるので、
`/lists/:listId` と同じ導線を出せる。

**未ログイン（ローカルのリスト）では出さない。** 共有はログインが要る。

## 2. 共有する URL から共有ページへ

URL そのものをリンクにした。**渡す前に、相手に見える画面を確かめられる。**
「押すと、渡した相手に見える画面が別のタブで開きます」と添えた。

**別のタブで開く。** 同じタブだと設定の画面に戻れなくなって不便。

## 確認

`typecheck` / `lint` / `format:check` / `test`（253 tests）/ `build` が緑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)