### PR TITLE
OGP 画像が出せなかった理由をログに残す

### DIFF
--- a/apps/web/src/index.ts
+++ b/apps/web/src/index.ts
@@ -686,11 +686,25 @@ const app = new Hono<AppEnv>()
 
     const { RENDER_URL, RENDER_HMAC_SECRET } = c.env
 
+    /**
+     * 画像を出せないときの返し。**理由は利用者に見せず、ログに残す。**
+     *
+     * ⚠️ **見分けが付かないと直せない**（#174）。
+     * 「生成サービスが落ちている」も「両側の鍵が違う」も同じ 503 になるので、
+     * 実際に 403 を踏んだとき、**コードを読んでも原因に到達できなかった**。
+     *
+     * 🔴 **署名も鍵も書かない。** ログに残ると、そこから叩けるようになる
+     */
+    const unavailable = (reason: string) => {
+      console.error(`og: ${reason}`)
+      return c.json({ error: 'Image Not Available' } as const, 503)
+    }
+
     // 🔴 **鍵が無ければ画像を出さない。** 署名なしで叩ける状態を作らない
     // （`TECH_STACK.md` §9）。**落ちるのではなく「用意できていない」と返す**。
     // URL の方は wrangler.jsonc の vars にあるので必ずある（消せば型エラーになる）
     if (!RENDER_HMAC_SECRET) {
-      return c.json({ error: 'Image Not Available' } as const, 503)
+      return unavailable('RENDER_HMAC_SECRET が設定されていない')
     }
 
     const payload = buildOgPayload(list, await selectItems(db, list.id), new Date())
@@ -702,12 +716,13 @@ const app = new Hono<AppEnv>()
     try {
       rendered = await fetch(renderRequestUrl(RENDER_URL, payload, signature))
     } catch {
-      return c.json({ error: 'Image Not Available' } as const, 503)
+      return unavailable(`生成サービスに繋がらない（${RENDER_URL}）`)
     }
 
     if (!rendered.ok) {
-      // 生成に失敗したものをキャッシュさせない
-      return c.json({ error: 'Image Not Available' } as const, 503)
+      // 生成に失敗したものをキャッシュさせない。
+      // **403 なら両側の鍵が違う**（生成サービスは理由を返さない）
+      return unavailable(`生成サービスが ${String(rendered.status)} を返した`)
     }
 
     return new Response(rendered.body, {

--- a/apps/web/test/og-route.test.ts
+++ b/apps/web/test/og-route.test.ts
@@ -1,6 +1,6 @@
 import { exports } from 'cloudflare:workers'
 import { OG_SIGNATURE_TTL_SECONDS } from '@yaritai100list/shared'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { buildOgPayload, cacheControlFor, ogImageUrl, renderRequestUrl } from '../src/og'
 import { lists } from '../src/db/schema'
@@ -165,6 +165,21 @@ describe('GET /og/:shareId', () => {
 
     expect(res.status).toBe(503)
     expect(await res.json()).toEqual({ error: 'Image Not Available' })
+  })
+
+  it('出せなかった理由がログに残る（応答には出さない）', async () => {
+    // ⚠️ 「繋がらない」も「鍵が違う」も同じ 503 なので、
+    // ログが無いと**どちらなのか分からない**（#174 で実際に詰まった）
+    const list = await createList({ visibility: 'unlisted' })
+    const logged = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    const res = await request(`/og/${list.shareId}`)
+
+    expect(logged).toHaveBeenCalledWith(expect.stringContaining('og:'))
+    // 🔴 理由は利用者に返さない（非公開かどうかの手がかりを増やさない）
+    expect(await res.json()).toEqual({ error: 'Image Not Available' })
+
+    logged.mockRestore()
   })
 
   it('🔴 鍵が未設定なら画像を出さない', async () => {


### PR DESCRIPTION
閉じる: #180

## なぜ

本番で `/og/:shareId` が 503 になったが、`wrangler tail` を見ても**例外は無く outcome は `ok`**。
「繋がらない」と「403（鍵の不一致）」が同じ応答になるので、**どちらか分からなかった。**

## やったこと

3つの経路それぞれに理由を書く。

| 経路 | ログ |
|---|---|
| 鍵が未設定 | `og: RENDER_HMAC_SECRET が設定されていない` |
| fetch が投げた | `og: 生成サービスに繋がらない（<URL>）` |
| 2xx 以外 | `og: 生成サービスが 403 を返した` |

🔴 **署名と鍵は書かない。** ログに残ると、そこから叩けるようになる。
**応答の中身は変えていない**（非公開かどうかの手がかりを増やさない）。

## テスト

- 理由がログに出る
- 🔴 応答には理由が出ない

🤖 Generated with [Claude Code](https://claude.com/claude-code)