### PR TITLE
README を、最低限の情報だけに整理する

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,37 +2,31 @@
 
 100個のやりたいことを書き溜めて、叶えたら印を付けるアプリ。
 
-ログインせずに使え（ブラウザに保存）、ログインすると永続保存と複数のマイリストが使える。
-将来的にリストの共有、SNS カード（OGP）、画像出力、他人のやりたいことの取り入れに対応する。
+ログインせずに使え（ブラウザに保存）、ログインするとサーバーに保存され、
+リストを複数持てて、人に共有できる。
 
-**公開先: https://yaritai100list.aiandrox.workers.dev**（中身はまだ土台のみ）
+**https://yaritai100list.aiandrox.workers.dev**
 
-**現在の状態: 土台を構築中。**
-`apps/web` が Hono + D1 + Drizzle で動くところまで来ている。
-進捗は[イシュー](https://github.com/aiandrox/yaritai100list/issues)を参照。
+**進捗と作業中の内容は[イシュー](https://github.com/aiandrox/yaritai100list/issues)にある。**
+このファイルには**変わらないことだけ**を書く。
 
 ## ドキュメント
 
 | ファイル | 内容 |
 |---|---|
-| [PRODUCT_SPEC.md](./PRODUCT_SPEC.md) | プロダクト仕様。何を作るか |
-| [TECH_STACK.md](./TECH_STACK.md) | 技術構成。なぜその選択をしたか、各案のメリット・リスク |
-| [MEMO.md](./MEMO.md) | 申し送り。実装順序を決めた理由、命名の検討過程 |
+| [PRODUCT_SPEC.md](./PRODUCT_SPEC.md) | プロダクト仕様。**何を作るか**と、決めた理由 |
+| [TECH_STACK.md](./TECH_STACK.md) | 技術構成。**なぜその選択をしたか**と、踏んだ落とし穴 |
 | [docs/workflow.md](./docs/workflow.md) | **開発の進め方。** イシューの進め方、PR の流れ、完了の条件 |
 | [docs/console-settings.md](./docs/console-settings.md) | **コンソールでしか設定できない項目**と現在値 |
+| [MEMO.md](./MEMO.md) | 申し送り。実装順序を決めた理由、命名の検討過程 |
+| [CLAUDE.md](./CLAUDE.md) | AI 向けの入口。**不変条件**（破ってはいけない約束）はここ |
 
 読む順番は `PRODUCT_SPEC.md` → `TECH_STACK.md`。
-作業に入るときは `docs/workflow.md`。
-
-## 進め方
-
-作業単位は GitHub の[イシュー](https://github.com/aiandrox/yaritai100list/issues)で管理する。
-親イシュー #1〜#10 が機能単位で、`MVP`（#1〜#6）と `Post-MVP`（#7〜#10）の2マイルストーンに分かれる。
-着手時に 1 PR 単位のサブイシューへ分割する。詳細は [docs/workflow.md](./docs/workflow.md)。
+**手を動かす前に `docs/workflow.md`。**
 
 ## ローカル開発
 
-Cloudflare のアカウントもログインも不要。すべてローカルで動く。
+Cloudflare のアカウントもログインも不要。**すべてローカルで動く。**
 
 ```sh
 npm install
@@ -42,24 +36,11 @@ npm run dev                                          # http://localhost:5173
 npm run typecheck && npm run lint && npm test        # PR を出す前に緑にする
 ```
 
-| コマンド | 内容 |
-|---|---|
-| `npm run dev` | Vite。**SPA と Worker の両方**が1プロセスで動く（Worker は workerd で実行される） |
-| `npm test` | Vitest + Miniflare。workerd の中で走り、D1 はインメモリ |
-| `npm run build --workspace @yaritai100list/web` | `dist/client`（SPA）と `dist/yaritai100list`（Worker）を出す |
-| `npm run db:generate --workspace @yaritai100list/web -- --name <名前>` | スキーマからマイグレーションを生成（**名前は必ず付ける**） |
-| `npm run db:migrate --workspace @yaritai100list/web` | ローカル D1 に適用 |
-
-**Vite の dev サーバーは IPv6（`[::1]`）でだけ listen する。**
-`curl http://127.0.0.1:5173` は接続できないので `localhost` を使う。
-
-環境変数は `apps/web/.dev.vars.example` を `.dev.vars` にコピーして使う。
-**通常のローカル開発では何も入れなくても動く**（`SENTRY_DSN` が空ならエラー通知は無効）。
-
-**`no such table` が出たら `db:migrate` を忘れている。**
-ローカル D1 の保存先は `wrangler.jsonc` の `database_id` ごとに分かれるため、
-その値を変えると**空のデータベースに切り替わる**（`.wrangler/state/` 配下）。
-テストは別のインメモリ D1 を使うので、テストが緑でもこの状態は起こりうる。
+- `npm run dev` は **SPA と Worker の両方**が1プロセスで動く（Worker は workerd で実行される）
+- `npm test` は workerd の中で走り、D1 はインメモリ
+- 環境変数は `apps/web/.dev.vars.example` を `.dev.vars` にコピー。
+  **通常は何も入れなくても動く**
+- 詰まったときは `docs/workflow.md` の「ローカルで詰まったとき」
 
 ## 構成
 
@@ -68,23 +49,10 @@ apps/
   web/        Cloudflare Workers（Hono + React SPA + D1）
   render/     Deno Deploy（Satori による画像生成）  ← 未作成
 packages/
-  shared/     型・Zod スキーマ・定数
+  shared/     型・Zod スキーマ・定数（サーバー・クライアント・画像生成の3箇所から使う）
 ```
 
-`apps/render` は OGP 画像に着手する時点で作る
-（Deno なので、npm workspaces に含めるかは `TECH_STACK.md` §12-2 の結論次第）。
-**ディレクトリ名は Deno Deploy のアプリ名 `yaritai100list-render` に合わせている**
-（`docs/console-settings.md`）。`image` にしないのは、PNG 以外の出力が来たときに名前がズレるため。
-
-デプロイ先は2つだが、**リポジトリは1つ**にする。
+**デプロイ先は2つになるが、リポジトリは1つ。**
 分けると、どのリポジトリが生きているのかを追えなくなる。
 
-## 技術構成の要点
-
-- Cloudflare Workers + D1 + Hono + React（SPA）+ Drizzle + Zod
-- 認証は Better Auth（セッションは D1 のみ。KV の `secondaryStorage` は使わない）
-- 画像生成のみ Deno Deploy（Satori + `@resvg/resvg-wasm`）
-- カスタムドメインは使わず `*.workers.dev`
-- **月額 ¥0**（行き詰まったら Cloudflare Workers Paid の $5 に寄せる）
-
-詳細と選定理由は [TECH_STACK.md](./TECH_STACK.md) を参照。
+`main` にマージすると**自動でデプロイされる**（`.github/workflows/deploy.yml`）。

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -121,6 +121,18 @@ npm run db:migrate:remote --workspace @yaritai100list/web   # スキーマを変
   値を持っていないため。必要になったら利用者に
   `wrangler secret put <名前>` の実行を依頼する
 
+### ローカルで詰まったとき
+
+**コードを読んでも分からない類**なので残しておく（README から移した）。
+
+- **`no such table` が出たら `db:migrate` を忘れている。**
+  ローカル D1 の保存先は `wrangler.jsonc` の `database_id` ごとに分かれるため、
+  **その値を変えると空のデータベースに切り替わる**（`.wrangler/state/` 配下）。
+  テストは別のインメモリ D1 を使うので、**テストが緑でもこの状態は起こりうる**
+- **Vite の dev サーバーは IPv6（`[::1]`）でだけ listen する。**
+  `curl http://127.0.0.1:5173` は接続できない。`localhost` を使う
+- **デプロイ直後の数秒は 404 や `error code: 1042` が返る。** 伝播待ち（上記）
+
 ### 依存関係を触るとき
 
 **`package-lock.json` を作り直さない。** 削除して `npm install` し直すと、


### PR DESCRIPTION
Closes #157

**都度更新される内容はイシューで管理している**ので、README には
「**何のアプリで、どう動かして、どこを見ればいいか**」だけを置いた（90行 → 62行）。

## 外したもの

| 外したもの | 理由 |
|---|---|
| 「現在の状態: 土台を構築中」「中身はまだ土台のみ」 | **古い。** 状態はイシューを見れば分かる |
| コマンドの一覧表 | `package.json` を見れば分かるものが多い |
| 技術構成の要点 | `TECH_STACK.md` にある。2箇所あると片方が古くなる |
| `apps/render` の命名の経緯 | `docs/console-settings.md` と `TECH_STACK.md` にある |

冒頭に「**このファイルには変わらないことだけを書く**」と明記した。
次に触る人（AI 含む）が、状態を書き足さないようにするため。

## 🔴 消さずに移したもの

**ローカルで詰まったときの知識は消さない**（コードを読んでも分からない類）。
`docs/workflow.md` に「ローカルで詰まったとき」を作って移した。

- `no such table` はローカル D1 のマイグレーション忘れ。
  **`database_id` を変えると空のデータベースに切り替わる**（テストが緑でも起こりうる）
- **Vite の dev サーバーは IPv6（`[::1]`）でだけ listen する**
- デプロイ直後の数秒は 404 や `1042`（元から §5 にあったものと並べた）

## 足したもの

- **`CLAUDE.md` への導線。** 不変条件がそこにあると分かる方がよい
- `main` にマージすると自動でデプロイされること（#117）

🤖 Generated with [Claude Code](https://claude.com/claude-code)