### PR TITLE
OGP に渡すデータと署名の形を決める

### DIFF
--- a/apps/web/test/og-payload.test.ts
+++ b/apps/web/test/og-payload.test.ts
@@ -1,0 +1,119 @@
+import {
+  LIST_TITLE_MAX_LENGTH,
+  OG_SIGNATURE_TTL_SECONDS,
+  ogPayloadSchema,
+  signOgPayload,
+  verifyOgPayload,
+  type OgPayload,
+} from '@yaritai100list/shared'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * OGP に渡すデータと署名のテスト（#170）。
+ *
+ * 署名は Cloudflare Workers が作り、Deno Deploy が確かめる。
+ * **ここで固定するのは「合わないものが通らないこと」。**
+ * 通ることだけ確かめても、踏み台にされる経路は塞げない。
+ */
+
+const SECRET = 'test-secret-not-used-outside-tests'
+const NOW = new Date('2026-08-08T00:00:00.000Z')
+
+function payload(overrides: Partial<OgPayload> = {}): OgPayload {
+  return {
+    title: '2026年の目標',
+    completed: 5,
+    filled: 23,
+    exp: Math.floor(NOW.getTime() / 1000) + OG_SIGNATURE_TTL_SECONDS,
+    ...overrides,
+  }
+}
+
+describe('ogPayloadSchema', () => {
+  it('🔴 作者を入れる場所が無い', () => {
+    // どの公開面にも作者を出さない（PRODUCT_SPEC.md §5.1）。
+    // 入れる場所が無ければ、間違えて入れることもない
+    const withAuthor = { ...payload(), userId: 'someone' }
+
+    expect(ogPayloadSchema.safeParse(withAuthor).success).toBe(false)
+  })
+
+  it('🔴 タイトルの長さに上限がある', () => {
+    // 画像に描くテキストは長さを制限する（TECH_STACK.md §9）。
+    // レイアウト崩れと CPU 消費の両方を防ぐ
+    expect(
+      ogPayloadSchema.safeParse(payload({ title: 'あ'.repeat(LIST_TITLE_MAX_LENGTH) })).success,
+    ).toBe(true)
+    expect(
+      ogPayloadSchema.safeParse(payload({ title: 'あ'.repeat(LIST_TITLE_MAX_LENGTH + 1) })).success,
+    ).toBe(false)
+  })
+
+  it('数は負にならない', () => {
+    expect(ogPayloadSchema.safeParse(payload({ completed: -1 })).success).toBe(false)
+  })
+})
+
+describe('署名', () => {
+  it('作った署名は通る', async () => {
+    const data = payload()
+    const signature = await signOgPayload(data, SECRET)
+
+    expect(await verifyOgPayload(data, signature, SECRET, NOW)).toBe(true)
+  })
+
+  it('同じ内容なら同じ署名になる（配るキャッシュがぶれない）', async () => {
+    expect(await signOgPayload(payload(), SECRET)).toBe(await signOgPayload(payload(), SECRET))
+  })
+
+  it('🔴 中身を1つ変えると通らない', async () => {
+    const signature = await signOgPayload(payload(), SECRET)
+
+    expect(await verifyOgPayload(payload({ title: '別のタイトル' }), signature, SECRET, NOW)).toBe(
+      false,
+    )
+    expect(await verifyOgPayload(payload({ completed: 6 }), signature, SECRET, NOW)).toBe(false)
+    expect(await verifyOgPayload(payload({ filled: 24 }), signature, SECRET, NOW)).toBe(false)
+  })
+
+  it('🔴 期限を延ばすと通らない（署名の対象に入っている）', async () => {
+    const data = payload()
+    const signature = await signOgPayload(data, SECRET)
+
+    expect(await verifyOgPayload({ ...data, exp: data.exp + 1 }, signature, SECRET, NOW)).toBe(
+      false,
+    )
+  })
+
+  it('🔴 期限が切れたら通らない', async () => {
+    const data = payload()
+    const signature = await signOgPayload(data, SECRET)
+    const later = new Date((data.exp + 1) * 1000)
+
+    expect(await verifyOgPayload(data, signature, SECRET, later)).toBe(false)
+  })
+
+  it('🔴 鍵が違うと通らない', async () => {
+    const data = payload()
+    const signature = await signOgPayload(data, SECRET)
+
+    expect(await verifyOgPayload(data, signature, 'another-secret', NOW)).toBe(false)
+  })
+
+  it('壊れた署名でも落ちない', async () => {
+    const data = payload()
+
+    expect(await verifyOgPayload(data, '', SECRET, NOW)).toBe(false)
+    expect(await verifyOgPayload(data, 'zzzz', SECRET, NOW)).toBe(false)
+    expect(await verifyOgPayload(data, 'abc', SECRET, NOW)).toBe(false)
+  })
+
+  it('🔴 区切りをまたいでも同じ署名にならない', async () => {
+    // 連結して署名すると、境目をずらした別の内容が同じ文字列になることがある。
+    // タイトルに改行を入れて、それが起きないことを見る
+    const a = await signOgPayload(payload({ title: 'あ\n5' }), SECRET)
+    const b = await signOgPayload(payload({ title: 'あ', completed: 5 }), SECRET)
+
+    expect(a).not.toBe(b)
+  })
+})

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -40,4 +40,5 @@ export const NEW_LIST_TITLE = '新しいやりたいことリスト'
 
 export * from './export'
 export * from './limits'
+export * from './og'
 export * from './validation'

--- a/packages/shared/src/og.ts
+++ b/packages/shared/src/og.ts
@@ -1,0 +1,131 @@
+import { z } from 'zod'
+
+import { LIST_TITLE_MAX_LENGTH } from './limits'
+
+/**
+ * OGP 画像に渡すデータと、その署名（#170）。
+ *
+ * 🔴 **署名と検証を同じファイルに置く。** 署名するのは Cloudflare Workers、
+ * 検証するのは Deno Deploy。**別々に書くと、片方を直したときにずれる**
+ * （そしてずれたことに気づくのは「画像が出ない」という形でしかない）。
+ *
+ * 🔴 **生成サービスに公開/非公開を判断させない**（`CLAUDE.md` の不変条件）。
+ * ここに来る時点で認可は済んでいる、という前提を**署名で担保する。**
+ * 生成側は「署名が合っていれば描く」だけでよくなる。
+ *
+ * ⚠️ **Deno でも動くものだけを使う**（`TECH_STACK.md` §12-2）。
+ * HMAC は Node の `crypto` ではなく **Web Crypto**（`crypto.subtle`）で書く。
+ * どちらのランタイムにもある。
+ */
+
+/**
+ * 画像に描く内容。**タイトルと達成状況だけ**（`PRODUCT_SPEC.md` §5.2）。
+ *
+ * 🔴 **作者を入れない。** どの公開面にも作者を出さない（§5.1）。
+ * **入れる場所が無ければ、間違えて入れることもない。**
+ *
+ * 項目の一覧も入れない。あれは画像出力（#9）の役割で、OGP には入らない。
+ */
+export const ogPayloadSchema = z
+  .object({
+    /** リストのタイトル。長さの上限は入力と同じ（レイアウト崩れと CPU の両方を防ぐ） */
+    title: z.string().min(1).max(LIST_TITLE_MAX_LENGTH),
+    /** 「やった」数 */
+    completed: z.number().int().min(0),
+    /** 書いた数。`completed / filled` で達成状況を出す */
+    filled: z.number().int().min(0),
+    /** 有効期限（epoch 秒）。**流出した URL をいつまでも叩ける状態にしない** */
+    exp: z.number().int().positive(),
+  })
+  .strict()
+
+export type OgPayload = z.infer<typeof ogPayloadSchema>
+
+/**
+ * 署名の有効期間（秒）。
+ *
+ * 短すぎると、SNS が後から取りに来たときに切れている。長すぎると流出したときに困る。
+ * **1時間**にしてある。SNS のクローラは貼られた直後に来るので足りる。
+ */
+export const OG_SIGNATURE_TTL_SECONDS = 60 * 60
+
+/** 署名の対象を1つの文字列にする。**両側で同じ並びにするため、ここでしか作らない。** */
+function canonical(payload: OgPayload): string {
+  // キーの順序で結果が変わらないよう、並びを固定して書く（JSON.stringify に任せない）
+  return [payload.title, payload.completed, payload.filled, payload.exp]
+    .map((value) => String(value))
+    .join('\n')
+}
+
+async function hmacKey(secret: string): Promise<CryptoKey> {
+  return crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign', 'verify'],
+  )
+}
+
+function toHex(buffer: ArrayBuffer): string {
+  return [...new Uint8Array(buffer)].map((byte) => byte.toString(16).padStart(2, '0')).join('')
+}
+
+/** 署名を作る（Cloudflare Workers 側）。 */
+export async function signOgPayload(payload: OgPayload, secret: string): Promise<string> {
+  const key = await hmacKey(secret)
+  const signature = await crypto.subtle.sign(
+    'HMAC',
+    key,
+    new TextEncoder().encode(canonical(payload)),
+  )
+
+  return toHex(signature)
+}
+
+/**
+ * 署名を確かめる（Deno Deploy 側）。
+ *
+ * **合わない理由を返さない。** 「期限切れ」と「改竄」を出し分けても、
+ * 呼び出し側にできることは変わらない（どちらも描かない）。
+ *
+ * `now` を引数で受け取るのはテストのため（`TECH_STACK.md` §10 と同じ理由で、
+ * 関数の中で時計を読まない）。
+ */
+export async function verifyOgPayload(
+  payload: OgPayload,
+  signature: string,
+  secret: string,
+  now: Date,
+): Promise<boolean> {
+  if (payload.exp * 1000 <= now.getTime()) return false
+
+  const key = await hmacKey(secret)
+
+  // 🔴 **自分で文字列比較しない。** `crypto.subtle.verify` は時間差で漏れない
+  return crypto.subtle.verify(
+    'HMAC',
+    key,
+    hexToBytes(signature),
+    new TextEncoder().encode(canonical(payload)),
+  )
+}
+
+/**
+ * 16進の文字列をバイト列に戻す。**不正な文字が来たら空を返す**（検証は必ず落ちる）。
+ *
+ * 戻り値を `ArrayBuffer` にしているのは、`crypto.subtle.verify` が
+ * `BufferSource` を要求するため（`Uint8Array<ArrayBufferLike>` は代入できない）。
+ */
+function hexToBytes(hex: string): ArrayBuffer {
+  if (hex.length % 2 !== 0 || !/^[0-9a-f]*$/.test(hex)) return new ArrayBuffer(0)
+
+  const buffer = new ArrayBuffer(hex.length / 2)
+  const bytes = new Uint8Array(buffer)
+
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = Number.parseInt(hex.slice(i * 2, i * 2 + 2), 16)
+  }
+
+  return buffer
+}

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,4 +1,14 @@
 {
   "extends": "../../tsconfig.base.json",
+
+  "compilerOptions": {
+    // 🔴 **DOM を入れない。** ここは Cloudflare Workers と Deno Deploy の両方から
+    // 使う（`TECH_STACK.md` §12-2）。`document` が見えると、いつか誰かが触る。
+    //
+    // `WebWorker` を入れているのは、**Web Crypto と TextEncoder のため**（#170）。
+    // OGP の署名で使う。どちらのランタイムにもあるが、ES2023 だけでは型が無い。
+    "lib": ["ES2023", "WebWorker"]
+  },
+
   "include": ["src"]
 }


### PR DESCRIPTION
Closes #170

#8 の**Deno Deploy が要らない部分**。設計は #8 のコメントに書いた。

## 判断したこと

🔴 **署名と検証を同じファイルに置く**（`packages/shared/src/og.ts`）。
署名するのは Cloudflare Workers、検証するのは Deno Deploy。
**別々に書くと片方を直したときにずれる**し、ずれたことに気づくのは
「画像が出ない」という形でしかない。

🔴 **作者を入れる場所が無い。** 渡す型に `userId` も名前も無い。
どの公開面にも作者を出さない（`PRODUCT_SPEC.md` §5.1）という決定を、
**型で守る**（入れる場所が無ければ、間違えて入れることもない）。

**有効期限を署名の対象に入れた。** 期限だけ書き換えて延命できない。
1時間にしてある（SNS のクローラは貼られた直後に来るので足りる）。

**自分で文字列比較しない。** `crypto.subtle.verify` に任せる（時間差で漏れない）。

**合わない理由を返さない。** 「期限切れ」と「改竄」を出し分けても、
呼び出し側にできることは変わらない（どちらも描かない）。

## `packages/shared` の `lib` に `WebWorker` を足した

Web Crypto と `TextEncoder` の型のため。
🔴 **DOM は入れない。** ここは Workers と Deno の両方から使うので、
`document` が見えると**いつか誰かが触る。**

## テスト（11件、全体 273 tests / 18 files）

**「合わないものが通らないこと」**を中心に:

- **中身を1つ変えると通らない**（タイトル・completed・filled）
- **期限を延ばすと通らない / 期限が切れたら通らない / 鍵が違うと通らない**
- 壊れた署名（空・非16進・奇数長）でも落ちない
- **区切りをまたいでも同じ署名にならない**（タイトルに改行を入れて確認）
- 作者を入れると弾かれる / タイトルの長さに上限がある

🤖 Generated with [Claude Code](https://claude.com/claude-code)