### PR TITLE
画像出力のデータと署名（POST 版）

### DIFF
--- a/apps/web/test/export-image-payload.test.ts
+++ b/apps/web/test/export-image-payload.test.ts
@@ -1,0 +1,207 @@
+import {
+  EXPORT_IMAGE_SIGNATURE_TTL_SECONDS,
+  exportImagePayloadSchema,
+  isExportImagePayloadExpired,
+  ITEM_TEXT_MAX_LENGTH,
+  ITEMS_PER_LIST_MAX,
+  LIST_TITLE_MAX_LENGTH,
+  signExportImagePayload,
+  verifyExportImagePayload,
+  type ExportImagePayload,
+} from '@yaritai100list/shared'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * 画像出力に渡すデータと署名のテスト（#189）。
+ *
+ * 署名は Cloudflare Workers が作り、Deno Deploy が確かめる。
+ * **どちらのランタイムにも Web Crypto があるので、ここで両側の挙動を見られる。**
+ *
+ * 🔴 見るのは **「署名が無い/合わないものを描かせないこと」。**
+ * ここが抜けると、誰でも叩けるラスタライズの踏み台になる（`TECH_STACK.md` §9）。
+ */
+
+const SECRET = 'test-secret-not-used-outside-tests'
+const NOW = new Date('2026-08-08T00:00:00.000Z')
+
+function payload(overrides: Partial<ExportImagePayload> = {}): ExportImagePayload {
+  return {
+    title: '人生でやりたいことリスト',
+    items: [
+      { text: '南極に行く', completed: true },
+      { text: 'オーロラを見る', completed: false },
+    ],
+    exp: Math.floor(NOW.getTime() / 1000) + EXPORT_IMAGE_SIGNATURE_TTL_SECONDS,
+    ...overrides,
+  }
+}
+
+describe('exportImagePayloadSchema', () => {
+  it('入力と同じ上限を使う（画像の都合で入力を狭めない）', () => {
+    const ok = exportImagePayloadSchema.safeParse(
+      payload({ title: 'あ'.repeat(LIST_TITLE_MAX_LENGTH) }),
+    )
+    const tooLong = exportImagePayloadSchema.safeParse(
+      payload({ title: 'あ'.repeat(LIST_TITLE_MAX_LENGTH + 1) }),
+    )
+
+    expect(ok.success).toBe(true)
+    expect(tooLong.success).toBe(false)
+  })
+
+  it('項目の文字数にも上限がある', () => {
+    const tooLong = exportImagePayloadSchema.safeParse(
+      payload({ items: [{ text: 'あ'.repeat(ITEM_TEXT_MAX_LENGTH + 1), completed: false }] }),
+    )
+
+    expect(tooLong.success).toBe(false)
+  })
+
+  it('🔴 100件を超える本文は弾く（描く量を無制限にしない）', () => {
+    const item = { text: '南極に行く', completed: false }
+    const ok = exportImagePayloadSchema.safeParse(
+      payload({ items: Array.from({ length: ITEMS_PER_LIST_MAX }, () => item) }),
+    )
+    const tooMany = exportImagePayloadSchema.safeParse(
+      payload({ items: Array.from({ length: ITEMS_PER_LIST_MAX + 1 }, () => item) }),
+    )
+
+    expect(ok.success).toBe(true)
+    expect(tooMany.success).toBe(false)
+  })
+
+  it('1件も無くても通る（まだ何も書いていないリスト）', () => {
+    expect(exportImagePayloadSchema.safeParse(payload({ items: [] })).success).toBe(true)
+  })
+
+  it('🔴 知らない項目は弾く（作者を紛れ込ませない）', () => {
+    const withAuthor = { ...payload(), author: 'aiandrox' }
+
+    expect(exportImagePayloadSchema.safeParse(withAuthor).success).toBe(false)
+  })
+})
+
+describe('署名', () => {
+  it('署名して確かめると通る', async () => {
+    const data = payload()
+
+    expect(
+      await verifyExportImagePayload(data, await signExportImagePayload(data, SECRET), SECRET, NOW),
+    ).toBe(true)
+  })
+
+  it('🔴 タイトルを1文字変えると通らない', async () => {
+    const data = payload()
+    const signature = await signExportImagePayload(data, SECRET)
+
+    expect(
+      await verifyExportImagePayload({ ...data, title: '別のリスト' }, signature, SECRET, NOW),
+    ).toBe(false)
+  })
+
+  it('🔴 項目を書き換えると通らない', async () => {
+    const data = payload()
+    const signature = await signExportImagePayload(data, SECRET)
+    const tampered = {
+      ...data,
+      items: [{ text: '書き換えた', completed: true }, ...data.items.slice(1)],
+    }
+
+    expect(await verifyExportImagePayload(tampered, signature, SECRET, NOW)).toBe(false)
+  })
+
+  it('🔴 「やった」印だけを付け替えても通らない', async () => {
+    const data = payload()
+    const signature = await signExportImagePayload(data, SECRET)
+    const tampered = {
+      ...data,
+      items: data.items.map((item) => ({ ...item, completed: !item.completed })),
+    }
+
+    expect(await verifyExportImagePayload(tampered, signature, SECRET, NOW)).toBe(false)
+  })
+
+  it('🔴 項目を1つ消しても通らない', async () => {
+    const data = payload()
+    const signature = await signExportImagePayload(data, SECRET)
+
+    expect(
+      await verifyExportImagePayload(
+        { ...data, items: data.items.slice(0, 1) },
+        signature,
+        SECRET,
+        NOW,
+      ),
+    ).toBe(false)
+  })
+
+  it('🔴 期限が切れていると通らない', async () => {
+    const data = payload()
+    const signature = await signExportImagePayload(data, SECRET)
+    const later = new Date((data.exp + 1) * 1000)
+
+    expect(await verifyExportImagePayload(data, signature, SECRET, later)).toBe(false)
+  })
+
+  it('🔴 鍵が違うと通らない', async () => {
+    const data = payload()
+    const signature = await signExportImagePayload(data, SECRET)
+
+    expect(await verifyExportImagePayload(data, signature, 'another-secret', NOW)).toBe(false)
+  })
+
+  it('壊れた署名でも落ちない', async () => {
+    const data = payload()
+
+    expect(await verifyExportImagePayload(data, '', SECRET, NOW)).toBe(false)
+    expect(await verifyExportImagePayload(data, 'zzzz', SECRET, NOW)).toBe(false)
+    expect(await verifyExportImagePayload(data, 'abc', SECRET, NOW)).toBe(false)
+  })
+
+  it('🔴 区切りをまたいでも同じ署名にならない', async () => {
+    // 単に繋いで署名すると、**境目をずらした別の内容が同じ文字列になる。**
+    // 入れ子があるぶん og.ts より起きやすいので、項目テキストに区切りを書いて確かめる
+    const a = await signExportImagePayload(
+      payload({ items: [{ text: 'あ2:い', completed: false }] }),
+      SECRET,
+    )
+    const b = await signExportImagePayload(
+      payload({
+        items: [
+          { text: 'あ', completed: false },
+          { text: 'い', completed: false },
+        ],
+      }),
+      SECRET,
+    )
+
+    expect(a).not.toBe(b)
+  })
+
+  it('🔴 項目の数を書き換えても通らない（件数も署名に入っている）', async () => {
+    const one = payload({ items: [{ text: '南極に行く', completed: false }] })
+    const two = payload({
+      items: [
+        { text: '南極に行く', completed: false },
+        { text: '', completed: false },
+      ],
+    })
+
+    expect(await signExportImagePayload(one, SECRET)).not.toBe(
+      await signExportImagePayload(two, SECRET),
+    )
+  })
+})
+
+describe('isExportImagePayloadExpired', () => {
+  it('期限そのものは切れている扱い', () => {
+    const data = payload()
+
+    expect(isExportImagePayloadExpired(data, new Date(data.exp * 1000))).toBe(true)
+    expect(isExportImagePayloadExpired(data, new Date(data.exp * 1000 - 1))).toBe(false)
+  })
+
+  it('有効期間は OGP より短い（押した直後に1回使うだけ）', () => {
+    expect(EXPORT_IMAGE_SIGNATURE_TTL_SECONDS).toBeLessThan(60 * 60)
+  })
+})

--- a/packages/shared/src/export-image.ts
+++ b/packages/shared/src/export-image.ts
@@ -1,0 +1,120 @@
+import { z } from 'zod'
+
+import { signCanonical, verifyCanonical } from './hmac'
+import { ITEM_TEXT_MAX_LENGTH, ITEMS_PER_LIST_MAX, LIST_TITLE_MAX_LENGTH } from './limits'
+
+/**
+ * 画像出力（#9）に渡すデータと、その署名（#189）。
+ *
+ * OGP（`og.ts`）と考え方は同じだが、**運び方が違う。**
+ *
+ * 🔴 **GET のクエリに載せられない。** 100項目 × 22文字 = 2,200文字。
+ * 日本語は URL エンコードで 1 文字 9 バイトになるので **約 20KB** になり、
+ * URL の実用上の上限（8KB 前後）を超える。**POST の本文に対して署名する。**
+ *
+ * 副作用として `/og` のような URL キャッシュが効かないが、
+ * **画像出力は「押したときに1枚作る」もの**で、SNS が繰り返し取りに来る OGP とは性質が違う。
+ */
+
+/**
+ * 画像に描く内容。**リストのタイトルと、やりたいこと全部**（`PRODUCT_SPEC.md` §5.3）。
+ *
+ * 🔴 **作者を入れない**（§5.1）。どの公開面にも出さない。
+ * **入れる場所が無ければ、間違えて入れることもない。**
+ *
+ * ⚠️ 上限は入力と同じものを使う。**画像の都合で入力を狭めない**（#146 の判断）。
+ * 上限があること自体は要る（レイアウト崩れと CPU の両方を防ぐ）。
+ */
+export const exportImagePayloadSchema = z
+  .object({
+    title: z.string().min(1).max(LIST_TITLE_MAX_LENGTH),
+    items: z
+      .array(
+        z
+          .object({
+            text: z.string().min(1).max(ITEM_TEXT_MAX_LENGTH),
+            /** 「やった」印が付いているか。日時は画像に出さないので真偽値だけ */
+            completed: z.boolean(),
+          })
+          .strict(),
+      )
+      .max(ITEMS_PER_LIST_MAX),
+    /** 有効期限（epoch 秒）。**流出した署名をいつまでも使える状態にしない** */
+    exp: z.number().int().positive(),
+  })
+  .strict()
+
+export type ExportImagePayload = z.infer<typeof exportImagePayloadSchema>
+
+/**
+ * 署名の有効期間（秒）。
+ *
+ * OGP（1時間）より短い **5分**。
+ * OGP は SNS が後から取りに来るので余裕が要るが、**こちらは押した直後に1回使うだけ。**
+ * 短いほど、流出したときに困らない。
+ */
+export const EXPORT_IMAGE_SIGNATURE_TTL_SECONDS = 5 * 60
+
+/**
+ * 署名の対象を1つの文字列にする。**両側で同じ並びにするため、ここでしか作らない。**
+ *
+ * 🔴 **長さを前に付ける**（`5:南極に行く` の形）。
+ * `og.ts` は改行で繋いでいるが、**入れ子があるとそれでは足りない。**
+ * 区切り文字を項目テキストに書かれるだけで、別の内容が同じ文字列になってしまう
+ * （例: 項目が1つで `a\nb` と、項目が2つで `a` `b`）。
+ * **長さを前に付ければ、中身に何が入っていても取り違えない。**
+ *
+ * ⚠️ 数えるのは**コードポイント数ではなくバイト数**。
+ * `String.length` はサロゲートペア（絵文字など）を2と数えるので、
+ * 実装を移したときにずれる余地がある。バイト数なら曖昧さがない。
+ */
+function canonical(payload: ExportImagePayload): string {
+  const encoder = new TextEncoder()
+  const part = (value: string) => `${String(encoder.encode(value).length)}:${value}`
+
+  return [
+    part(payload.title),
+    part(String(payload.exp)),
+    part(String(payload.items.length)),
+    ...payload.items.flatMap((item) => [part(item.text), part(item.completed ? '1' : '0')]),
+  ].join('')
+}
+
+/** 署名を作る（Cloudflare Workers 側）。 */
+export async function signExportImagePayload(
+  payload: ExportImagePayload,
+  secret: string,
+): Promise<string> {
+  return signCanonical(canonical(payload), secret)
+}
+
+/**
+ * 期限が切れているか。
+ *
+ * `verifyExportImagePayload` の外に出してあるのは**ログのため**（#184 と同じ）。
+ * 「期限切れ」と「署名が合わない」は原因も対処も違う。
+ *
+ * 🔴 **判定はここ1箇所。** 呼び出し側で `exp` を見比べ直さない。
+ */
+export function isExportImagePayloadExpired(payload: ExportImagePayload, now: Date): boolean {
+  return payload.exp * 1000 <= now.getTime()
+}
+
+/**
+ * 署名を確かめる（Deno Deploy 側）。
+ *
+ * **合わない理由を返さない。** 「期限切れ」も「改竄」も、
+ * 呼び出し側にできることは変わらない（どちらも描かない）。
+ *
+ * `now` を引数で受け取るのはテストのため（`TECH_STACK.md` §10）。
+ */
+export async function verifyExportImagePayload(
+  payload: ExportImagePayload,
+  signature: string,
+  secret: string,
+  now: Date,
+): Promise<boolean> {
+  if (isExportImagePayloadExpired(payload, now)) return false
+
+  return verifyCanonical(canonical(payload), signature, secret)
+}

--- a/packages/shared/src/hmac.ts
+++ b/packages/shared/src/hmac.ts
@@ -1,0 +1,72 @@
+/**
+ * HMAC の下回り（#189）。
+ *
+ * 🔴 **署名する側と確かめる側で同じものを使う。** 署名するのは Cloudflare Workers、
+ * 確かめるのは Deno Deploy。**別々に書くと、片方を直したときにずれる**
+ * （そしてずれたことに気づくのは「画像が出ない」という形でしかない）。
+ *
+ * ⚠️ **Deno でも動くものだけを使う**（`TECH_STACK.md` §12-2）。
+ * Node の `crypto` ではなく **Web Crypto**（`crypto.subtle`）。どちらのランタイムにもある。
+ *
+ * ここには**署名の対象の作り方を置かない。** それは用途ごとに違う（`og.ts` / `export-image.ts`）。
+ */
+
+async function hmacKey(secret: string): Promise<CryptoKey> {
+  return crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign', 'verify'],
+  )
+}
+
+function toHex(buffer: ArrayBuffer): string {
+  return [...new Uint8Array(buffer)].map((byte) => byte.toString(16).padStart(2, '0')).join('')
+}
+
+/**
+ * 16進の文字列をバイト列に戻す。**不正な文字が来たら空を返す**（検証は必ず落ちる）。
+ *
+ * 戻り値を `ArrayBuffer` にしているのは、`crypto.subtle.verify` が
+ * `BufferSource` を要求するため（`Uint8Array<ArrayBufferLike>` は代入できない）。
+ */
+function hexToBytes(hex: string): ArrayBuffer {
+  if (hex.length % 2 !== 0 || !/^[0-9a-f]*$/.test(hex)) return new ArrayBuffer(0)
+
+  const buffer = new ArrayBuffer(hex.length / 2)
+  const bytes = new Uint8Array(buffer)
+
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = Number.parseInt(hex.slice(i * 2, i * 2 + 2), 16)
+  }
+
+  return buffer
+}
+
+/** 文字列に署名する。戻り値は16進。 */
+export async function signCanonical(canonical: string, secret: string): Promise<string> {
+  const key = await hmacKey(secret)
+
+  return toHex(await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(canonical)))
+}
+
+/**
+ * 署名を確かめる。
+ *
+ * 🔴 **自分で文字列比較しない。** `crypto.subtle.verify` は時間差で漏れない。
+ */
+export async function verifyCanonical(
+  canonical: string,
+  signature: string,
+  secret: string,
+): Promise<boolean> {
+  const key = await hmacKey(secret)
+
+  return crypto.subtle.verify(
+    'HMAC',
+    key,
+    hexToBytes(signature),
+    new TextEncoder().encode(canonical),
+  )
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -6,6 +6,8 @@
  */
 
 export * from './export'
+export * from './export-image'
+export * from './hmac'
 export * from './limits'
 export * from './og'
 export * from './og-template'

--- a/packages/shared/src/og.ts
+++ b/packages/shared/src/og.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod'
 
+import { signCanonical, verifyCanonical } from './hmac'
 import { LIST_TITLE_MAX_LENGTH } from './limits'
 
 /**
@@ -13,9 +14,8 @@ import { LIST_TITLE_MAX_LENGTH } from './limits'
  * ここに来る時点で認可は済んでいる、という前提を**署名で担保する。**
  * 生成側は「署名が合っていれば描く」だけでよくなる。
  *
- * ⚠️ **Deno でも動くものだけを使う**（`TECH_STACK.md` §12-2）。
- * HMAC は Node の `crypto` ではなく **Web Crypto**（`crypto.subtle`）で書く。
- * どちらのランタイムにもある。
+ * HMAC の下回りは `hmac.ts`。**署名の対象の作り方だけがここにある**
+ * （用途ごとに違うため。画像出力は #189）。
  */
 
 /**
@@ -57,30 +57,9 @@ function canonical(payload: OgPayload): string {
     .join('\n')
 }
 
-async function hmacKey(secret: string): Promise<CryptoKey> {
-  return crypto.subtle.importKey(
-    'raw',
-    new TextEncoder().encode(secret),
-    { name: 'HMAC', hash: 'SHA-256' },
-    false,
-    ['sign', 'verify'],
-  )
-}
-
-function toHex(buffer: ArrayBuffer): string {
-  return [...new Uint8Array(buffer)].map((byte) => byte.toString(16).padStart(2, '0')).join('')
-}
-
 /** 署名を作る（Cloudflare Workers 側）。 */
 export async function signOgPayload(payload: OgPayload, secret: string): Promise<string> {
-  const key = await hmacKey(secret)
-  const signature = await crypto.subtle.sign(
-    'HMAC',
-    key,
-    new TextEncoder().encode(canonical(payload)),
-  )
-
-  return toHex(signature)
+  return signCanonical(canonical(payload), secret)
 }
 
 /**
@@ -115,32 +94,5 @@ export async function verifyOgPayload(
 ): Promise<boolean> {
   if (isOgPayloadExpired(payload, now)) return false
 
-  const key = await hmacKey(secret)
-
-  // 🔴 **自分で文字列比較しない。** `crypto.subtle.verify` は時間差で漏れない
-  return crypto.subtle.verify(
-    'HMAC',
-    key,
-    hexToBytes(signature),
-    new TextEncoder().encode(canonical(payload)),
-  )
-}
-
-/**
- * 16進の文字列をバイト列に戻す。**不正な文字が来たら空を返す**（検証は必ず落ちる）。
- *
- * 戻り値を `ArrayBuffer` にしているのは、`crypto.subtle.verify` が
- * `BufferSource` を要求するため（`Uint8Array<ArrayBufferLike>` は代入できない）。
- */
-function hexToBytes(hex: string): ArrayBuffer {
-  if (hex.length % 2 !== 0 || !/^[0-9a-f]*$/.test(hex)) return new ArrayBuffer(0)
-
-  const buffer = new ArrayBuffer(hex.length / 2)
-  const bytes = new Uint8Array(buffer)
-
-  for (let i = 0; i < bytes.length; i++) {
-    bytes[i] = Number.parseInt(hex.slice(i * 2, i * 2 + 2), 16)
-  }
-
-  return buffer
+  return verifyCanonical(canonical(payload), signature, secret)
 }


### PR DESCRIPTION
Closes #189

## POST にした理由

OGP（#170）は GET のクエリに載せて署名したが、**画像出力では同じ手が使えない。**

100項目 × 22文字 = 2,200文字。日本語は URL エンコードで 1 文字 9 バイトになるので **約 20KB**。
URL の実用上の上限（8KB 前後）を超える。→ **本文に対して署名する。**

副作用として `/og` のような URL キャッシュが効かないが、
**画像出力は「押したときに1枚作る」もの**なので困らない。

## canonical は長さを前に付ける

`og.ts` は改行で繋いでいるが、**入れ子があるとそれでは足りない。**
区切りを項目テキストに書かれるだけで、別の内容が同じ文字列になる:

```
項目が1つ: ["あ\nい"]     → "あ\nい"
項目が2つ: ["あ", "い"]   → "あ\nい"   ← 同じ！
```

なので `5:南極に行く` の形で**長さを前に付ける**。中身に何が入っていても取り違えない。
数えるのは**バイト数**（`String.length` はサロゲートペアを2と数えるので曖昧）。
**件数も署名に入れている。**

## `og.ts` の canonical は変えていない

長さ前置きの方が良いが、**変えると両側のデプロイのずれで画像が一時的に出なくなる**
（Workers は GitHub Actions、Deno Deploy は自前のビルドで、揃わない）。
`og.ts` の形は既にテストで守られているので、そのままにした。

共有したのは **HMAC の下回りだけ**（`hmac.ts`）。署名の対象の作り方は用途ごとに違う。

## 有効期間は 5分

OGP は1時間（SNS が後から取りに来る）。**こちらは押した直後に1回使うだけ**なので短くした。

## テスト（17 件）

- 🔴 タイトル / 項目 / 「やった」印 / 件数、どれを書き換えても通らない
- 🔴 **区切りをまたいでも同じ署名にならない**（項目テキストに `2:` を書いて確認）
- 🔴 期限切れ・鍵違い・壊れた署名
- 🔴 100件を超える本文を弾く、知らない項目（作者など）を弾く

🤖 Generated with [Claude Code](https://claude.com/claude-code)