### PR TITLE
共有ページに og:image を出す

### DIFF
--- a/apps/web/src/index.ts
+++ b/apps/web/src/index.ts
@@ -24,7 +24,7 @@ import { createDb, type Db } from './db'
 import { items, lists } from './db/schema'
 import type { AppEnv } from './env'
 import { newId, newShareId } from './id'
-import { buildOgPayload, cacheControlFor, renderRequestUrl } from './og'
+import { buildOgPayload, cacheControlFor, ogImageUrl, renderRequestUrl } from './og'
 import { rateLimitCreates } from './rate-limit'
 import { renderSharePage, renderShareNotFound } from './share'
 import { sentryOptions } from './sentry'
@@ -644,6 +644,8 @@ const app = new Hono<AppEnv>()
     return c.html(
       renderSharePage({
         title: list.title,
+        // 🔴 **更新日時を URL に入れる**（#173）。入れないと SNS が古い画像を出し続ける
+        imageUrl: ogImageUrl(new URL(c.req.url).origin, list.shareId, list.updatedAt),
         items: rows.map((item) => ({
           text: item.text,
           completedAt: item.completedAt === null ? null : item.completedAt.getTime(),

--- a/apps/web/src/og.ts
+++ b/apps/web/src/og.ts
@@ -47,6 +47,19 @@ export function buildOgPayload(
 }
 
 /**
+ * 共有ページの `og:image` に書く URL（#173）。
+ *
+ * 🔴 **更新日時を `v` に入れる。** SNS は画像を強くキャッシュするので、
+ * URL が変わらないと**リストを更新しても古い画像が出続ける。**
+ * 逆に `v` が付いていることで、こちらは恒久キャッシュにできる（`cacheControlFor`）。
+ *
+ * ⚠️ **絶対 URL にする。** SNS は相対パスを解決しない。
+ */
+export function ogImageUrl(origin: string, shareId: string, updatedAt: Date): string {
+  return `${origin}/og/${shareId}?v=${String(updatedAt.getTime())}`
+}
+
+/**
  * 生成サービスに投げる URL。**GET にしてあるのは、あちら側でもキャッシュが効くから。**
  */
 export function renderRequestUrl(base: string, payload: OgPayload, signature: string): string {

--- a/apps/web/src/share.ts
+++ b/apps/web/src/share.ts
@@ -1,4 +1,4 @@
-import { SERVICE_NAME } from '@yaritai100list/shared'
+import { OG_IMAGE_HEIGHT, OG_IMAGE_WIDTH, SERVICE_NAME } from '@yaritai100list/shared'
 import { html, raw } from 'hono/html'
 
 // 🔴 **色と幅は SPA と同じファイルから読む**（#159）。
@@ -73,6 +73,8 @@ export interface SharedItem {
 export interface SharedList {
   title: string
   items: SharedItem[]
+  /** OGP 画像の絶対 URL（#173）。呼び出し側で組み立てる（`src/og.ts`） */
+  imageUrl: string
 }
 
 /**
@@ -98,6 +100,8 @@ function formatCompletedAt(completedAt: number): string {
 function layout(options: {
   title: string
   description: string
+  /** OGP 画像の絶対 URL（#173）。「見つからない」ページには無い */
+  imageUrl?: string
   body: HtmlEscapedString | Promise<HtmlEscapedString>
 }) {
   return html`<!doctype html>
@@ -108,11 +112,25 @@ function layout(options: {
         <title>${options.title}</title>
         <meta name="description" content="${options.description}" />
 
-        <!-- OGP。画像（og:image）は #8 で足す -->
+        <!--
+          OGP（#173）。画像があるときだけ大きいカードにする。
+          🔴 **画像が無いのに summary_large_image にしない。**
+          画像の枠だけが空いたカードになる。
+          ⚠️ この中にバッククォートを書かない（テンプレートリテラルが終わる）
+        -->
         <meta property="og:type" content="website" />
         <meta property="og:title" content="${options.title}" />
         <meta property="og:description" content="${options.description}" />
-        <meta name="twitter:card" content="summary" />
+        ${
+          options.imageUrl === undefined
+            ? html`<meta name="twitter:card" content="summary" />`
+            : html`
+                <meta property="og:image" content="${options.imageUrl}" />
+                <meta property="og:image:width" content="${String(OG_IMAGE_WIDTH)}" />
+                <meta property="og:image:height" content="${String(OG_IMAGE_HEIGHT)}" />
+                <meta name="twitter:card" content="summary_large_image" />
+              `
+        }
 
         <!--
           🔴 検索には載せない（PRODUCT_SPEC.md §5.1）。
@@ -148,6 +166,7 @@ export function renderSharePage(list: SharedList): HtmlEscapedString | Promise<H
   return layout({
     title: `${list.title}｜${SERVICE_NAME}`,
     description,
+    imageUrl: list.imageUrl,
     body: html`
       <h1>${list.title}</h1>
       <p class="count">${description}</p>

--- a/apps/web/test/og-route.test.ts
+++ b/apps/web/test/og-route.test.ts
@@ -2,7 +2,7 @@ import { exports } from 'cloudflare:workers'
 import { OG_SIGNATURE_TTL_SECONDS } from '@yaritai100list/shared'
 import { describe, expect, it } from 'vitest'
 
-import { buildOgPayload, cacheControlFor, renderRequestUrl } from '../src/og'
+import { buildOgPayload, cacheControlFor, ogImageUrl, renderRequestUrl } from '../src/og'
 import { lists } from '../src/db/schema'
 import { createTestUser, testBaseUrl, testDb } from './helpers'
 
@@ -95,6 +95,33 @@ describe('renderRequestUrl', () => {
     )
 
     expect(url).toContain('.com/og?')
+  })
+})
+
+describe('ogImageUrl', () => {
+  it('🔴 更新日時が入る（入らないと SNS が古い画像を出し続ける）', () => {
+    const url = ogImageUrl('https://example.com', 'abc123', new Date('2026-08-08T00:00:00.000Z'))
+
+    expect(url).toBe('https://example.com/og/abc123?v=1786147200000')
+  })
+
+  it('🔴 更新すると別の URL になる', () => {
+    const at = (iso: string) => ogImageUrl('https://example.com', 'abc123', new Date(iso))
+
+    expect(at('2026-08-08T00:00:00.000Z')).not.toBe(at('2026-08-08T00:00:01.000Z'))
+  })
+
+  it('絶対 URL にする（SNS は相対パスを解決しない）', () => {
+    expect(ogImageUrl('https://example.com', 'x', new Date(0))).toMatch(/^https:\/\//)
+  })
+
+  // `v` が付くので、この URL は恒久キャッシュになる（`cacheControlFor`）
+  it('cacheControlFor が恒久キャッシュと判断する形になっている', () => {
+    const version = new URL(ogImageUrl('https://example.com', 'x', new Date(1))).searchParams.get(
+      'v',
+    )
+
+    expect(cacheControlFor(version ?? undefined)).toContain('immutable')
   })
 })
 

--- a/apps/web/test/share-page.test.ts
+++ b/apps/web/test/share-page.test.ts
@@ -146,6 +146,62 @@ describe('公開されているリスト', () => {
     expect(body).toContain('noindex')
   })
 
+  /**
+   * OGP 画像（#173）。
+   *
+   * 🔴 見るのは **「更新すると URL が変わること」。**
+   * SNS は画像を強くキャッシュするので、ここが効いていないと
+   * **更新しても古い画像が出続ける**（しかもこちらからは消せない）。
+   */
+  describe('OGP 画像', () => {
+    /** `og:image` に書かれた URL を取り出す。 */
+    function imageUrlIn(body: string): string | null {
+      return /<meta property="og:image" content="([^"]+)"/.exec(body)?.[1] ?? null
+    }
+
+    it('URL に更新日時が入っている', async () => {
+      const list = await createList({ visibility: 'public' })
+
+      const url = imageUrlIn(await (await request(`/share/${list.shareId}`)).text())
+      const [row] = await testDb().select().from(lists).where(eq(lists.id, list.id))
+
+      expect(url).toBe(`${testBaseUrl()}/og/${list.shareId}?v=${String(row?.updatedAt.getTime())}`)
+    })
+
+    it('🔴 リストを更新すると URL が変わる', async () => {
+      const list = await createList({ visibility: 'public' })
+
+      const before = imageUrlIn(await (await request(`/share/${list.shareId}`)).text())
+
+      await testDb()
+        .update(lists)
+        .set({ updatedAt: new Date(Date.now() + 60_000) })
+        .where(eq(lists.id, list.id))
+
+      const after = imageUrlIn(await (await request(`/share/${list.shareId}`)).text())
+
+      expect(before).not.toBeNull()
+      expect(after).not.toBe(before)
+    })
+
+    it('画像があるので大きいカードにする', async () => {
+      const list = await createList({ visibility: 'public' })
+
+      const body = await (await request(`/share/${list.shareId}`)).text()
+
+      expect(body).toContain('content="summary_large_image"')
+    })
+
+    it('🔴 見つからないページには画像を出さない', async () => {
+      // 存在しないリストの画像は作れない。
+      // 枠だけ空いたカードになるので、カードの種類も戻す
+      const body = await (await request('/share/no-such-share-id')).text()
+
+      expect(body).not.toContain('og:image')
+      expect(body).toContain('content="summary"')
+    })
+  })
+
   it('項目が0件でも壊れない', async () => {
     const list = await createList({ visibility: 'unlisted' })
 

--- a/docs/console-settings.md
+++ b/docs/console-settings.md
@@ -234,20 +234,20 @@ Vite に変えたため、2026-08-06 に GCP 側のリダイレクト URI も 87
 
 ## Deno Deploy（画像生成）
 
-**organization まで作成済み**（#1、2026-08-06）。**アプリの作成はまだ**（#172）。
+**organization**（#1、2026-08-06）と**アプリ**（#172、2026-08-08）の両方を作成済み。
 
 | 項目 | 現在値 | 備考 |
 |---|---|---|
 | コンソール | https://console.deno.com | Classic（`dash.deno.com`）は 2026-07-20 廃止 |
 | organization slug | **`aiandrox`** | |
 | プラン | **Free** | **クレジットカード登録は不要**（2026-08-06 にサインアップ画面で確認） |
-| アプリ名 | **`yaritai100list-render`**（未作成） | #172 で作る。**この名前で作る**（`RENDER_URL` がこの名前を前提にしている） |
-| 想定ホスト名 | `yaritai100list-render.aiandrox.deno.net` | |
+| アプリ名 | **`yaritai100list-render`** | **この名前で作る**（`RENDER_URL` がこの名前を前提にしている） |
+| ホスト名 | `yaritai100list-render.aiandrox.deno.net` | |
 | HMAC 鍵の名前 | `RENDER_HMAC_SECRET` | Cloudflare 側と同じ値を共有する。値はここに書かない。**Cloudflare 側は設定済み**（2026-08-08） |
 
-### アプリを作るときの設定（#172）
+### アプリを作るときの設定（#172、2026-08-08 に設定済み）
 
-コードは `apps/render` に用意してある。**コンソールで作るときに指定するもの:**
+コードは `apps/render` にある。**コンソールで作るときに指定したもの:**
 
 | 項目 | 値 | 理由 |
 |---|---|---|
@@ -256,6 +256,8 @@ Vite に変えたため、2026-08-06 に GCP 側のリダイレクト URI も 87
 | ルートディレクトリ | **リポジトリの root（`.`）** | ⚠️ `apps/render` にすると **`packages/shared` が見えなくなる** |
 | エントリポイント | **`apps/render/main.ts`** | |
 | 環境変数 | `RENDER_HMAC_SECRET` | **Cloudflare 側と同じ値**（値はここに書かない） |
+| インストールコマンド | `npm install`（既定のまま） | ⚠️ root に `package.json` があるため Deno は node_modules を使う解決になる。**消すと壊れうる** |
+| ビルドコマンド | なし | Deno なのでビルド不要 |
 
 **デプロイは Deno Deploy の GitHub 連携に任せる**（`main` への push で出る）。
 Cloudflare 側（`.github/workflows/deploy.yml`）とは別系統になるが、


### PR DESCRIPTION
閉じる: #173

## やったこと

- 共有ページ（`src/share.ts` の `layout()`）に `og:image` を足した
- **URL に更新日時を入れた**（`/og/:shareId?v=<updated_at>`）
- 画像があるときだけ `twitter:card` を `summary_large_image` にした

## 判断

**`v` は `lists.updated_at`。** 項目を書き換えたときも `touchList()` でここが動くので、
「やった」を付けただけでも URL が変わる（`items-api.test.ts` に既存の確認がある）。

**「見つからない」ページには画像を出さない。** 存在しないリストの画像は作れないので、
枠だけ空いたカードになる。カードの種類も `summary` に戻している。

⚠️ `share.ts` の HTML コメントに**バッククォートを書かない**。
テンプレートリテラルがそこで終わる（この PR で1度踏んだ）。

## テスト

- `og:image` の URL に更新日時が入っている
- 🔴 更新すると URL が変わる
- 🔴 見つからないページには画像を出さない

利用者の確認が要るもの: **実際に SNS に貼ってカードが出ること**（#173 の完了条件）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)