### PR TITLE
RENDER_URL を vars に移し、生成サービスの設定を記録する

### DIFF
--- a/apps/web/.dev.vars.example
+++ b/apps/web/.dev.vars.example
@@ -27,10 +27,10 @@ SENTRY_ENVIRONMENT=local
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 
-# 画像生成サービス（Deno Deploy）。**両方そろって初めて OGP 画像が出る**（#171）。
-# 未設定なら /og/:shareId は 503 を返す。ローカルでは空でよい。
-#
-# RENDER_HMAC_SECRET は**両側で同じ値**にする（生成サービスが署名を確かめる）。
+# 画像生成サービス（Deno Deploy）と共有する鍵。**両側で同じ値**にする。
 #   openssl rand -base64 32
-RENDER_URL=
+# 未設定なら /og/:shareId は 503 を返す（ローカルでは空でよい）。
+#
+# URL の方は wrangler.jsonc の vars にある（秘密ではないため）。
+# ローカルから別の生成サービスを見たいときだけ、ここで RENDER_URL を上書きする。
 RENDER_HMAC_SECRET=

--- a/apps/web/src/index.ts
+++ b/apps/web/src/index.ts
@@ -684,15 +684,24 @@ const app = new Hono<AppEnv>()
 
     const { RENDER_URL, RENDER_HMAC_SECRET } = c.env
 
-    // まだ生成サービスが無い（#172）。**落ちるのではなく「用意できていない」と返す**
-    if (!RENDER_URL || !RENDER_HMAC_SECRET) {
+    // 🔴 **鍵が無ければ画像を出さない。** 署名なしで叩ける状態を作らない
+    // （`TECH_STACK.md` §9）。**落ちるのではなく「用意できていない」と返す**。
+    // URL の方は wrangler.jsonc の vars にあるので必ずある（消せば型エラーになる）
+    if (!RENDER_HMAC_SECRET) {
       return c.json({ error: 'Image Not Available' } as const, 503)
     }
 
     const payload = buildOgPayload(list, await selectItems(db, list.id), new Date())
     const signature = await signOgPayload(payload, RENDER_HMAC_SECRET)
 
-    const rendered = await fetch(renderRequestUrl(RENDER_URL, payload, signature))
+    // ⚠️ **繋がらないときは fetch が投げる**（サービスがまだ無い、落ちている）。
+    // 捕まえないと 500 になり、**失敗を「壊れた」として扱ってしまう**
+    let rendered: Response
+    try {
+      rendered = await fetch(renderRequestUrl(RENDER_URL, payload, signature))
+    } catch {
+      return c.json({ error: 'Image Not Available' } as const, 503)
+    }
 
     if (!rendered.ok) {
       // 生成に失敗したものをキャッシュさせない

--- a/apps/web/src/og.ts
+++ b/apps/web/src/og.ts
@@ -8,15 +8,14 @@ import { OG_SIGNATURE_TTL_SECONDS, type OgPayload } from '@yaritai100list/shared
  * 描くデータだけを署名して渡す。
  */
 
+/**
+ * ⚠️ **`RENDER_URL` はここに無い。** 秘密ではないので `wrangler.jsonc` の `vars` にあり、
+ * 型は `wrangler types` が `Env` に生成する（`BETTER_AUTH_URL` と同じ扱い）。
+ * 設定をコードに乗せておく、という方針（`TECH_STACK.md` §1）。
+ *
+ * **消すと型エラーになる**ので、消したことに気づける。
+ */
 export interface RenderEnv {
-  /**
-   * 画像生成サービス（Deno Deploy）の URL。
-   *
-   * **未設定なら画像を出さない**（503）。#172 でサービスを作るまではこの状態。
-   * 落ちるのではなく「まだ無い」と返す。
-   */
-  readonly RENDER_URL?: string
-
   /**
    * 生成サービスと共有する鍵。**両側で同じ値**（`docs/console-settings.md`）。
    *

--- a/apps/web/test/og-route.test.ts
+++ b/apps/web/test/og-route.test.ts
@@ -140,9 +140,9 @@ describe('GET /og/:shareId', () => {
     expect(await res.json()).toEqual({ error: 'Image Not Available' })
   })
 
-  it('🔴 鍵や URL が未設定なら画像を出さない', async () => {
+  it('🔴 鍵が未設定なら画像を出さない', async () => {
     // **署名なしで叩ける状態を作らない**（TECH_STACK.md §9）。
-    // テスト環境には RENDER_URL も RENDER_HMAC_SECRET も無い
+    // テスト環境に RENDER_HMAC_SECRET は無い（.dev.vars も CI も入れていない）
     const list = await createList({ visibility: 'public' })
 
     expect((await request(`/og/${list.shareId}`)).status).toBe(503)

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -27,6 +27,13 @@
   // （Host は攻撃者が差し替えられる）。
   "vars": {
     "BETTER_AUTH_URL": "https://yaritai100list.aiandrox.workers.dev",
+
+    // 画像生成サービス（Deno Deploy）。**秘密の値ではないのでここに書く**（#172）。
+    // 一緒に使う `RENDER_HMAC_SECRET` の方はシークレット（`wrangler secret put`）。
+    //
+    // ホスト名は `{アプリ名}.{org slug}.deno.net`。
+    // **org slug を変えるとここも変える**（`docs/console-settings.md`）。
+    "RENDER_URL": "https://yaritai100list-render.aiandrox.deno.net",
   },
 
   // SPA を Workers から配信する。ビルド出力のディレクトリは

--- a/docs/console-settings.md
+++ b/docs/console-settings.md
@@ -241,9 +241,9 @@ Vite に変えたため、2026-08-06 に GCP 側のリダイレクト URI も 87
 | コンソール | https://console.deno.com | Classic（`dash.deno.com`）は 2026-07-20 廃止 |
 | organization slug | **`aiandrox`** | |
 | プラン | **Free** | **クレジットカード登録は不要**（2026-08-06 にサインアップ画面で確認） |
-| アプリ名 | **`yaritai100list-render`**（未作成） | #8 で作る |
+| アプリ名 | **`yaritai100list-render`**（未作成） | #172 で作る。**この名前で作る**（`RENDER_URL` がこの名前を前提にしている） |
 | 想定ホスト名 | `yaritai100list-render.aiandrox.deno.net` | |
-| HMAC 鍵の名前 | `RENDER_HMAC_SECRET` | Cloudflare 側と同じ値を共有する。値はここに書かない |
+| HMAC 鍵の名前 | `RENDER_HMAC_SECRET` | Cloudflare 側と同じ値を共有する。値はここに書かない。**Cloudflare 側は設定済み**（2026-08-08） |
 
 ### コンソールでしか触れないもの
 
@@ -398,7 +398,7 @@ SDK 側は何も送っていない。消したい場合は
 | `GOOGLE_CLIENT_SECRET` | Google OAuth | `.dev.vars` | `wrangler secret put` | — |
 | `BETTER_AUTH_SECRET` | セッション署名 | `.dev.vars` | `wrangler secret put` | — |
 | `RENDER_HMAC_SECRET` | 画像生成の署名（**両側で同じ値**） | `.dev.vars` | `wrangler secret put` | コンソールの環境変数 |
-| `RENDER_URL` | 画像生成サービスの URL（秘密ではないが、環境ごとに違うのでここ） | `.dev.vars` | `wrangler secret put` | — |
+| `RENDER_URL` | 画像生成サービスの URL。**秘密ではないので `wrangler.jsonc` の `vars`**（#172） | `.dev.vars` で上書き可 | `wrangler.jsonc` の `vars` | — |
 | `SENTRY_DSN` | エラー通知（**シークレット扱い。理由は Sentry の節**） | `.dev.vars` | `wrangler secret put` | コンソールの環境変数 |
 
 変数名は #3 / #8 / #18 での想定。**確定したらこの表を更新する。**


### PR DESCRIPTION
親: #172（先に設定だけ整える）

## `RENDER_URL` はシークレットにしない

**秘密の値ではない**ので `wrangler.jsonc` の `vars` に置いた（`BETTER_AUTH_URL` と同じ扱い）。
設定をコードに乗せておく、という方針（`TECH_STACK.md` §1）。

```jsonc
"RENDER_URL": "https://yaritai100list-render.aiandrox.deno.net"
```

`wrangler types` が `Env` に型を生成するので、**消すと型エラーになる。**
そのぶんコード側の「未設定なら 503」は `RENDER_HMAC_SECRET` だけを見る形にした
（`RENDER_URL` の存在チェックが**常に真になって lint に怒られた**ので、
型が保証しているものを二重に確かめない形に直した）。

## ⚠️ 繋がらないときは `fetch` が投げる

生成サービスがまだ無いので、**URL は設定されているが繋がらない**という状態になる。
捕まえていないと 500 になり、**「まだ用意できていない」を「壊れた」として扱ってしまう。**
`try` で囲んで 503 にした。

## 記録

`docs/console-settings.md`:

- アプリ名 `yaritai100list-render` を **「この名前で作る」**と明記
  （`RENDER_URL` がこの名前を前提にしているため）
- **Cloudflare 側の `RENDER_HMAC_SECRET` は設定済み**（2026-08-08、利用者が実施）
- `RENDER_URL` の置き場所を「シークレット」から「`vars`」に訂正

org slug（`aiandrox`）は #1 の時点で記録済みだった。

## 確認

`typecheck` / `lint` / `format:check` / `test`（284 tests）/ `build` が緑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)