### PR TITLE
/og/:shareId の入口（認可・キャッシュ）

### DIFF
--- a/apps/web/.dev.vars.example
+++ b/apps/web/.dev.vars.example
@@ -26,3 +26,11 @@ SENTRY_ENVIRONMENT=local
 # **未設定でもアプリは起動する**（ログイン手段が無くなるだけ）。
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
+
+# 画像生成サービス（Deno Deploy）。**両方そろって初めて OGP 画像が出る**（#171）。
+# 未設定なら /og/:shareId は 503 を返す。ローカルでは空でよい。
+#
+# RENDER_HMAC_SECRET は**両側で同じ値**にする（生成サービスが署名を確かめる）。
+#   openssl rand -base64 32
+RENDER_URL=
+RENDER_HMAC_SECRET=

--- a/apps/web/src/env.ts
+++ b/apps/web/src/env.ts
@@ -2,6 +2,7 @@ import type { InferSelectModel } from 'drizzle-orm'
 
 import type { AuthEnv } from './auth'
 import type { items, lists } from './db/schema'
+import type { RenderEnv } from './og'
 import type { SentryEnv } from './sentry'
 
 /**
@@ -17,7 +18,7 @@ import type { SentryEnv } from './sentry'
  * **このアプリが動くために必要な環境変数の一覧**がここに集まる形になっている。
  */
 export interface AppEnv {
-  Bindings: Env & AuthEnv & SentryEnv
+  Bindings: Env & AuthEnv & SentryEnv & RenderEnv
 
   Variables: {
     /** `requireUser` が入れる。ログイン中の利用者の id */

--- a/apps/web/src/index.ts
+++ b/apps/web/src/index.ts
@@ -9,6 +9,7 @@ import {
   LISTS_PER_USER_MAX,
   SHARED_VISIBILITIES,
   itemTextSchema,
+  signOgPayload,
   listTitleSchema,
   visibilitySchema,
 } from '@yaritai100list/shared'
@@ -23,6 +24,7 @@ import { createDb, type Db } from './db'
 import { items, lists } from './db/schema'
 import type { AppEnv } from './env'
 import { newId, newShareId } from './id'
+import { buildOgPayload, cacheControlFor, renderRequestUrl } from './og'
 import { rateLimitCreates } from './rate-limit'
 import { renderSharePage, renderShareNotFound } from './share'
 import { sentryOptions } from './sentry'
@@ -648,6 +650,61 @@ const app = new Hono<AppEnv>()
         })),
       }),
     )
+  })
+
+  /**
+   * OGP 画像（#171）。**ログインは要らない。**
+   *
+   * 🔴 **`wrangler.jsonc` の `run_worker_first` に `/og/*` を入れてある。**
+   * 入れ忘れると Worker に届かず、SPA の index.html が返る（404 にならない）。
+   *
+   * 🔴 **共有ページ（#137）と同じ判定を通す。** 非公開のリストは画像も出さない。
+   * 「画像だけ漏れる」は典型的な事故（`CLAUDE.md` の不変条件）。
+   * 存在しない `shareId` と応答を揃えるのも同じ理由。
+   *
+   * 画像を作るのは Deno Deploy 側（#172）。**ここは認可して、署名して、渡すだけ。**
+   */
+  .get('/og/:shareId', async (c) => {
+    const db = createDb(c.env.DB)
+
+    const [list] = await db
+      .select()
+      .from(lists)
+      .where(
+        and(
+          eq(lists.shareId, c.req.param('shareId')),
+          inArray(lists.visibility, [...SHARED_VISIBILITIES]),
+        ),
+      )
+      .limit(1)
+
+    if (!list) {
+      return c.json({ error: 'Not Found' } as const, 404)
+    }
+
+    const { RENDER_URL, RENDER_HMAC_SECRET } = c.env
+
+    // まだ生成サービスが無い（#172）。**落ちるのではなく「用意できていない」と返す**
+    if (!RENDER_URL || !RENDER_HMAC_SECRET) {
+      return c.json({ error: 'Image Not Available' } as const, 503)
+    }
+
+    const payload = buildOgPayload(list, await selectItems(db, list.id), new Date())
+    const signature = await signOgPayload(payload, RENDER_HMAC_SECRET)
+
+    const rendered = await fetch(renderRequestUrl(RENDER_URL, payload, signature))
+
+    if (!rendered.ok) {
+      // 生成に失敗したものをキャッシュさせない
+      return c.json({ error: 'Image Not Available' } as const, 503)
+    }
+
+    return new Response(rendered.body, {
+      headers: {
+        'content-type': rendered.headers.get('content-type') ?? 'image/png',
+        'cache-control': cacheControlFor(c.req.query('v')),
+      },
+    })
   })
 
   /**

--- a/apps/web/src/og.ts
+++ b/apps/web/src/og.ts
@@ -1,0 +1,78 @@
+import { OG_SIGNATURE_TTL_SECONDS, type OgPayload } from '@yaritai100list/shared'
+
+/**
+ * OGP 画像の入口（#171）。**認可はここで済ませる。**
+ *
+ * 🔴 **生成サービスに公開/非公開を判断させない**（`CLAUDE.md` の不変条件）。
+ * 「画像だけ漏れる」は典型的な事故なので、共有ページ（#137）と**同じ判定**を通してから、
+ * 描くデータだけを署名して渡す。
+ */
+
+export interface RenderEnv {
+  /**
+   * 画像生成サービス（Deno Deploy）の URL。
+   *
+   * **未設定なら画像を出さない**（503）。#172 でサービスを作るまではこの状態。
+   * 落ちるのではなく「まだ無い」と返す。
+   */
+  readonly RENDER_URL?: string
+
+  /**
+   * 生成サービスと共有する鍵。**両側で同じ値**（`docs/console-settings.md`）。
+   *
+   * 未設定なら画像を出さない。**署名なしで叩ける状態を作らない**
+   * （放置すると CPU 枠を溶かす踏み台になる。`TECH_STACK.md` §9）。
+   */
+  readonly RENDER_HMAC_SECRET?: string
+}
+
+/**
+ * 画像に描くデータを組み立てる。**純関数**（`TECH_STACK.md` §10）。
+ *
+ * 渡すのは**タイトルと達成状況だけ。** 作者も項目の一覧も入れない
+ * （`PRODUCT_SPEC.md` §5.2。そもそも `OgPayload` に入れる場所が無い）。
+ *
+ * 達成状況の分母は**書いた数**。画面（#168）とマークダウン（#129）と揃えてある。
+ */
+export function buildOgPayload(
+  list: { title: string },
+  items: { completedAt: Date | null }[],
+  now: Date,
+): OgPayload {
+  return {
+    title: list.title,
+    completed: items.filter((item) => item.completedAt !== null).length,
+    filled: items.length,
+    exp: Math.floor(now.getTime() / 1000) + OG_SIGNATURE_TTL_SECONDS,
+  }
+}
+
+/**
+ * 生成サービスに投げる URL。**GET にしてあるのは、あちら側でもキャッシュが効くから。**
+ */
+export function renderRequestUrl(base: string, payload: OgPayload, signature: string): string {
+  const params = new URLSearchParams({
+    title: payload.title,
+    completed: String(payload.completed),
+    filled: String(payload.filled),
+    exp: String(payload.exp),
+    sig: signature,
+  })
+
+  return `${base.replace(/\/$/, '')}/og?${params.toString()}`
+}
+
+/**
+ * 画像のキャッシュの指示。
+ *
+ * 🔴 **`v` が付いているときだけ恒久キャッシュにする**（#8 のコメント）。
+ * リストを更新すると `v` が変わって別の URL になるので、古い画像が残らない。
+ *
+ * `v` が無い URL は**誰が作ったものか分からない**（手で叩かれた、古いリンク）。
+ * 恒久キャッシュにすると更新しても直らなくなるので、短くしておく。
+ */
+export function cacheControlFor(version: string | undefined): string {
+  return version === undefined || version === ''
+    ? 'public, max-age=300'
+    : 'public, max-age=31536000, immutable'
+}

--- a/apps/web/test/og-route.test.ts
+++ b/apps/web/test/og-route.test.ts
@@ -1,0 +1,150 @@
+import { exports } from 'cloudflare:workers'
+import { OG_SIGNATURE_TTL_SECONDS } from '@yaritai100list/shared'
+import { describe, expect, it } from 'vitest'
+
+import { buildOgPayload, cacheControlFor, renderRequestUrl } from '../src/og'
+import { lists } from '../src/db/schema'
+import { createTestUser, testBaseUrl, testDb } from './helpers'
+
+/**
+ * OGP 画像の入口のテスト（#171）。
+ *
+ * 🔴 見るのは **「非公開の画像が出ないこと」** が中心。
+ * 「画像だけ漏れる」は典型的な事故（`CLAUDE.md` の不変条件）。
+ *
+ * 画像そのものは Deno Deploy 側（#172）。**まだ無いので 503 が正しい応答。**
+ */
+
+const request = (path: string) => exports.default.fetch(new Request(`${testBaseUrl()}${path}`))
+
+async function createList(options: {
+  visibility: 'private' | 'unlisted' | 'public'
+  title?: string
+}) {
+  const db = testDb()
+  const userId = await createTestUser(`${crypto.randomUUID()}@example.com`)
+  const id = crypto.randomUUID()
+  const shareId = crypto.randomUUID().replaceAll('-', '')
+
+  await db.insert(lists).values({
+    id,
+    userId,
+    title: options.title ?? '2026年の目標',
+    shareId,
+    visibility: options.visibility,
+  })
+
+  return { id, shareId }
+}
+
+describe('buildOgPayload', () => {
+  const now = new Date('2026-08-08T00:00:00.000Z')
+
+  it('達成状況を数える。分母は書いた数', () => {
+    const payload = buildOgPayload(
+      { title: '2026年の目標' },
+      [{ completedAt: new Date() }, { completedAt: null }, { completedAt: new Date() }],
+      now,
+    )
+
+    expect(payload.title).toBe('2026年の目標')
+    expect(payload.completed).toBe(2)
+    expect(payload.filled).toBe(3)
+  })
+
+  it('期限が入る', () => {
+    const payload = buildOgPayload({ title: 'x' }, [], now)
+
+    expect(payload.exp).toBe(Math.floor(now.getTime() / 1000) + OG_SIGNATURE_TTL_SECONDS)
+  })
+
+  it('🔴 作者を入れる場所が無い', () => {
+    // 型で守っている。渡す値を増やしても入らない
+    expect(Object.keys(buildOgPayload({ title: 'x' }, [], now)).sort()).toEqual([
+      'completed',
+      'exp',
+      'filled',
+      'title',
+    ])
+  })
+})
+
+describe('renderRequestUrl', () => {
+  it('署名を含む URL を組み立てる', () => {
+    const url = renderRequestUrl(
+      'https://render.example.com',
+      { title: 'あ い', completed: 1, filled: 2, exp: 123 },
+      'sig',
+    )
+
+    expect(url.startsWith('https://render.example.com/og?')).toBe(true)
+    expect(new URL(url).searchParams.get('title')).toBe('あ い')
+    expect(new URL(url).searchParams.get('sig')).toBe('sig')
+  })
+
+  it('末尾のスラッシュがあっても二重にならない', () => {
+    const url = renderRequestUrl(
+      'https://render.example.com/',
+      {
+        title: 'x',
+        completed: 0,
+        filled: 0,
+        exp: 1,
+      },
+      'sig',
+    )
+
+    expect(url).toContain('.com/og?')
+  })
+})
+
+describe('cacheControlFor', () => {
+  it('🔴 v が付いているときだけ恒久キャッシュ', () => {
+    // v が無い URL は更新しても直らなくなるので、短くしておく
+    expect(cacheControlFor('123')).toContain('immutable')
+    expect(cacheControlFor(undefined)).not.toContain('immutable')
+    expect(cacheControlFor('')).not.toContain('immutable')
+  })
+})
+
+describe('GET /og/:shareId', () => {
+  it('🔴 非公開のリストの画像は出ない', async () => {
+    const list = await createList({ visibility: 'private' })
+
+    expect((await request(`/og/${list.shareId}`)).status).toBe(404)
+  })
+
+  it('🔴 非公開と、存在しない ID で応答が完全に一致する', async () => {
+    const list = await createList({ visibility: 'private' })
+
+    const hidden = await request(`/og/${list.shareId}`)
+    const missing = await request('/og/no-such-share-id')
+
+    expect(hidden.status).toBe(missing.status)
+    expect(await hidden.text()).toBe(await missing.text())
+  })
+
+  it('🔴 編集用の ID を渡しても出ない', async () => {
+    const list = await createList({ visibility: 'public' })
+
+    expect((await request(`/og/${list.id}`)).status).toBe(404)
+  })
+
+  it('公開されていれば 404 にはならない', async () => {
+    // 生成サービスがまだ無いので 503。**認可は通っている**ことの確認
+    const list = await createList({ visibility: 'unlisted' })
+
+    const res = await request(`/og/${list.shareId}`)
+
+    expect(res.status).toBe(503)
+    expect(await res.json()).toEqual({ error: 'Image Not Available' })
+  })
+
+  it('🔴 鍵や URL が未設定なら画像を出さない', async () => {
+    // **署名なしで叩ける状態を作らない**（TECH_STACK.md §9）。
+    // テスト環境には RENDER_URL も RENDER_HMAC_SECRET も無い
+    const list = await createList({ visibility: 'public' })
+
+    expect((await request(`/og/${list.shareId}`)).status).toBe(503)
+  })
+})

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -49,7 +49,7 @@
   // 静的ファイルの配信まで Worker の実行回数を消費するため、無料枠に効く。
   "assets": {
     "not_found_handling": "single-page-application",
-    "run_worker_first": ["/api/*", "/share/*"],
+    "run_worker_first": ["/api/*", "/share/*", "/og/*"],
   },
 
   // 作成系（リスト・項目・取り込み）のレート制限。**コンソールではなくここで設定する。**

--- a/docs/console-settings.md
+++ b/docs/console-settings.md
@@ -398,6 +398,7 @@ SDK 側は何も送っていない。消したい場合は
 | `GOOGLE_CLIENT_SECRET` | Google OAuth | `.dev.vars` | `wrangler secret put` | — |
 | `BETTER_AUTH_SECRET` | セッション署名 | `.dev.vars` | `wrangler secret put` | — |
 | `RENDER_HMAC_SECRET` | 画像生成の署名（**両側で同じ値**） | `.dev.vars` | `wrangler secret put` | コンソールの環境変数 |
+| `RENDER_URL` | 画像生成サービスの URL（秘密ではないが、環境ごとに違うのでここ） | `.dev.vars` | `wrangler secret put` | — |
 | `SENTRY_DSN` | エラー通知（**シークレット扱い。理由は Sentry の節**） | `.dev.vars` | `wrangler secret put` | コンソールの環境変数 |
 
 変数名は #3 / #8 / #18 での想定。**確定したらこの表を更新する。**


### PR DESCRIPTION
Closes #171

**画像を作るのは Deno Deploy 側（#172）。ここは認可して、署名して、渡すだけ。**
生成サービスがまだ無いので、いまは 503 を返す。

## 🔴 気をつけたこと

**共有ページ（#137）と同じ判定を通す。** 非公開のリストは画像も出さない。
**「画像だけ漏れる」は典型的な事故**（`CLAUDE.md` の不変条件）。
存在しない `shareId` と応答も揃えてある。

**`wrangler.jsonc` の `run_worker_first` に `/og/*` を足した。**
忘れると Worker に届かず SPA が返る（404 にならないので気づきにくい）。

**鍵か URL が無ければ 503。** **署名なしで叩ける状態を作らない**（`TECH_STACK.md` §9）。
落ちるのではなく「まだ用意できていない」と返す。

**`v` が付いているときだけ恒久キャッシュ**（`immutable`）。
`v` が無い URL は手で叩かれたか古いリンクなので、恒久にすると**更新しても直らなくなる。**

## 生成サービスへの渡し方

`GET {RENDER_URL}/og?title=...&completed=...&filled=...&exp=...&sig=...`

GET にしたのは、**あちら側でもキャッシュが効く**から。
渡すのは**タイトルと達成状況だけ**（`OgPayload` に作者を入れる場所が無い）。

## テスト（11件、全体 284 tests / 19 files）

- 🔴 **非公開のリストの画像が出ない / 存在しない ID と応答が一致する**
- 🔴 **編集用の ID を渡しても出ない**
- 公開されていれば 404 にはならない（**認可は通っている**ことの確認。いまは 503）
- `v` の有無でキャッシュが変わる
- `buildOgPayload` の中身（分母は書いた数、期限が入る、**作者を入れる場所が無い**）

## 残り

#172（Deno Deploy）で **`RENDER_URL` と `RENDER_HMAC_SECRET`** を設定すると画像が出る。
`.dev.vars.example` と `docs/console-settings.md` に追記済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)