### PR TITLE
生成サービスが描かなかった理由をログに残す

### DIFF
--- a/apps/render/main.ts
+++ b/apps/render/main.ts
@@ -3,6 +3,7 @@ import satori from 'satori'
 
 import {
   buildOgTemplate,
+  isOgPayloadExpired,
   OG_IMAGE_HEIGHT,
   OG_IMAGE_WIDTH,
   ogPayloadSchema,
@@ -59,8 +60,13 @@ const FONTS = [
 /**
  * 問い合わせから、描く内容を取り出す。
  *
- * **合わない理由を返さない。** 「期限切れ」も「改竄」も、
+ * 🔴 **合わない理由を応答に載せない。** 「期限切れ」も「改竄」も、
  * 呼び出し側にできることは変わらない（どちらも描かない）。
+ * 出し分けると、叩く側に手がかりを与える。
+ *
+ * ⚠️ **ただしログには残す**（#184）。原因も対処も違うのに区別できず、
+ * 実際に「両側の鍵が違う」のを見つけるのに時間がかかった。
+ * **署名も鍵も書かない**（ログから叩けるようになる）。
  */
 async function readPayload(url: URL, now: Date) {
   const params = url.searchParams
@@ -72,10 +78,26 @@ async function readPayload(url: URL, now: Date) {
     exp: Number(params.get('exp')),
   })
 
-  if (!parsed.success) return null
+  if (!parsed.success) {
+    // どの項目が形として通らなかったか。**値は書かない**
+    console.error(
+      `og: 形が違う（${parsed.error.issues.map((issue) => issue.path.join('.')).join(', ')}）`,
+    )
+    return null
+  }
+
+  // 🔴 期限は `verifyOgPayload` も見る。ここで見るのは**ログのためだけ**。
+  // 判定そのものは `isOgPayloadExpired` の1箇所にある
+  if (isOgPayloadExpired(parsed.data, now)) {
+    console.error('og: 期限が切れている（呼び出し側の時計がずれている可能性）')
+    return null
+  }
 
   const signature = params.get('sig') ?? ''
-  if (!(await verifyOgPayload(parsed.data, signature, SECRET!, now))) return null
+  if (!(await verifyOgPayload(parsed.data, signature, SECRET!, now))) {
+    console.error('og: 署名が合わない（両側の RENDER_HMAC_SECRET が違う可能性）')
+    return null
+  }
 
   return parsed.data
 }

--- a/apps/render/main_test.ts
+++ b/apps/render/main_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from '@std/assert'
+import { assertEquals, assertStringIncludes } from '@std/assert'
 
 import { signOgPayload, type OgPayload } from '../../packages/shared/src/index.ts'
 
@@ -84,6 +84,51 @@ Deno.test('形が違えば描かない（数でない値）', async () => {
   )
 
   assertEquals(res.status, 403)
+})
+
+Deno.test('描かなかった理由がログに残る（応答には出さない）', async () => {
+  // ⚠️ 「期限切れ」と「署名が合わない」は原因も対処も違う。
+  // 区別が付かず、**両側の鍵が違うのを見つけるのに時間がかかった**（#184）
+  const written: string[] = []
+  const original = console.error
+  console.error = (message: unknown) => written.push(String(message))
+
+  try {
+    const expired = await requestFor(payload({ exp: Math.floor(Date.now() / 1000) - 1 }))
+    const wrongKey = await requestFor(payload(), {
+      signature: await signOgPayload(payload(), 'another-secret'),
+    })
+
+    assertStringIncludes(written[0] ?? '', '期限')
+    assertStringIncludes(written[1] ?? '', '署名')
+
+    // 🔴 応答は変えない。理由を返すと、叩く側に手がかりを与える
+    assertEquals(await expired.text(), 'Forbidden')
+    assertEquals(await wrongKey.text(), 'Forbidden')
+  } finally {
+    console.error = original
+  }
+})
+
+Deno.test('🔴 ログに署名を書かない', async () => {
+  // 残っていると、そこから叩けるようになる
+  const data = payload()
+  const signature = await signOgPayload(data, SECRET)
+
+  const written: string[] = []
+  const original = console.error
+  console.error = (message: unknown) => written.push(String(message))
+
+  try {
+    await requestFor({ ...data, title: '書き換えたタイトル' }, { signature })
+  } finally {
+    console.error = original
+  }
+
+  for (const line of written) {
+    assertEquals(line.includes(signature), false)
+    assertEquals(line.includes(SECRET), false)
+  }
 })
 
 Deno.test('知らない経路は 404', async () => {

--- a/packages/shared/src/og.ts
+++ b/packages/shared/src/og.ts
@@ -84,10 +84,25 @@ export async function signOgPayload(payload: OgPayload, secret: string): Promise
 }
 
 /**
+ * 期限が切れているか。
+ *
+ * ⚠️ **`verifyOgPayload` の外に出してあるのは、ログのため**（#184）。
+ * 「期限切れ」と「署名が合わない」は原因も対処も違うのに、
+ * どちらも 403 になって切り分けられなかった。
+ *
+ * 🔴 **判定はここ1箇所。** 呼び出し側で `exp` を見比べ直さない
+ * （2箇所に書くと、片方だけ直る）。
+ */
+export function isOgPayloadExpired(payload: OgPayload, now: Date): boolean {
+  return payload.exp * 1000 <= now.getTime()
+}
+
+/**
  * 署名を確かめる（Deno Deploy 側）。
  *
- * **合わない理由を返さない。** 「期限切れ」と「改竄」を出し分けても、
+ * **合わない理由を返さない。** 「期限切れ」も「改竄」も、
  * 呼び出し側にできることは変わらない（どちらも描かない）。
+ * 理由が要るのは**ログだけ**なので、`isOgPayloadExpired` を別に呼ぶ。
  *
  * `now` を引数で受け取るのはテストのため（`TECH_STACK.md` §10 と同じ理由で、
  * 関数の中で時計を読まない）。
@@ -98,7 +113,7 @@ export async function verifyOgPayload(
   secret: string,
   now: Date,
 ): Promise<boolean> {
-  if (payload.exp * 1000 <= now.getTime()) return false
+  if (isOgPayloadExpired(payload, now)) return false
 
   const key = await hmacKey(secret)
 


### PR DESCRIPTION
閉じる: #184

## なぜ

`/og` の 403 が **「期限切れ」「署名が合わない」「形が違う」のどれなのか分からなかった。**
呼び出し側（#180）で「生成サービスが 403 を返した」までは追えるようになったが、
その先が分からず、**両側の鍵が違うことを突き止めるのに時間がかかった**（2026-08-08）。

## やったこと

`readPayload()` の3つの経路にログを足す。

| 経路 | ログ |
|---|---|
| Zod が落ちた | `og: 形が違う（completed）` ← **項目名だけ。値は書かない** |
| 期限切れ | `og: 期限が切れている（呼び出し側の時計がずれている可能性）` |
| 署名が合わない | `og: 署名が合わない（両側の RENDER_HMAC_SECRET が違う可能性）` |

🔴 **応答は変えていない。** どれも `403 Forbidden` のまま。理由を返すと叩く側に手がかりを与える。

## 期限の判定を1箇所に保つ

理由を出し分けるには、期限を `verifyOgPayload` の外でも見る必要がある。
**`exp` の比較を2箇所に書くと、片方だけ直る事故になる**ので、
`isOgPayloadExpired()` として `packages/shared` に切り出し、`verifyOgPayload` もそれを呼ぶ。

## テスト（Deno 側 10 件）

- 理由がログに出る（期限 / 署名）
- 🔴 応答は `Forbidden` のまま変わらない
- 🔴 **ログに署名も鍵も書かない**

🤖 Generated with [Claude Code](https://claude.com/claude-code)