### PR TITLE
未入力の行と入力済みの行の高さを揃える

### DIFF
--- a/apps/web/src/client/ListEditor.tsx
+++ b/apps/web/src/client/ListEditor.tsx
@@ -183,7 +183,17 @@ function isCommitKey(event: React.KeyboardEvent): boolean {
   return event.key === 'Enter' && !event.nativeEvent.isComposing
 }
 
-const ROW = 'flex items-center gap-2 py-1.5'
+/**
+ * 行の骨格。🔴 **高さをここで決める**（#147）。
+ *
+ * 中身に決めさせると、**入力欄のある行（32px）と、無い行（丸だけで 24px）で
+ * 段差ができる。** 100行並ぶ画面なので、書けた枠と空の枠の境目で目立つ。
+ *
+ * `min-h-11`（44px）は、いまの入力欄（`text-base` + `py-1` = 32px）に
+ * 上下の余白（`py-1.5` = 12px）を足した高さ。**中身が変わっても行は動かない。**
+ * `h-11` にしないのは、将来この中に背の高いものを置いたときに切れないため。
+ */
+const ROW = 'flex min-h-11 items-center gap-2 py-1.5'
 const ROW_BORDER = 'border-b border-brand/40'
 
 /**


### PR DESCRIPTION
Closes #147

**行の高さを `ROW`（1箇所）で決めるようにした。**

## 原因

3種類の行が同じ `ROW`（`py-1.5`）を使いながら、**高さを中身が決めていた。**

| 行 | いちばん背の高い中身 | 行の高さ |
|---|---|---|
| `ItemRow` / `NextRow` | 入力欄（`text-base` + `py-1` = **32px**） | 44px |
| `EmptyRow` | 丸だけ（`size-6` = **24px**） | **36px** |

100行並ぶ画面なので、**書けた枠と空の枠の境目で 8px の段差**になっていた。

## 直し方

`ROW` に `min-h-11`（44px）を持たせた。
いまの入力欄（32px）＋上下の余白（12px）と同じ高さなので、
**入力済みの行の見た目は変わらず、空の行だけが揃う。**

`h-11` にしなかったのは、**将来この中に背の高いものを置いたときに切れない**ようにするため。

## 確認

`typecheck` / `lint` / `format:check` / `test`（253 tests）/ `build` が緑。
⚠️ 段差が消えたかは**目視を依頼する**（書けた枠と空の枠の境目、完了した行の前後）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)