### PR TITLE
画像生成サービスのビルドで npm install を要らなくする

### DIFF
--- a/apps/render/deno.json
+++ b/apps/render/deno.json
@@ -11,6 +11,15 @@
   // `TECH_STACK.md` §12 の「shared を Deno から使えるか」の答えがこれ。
   "unstable": ["sloppy-imports"],
 
+  // 🔴 **node_modules を作らない。**
+  // リポジトリの root に `package.json` があるので、指定しないと Deno は
+  // node_modules を使う解決に切り替わり、**Deno Deploy のビルドで `npm install` が要る**。
+  // このアプリは `npm:` 指定子だけで動くので、Deno のキャッシュに任せる。
+  //
+  // ⚠️ これを外すなら、Deno Deploy の Install command も戻すこと
+  // （`docs/console-settings.md`）。ビルドの転送量が跳ね上がる（#182）
+  "nodeModulesDir": "none",
+
   "imports": {
     "satori": "npm:satori@^0.29.0",
     "@resvg/resvg-wasm": "npm:@resvg/resvg-wasm@^2.6.2",

--- a/docs/console-settings.md
+++ b/docs/console-settings.md
@@ -256,7 +256,7 @@ Vite に変えたため、2026-08-06 に GCP 側のリダイレクト URI も 87
 | ルートディレクトリ | **リポジトリの root（`.`）** | ⚠️ `apps/render` にすると **`packages/shared` が見えなくなる** |
 | エントリポイント | **`apps/render/main.ts`** | |
 | 環境変数 | `RENDER_HMAC_SECRET` | **Cloudflare 側と同じ値**（値はここに書かない） |
-| インストールコマンド | `npm install`（既定のまま） | ⚠️ root に `package.json` があるため Deno は node_modules を使う解決になる。**消すと壊れうる** |
+| インストールコマンド | **空にする** | 🔴 `apps/render/deno.json` に `"nodeModulesDir": "none"` を入れてあるので `npm install` は要らない。**入れたままにすると、ビルドのたびに monorepo 全部を落としてきて転送量を食う**（#182） |
 | ビルドコマンド | なし | Deno なのでビルド不要 |
 
 **デプロイは Deno Deploy の GitHub 連携に任せる**（`main` への push で出る）。


### PR DESCRIPTION
閉じる: #182

## なぜ

Deno Deploy から**無料枠（Outbound Traffic）を 75% 使ったというメール**が来た。
アプリの転送量は **82.1KiB / 16 リクエスト**なので、**アプリではなくビルド。**

Install command が `npm install` になっていて、**ビルドのたびに monorepo の依存を全部落としていた。**

## やったこと

`apps/render/deno.json` に `"nodeModulesDir": "none"`。

これが要るのは、**リポジトリの root に `package.json` がある**ため。
指定しないと Deno は node_modules を使う解決に切り替わり、`npm install` が前提になる。
このアプリは `npm:` 指定子（satori / resvg-wasm / zod）だけで動くので、Deno のキャッシュに任せられる。

## 確認

node_modules を無視して通ることを見た:

```
deno check --node-modules-dir=none main.ts   # 通る
deno test  --node-modules-dir=none           # 8 passed
```

## コンソール側の作業（マージ後）

**Deno Deploy の Install command を空にする。** `docs/console-settings.md` に理由ごと書いた。

⚠️ 以前このファイルに「消すと壊れうる」と書いたが**間違い。** この PR で打ち消してある。

🤖 Generated with [Claude Code](https://claude.com/claude-code)