### PR TITLE
達成した項目の数も画面に出す

### DIFF
--- a/apps/web/src/client/ListEditor.tsx
+++ b/apps/web/src/client/ListEditor.tsx
@@ -5,7 +5,14 @@ import {
 } from '@yaritai100list/shared'
 import { useEffect, useRef, useState } from 'react'
 
-import { filledCount, toSlots, type CompletionPermission, type Item, type LocalList } from './model'
+import {
+  completedCount,
+  filledCount,
+  toSlots,
+  type CompletionPermission,
+  type Item,
+  type LocalList,
+} from './model'
 
 /**
  * リストの編集画面。**ここに置くのは描画と入力欄の下書きだけ。**
@@ -40,6 +47,7 @@ export function ListEditor({
   onRemoveItem,
 }: ListEditorProps) {
   const filled = filledCount(list)
+  const completed = completedCount(list)
 
   /**
    * 完了を押せないときに、その行の下へ理由を出すための状態。
@@ -92,11 +100,26 @@ export function ListEditor({
     <div>
       <ListTitleField title={list.title} onRename={onRenameList} />
 
-      <p className="mt-1 flex items-baseline gap-1 text-brand-deep">
-        <span className="text-2xl font-bold tabular-nums">{filled}</span>
-        <span className="text-sm tabular-nums">/ {ITEMS_PER_LIST_MAX}</span>
-        {/* 「達成度ではなく埋まり具合」（PRODUCT_SPEC.md §3）と分かる言葉を添える */}
-        <span className="text-xs text-slate-500">書けた</span>
+      {/*
+        2つの数字は**別のことを言っている**（#145）。
+        「書けた」は 100 という枠がまだ埋まっていないことを見せる（PRODUCT_SPEC.md §1）。
+        「やった」はそのうち何個叶えたか。**片方に置き換えない。**
+
+        分母はどちらも 100（上限）。マークダウン（#129）が分母を入力済みの数に
+        しているのは、あちらが転載用で読む人が知りたいのが達成の割合だから
+      */}
+      <p className="mt-1 flex items-baseline gap-3 text-brand-deep">
+        <span className="flex items-baseline gap-1">
+          <span className="text-2xl font-bold tabular-nums">{filled}</span>
+          <span className="text-sm tabular-nums">/ {ITEMS_PER_LIST_MAX}</span>
+          <span className="text-xs text-slate-500">書けた</span>
+        </span>
+
+        <span className="flex items-baseline gap-1">
+          <span className="text-2xl font-bold tabular-nums">{completed}</span>
+          <span className="text-sm tabular-nums">/ {ITEMS_PER_LIST_MAX}</span>
+          <span className="text-xs text-slate-500">やった</span>
+        </span>
       </p>
 
       <ol className="mt-4">

--- a/apps/web/src/client/model.ts
+++ b/apps/web/src/client/model.ts
@@ -313,6 +313,22 @@ export function filledCount(list: LocalList): number {
   return list.items.length
 }
 
+/**
+ * 「やった」印を付けた数（#145）。
+ *
+ * **埋まり具合（`filledCount`）を置き換えない。** 並べて出す。
+ * 100 という枠がまだ埋まっていないことを見せるのがあちらの役目で、
+ * こちらは「そのうち何個叶えたか」。**別のことを言っている。**
+ *
+ * ⚠️ 画面に出すときの分母は **100（上限）** にする。
+ * マークダウン（#129）は分母を「入力済みの数」にしているが、あちらは**転載用**で、
+ * 読む人が知りたいのは達成の割合。画面は**枠がまだ空いていること**を見せる場所なので、
+ * 分母を揃えない。
+ */
+export function completedCount(list: LocalList): number {
+  return list.items.filter((item) => item.completedAt !== null).length
+}
+
 // --- 保存 -------------------------------------------------------------------
 
 /**

--- a/apps/web/test/client-model.test.ts
+++ b/apps/web/test/client-model.test.ts
@@ -9,6 +9,7 @@ import { describe, expect, it } from 'vitest'
 import {
   addItem,
   createEmptyList,
+  completedCount,
   filledCount,
   formatItemNumber,
   hasAnythingToImport,
@@ -332,6 +333,27 @@ describe('toSlots / formatItemNumber / filledCount', () => {
     expect(formatItemNumber(1)).toBe('001')
     expect(formatItemNumber(23)).toBe('023')
     expect(formatItemNumber(100)).toBe('100')
+  })
+
+  it('🔴 達成済みの数を数える', () => {
+    const one = expectOk(setItemCompletedAt(listOf('1つ目', '2つ目', '3つ目'), 'i1', 1))
+    const two = expectOk(setItemCompletedAt(one, 'i3', 1))
+
+    expect(completedCount(createEmptyList())).toBe(0)
+    expect(completedCount(listOf('1つ目', '2つ目'))).toBe(0)
+    expect(completedCount(one)).toBe(1)
+    expect(completedCount(two)).toBe(2)
+  })
+
+  it('🔴 全部やっても、埋まり具合とは別の数字のまま', () => {
+    // 置き換えると「100 という枠がまだ埋まっていない」が見えなくなる（#145）
+    const all = ['1つ目', '2つ目'].reduce(
+      (list, _, index) => expectOk(setItemCompletedAt(list, `i${String(index + 1)}`, 1)),
+      listOf('1つ目', '2つ目'),
+    )
+
+    expect(completedCount(all)).toBe(2)
+    expect(filledCount(all)).toBe(2)
   })
 
   it('🔴 「23 / 100」の左は埋まり具合。完了した数ではない', () => {


### PR DESCRIPTION
Closes #145

```
23 / 100 書けた    5 / 100 やった
```

## 判断したこと

🔴 **埋まり具合を置き換えない。並べる。**
2つは**別のことを言っている。**

| 数字 | 意味 |
|---|---|
| 書けた | **100 という枠がまだ埋まっていない**ことを見せる（`PRODUCT_SPEC.md` §1、§3） |
| やった | そのうち何個叶えたか |

置き換えると、このアプリが「埋める楽しさ」を出すために持っている数字が消える。

**分母はどちらも 100（上限）。**
マークダウン（#129）は分母を「入力済みの数」にしているが、
あちらは**転載用**で、読む人が知りたいのは達成の割合。
画面は**枠がまだ空いていること**を見せる場所なので、揃えない。
この理由は `completedCount` のコメントに残した（次に読む人が「揃えよう」としないように）。

## テスト

`completedCount` に3件（0件・一部・全部）。
**全部やっても埋まり具合と別の数字のまま**であることも固定した（**255 tests が緑**）。

⚠️ 並びの見え方は目視を依頼する（狭い画面で折り返さないか）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)