### PR TITLE
生成サービスに POST /export を足す

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,9 @@ jobs:
       - name: render (deno)
         if: ${{ !cancelled() && steps.install.outcome == 'success' }}
         working-directory: apps/render
+        # ⚠️ **deno.json のタスクを呼ぶ。** ここに同じコマンドを書くと、
+        # 見るファイルが手元と CI でずれる（preview.ts が実際にずれていた）
         run: |
-          deno check main.ts main_test.ts
+          deno task check
           deno lint
-          deno test --allow-read --allow-env
+          deno task test

--- a/apps/render/main.ts
+++ b/apps/render/main.ts
@@ -2,18 +2,34 @@ import { initWasm, Resvg } from '@resvg/resvg-wasm'
 import satori from 'satori'
 
 import {
+  buildExportImageTemplate,
   buildOgTemplate,
+  EXPORT_IMAGE_HEIGHT,
+  EXPORT_IMAGE_MAX_BODY_BYTES,
+  EXPORT_IMAGE_SIGNATURE_HEADER,
+  EXPORT_IMAGE_WIDTH,
+  exportImagePayloadSchema,
+  isExportImagePayloadExpired,
   isOgPayloadExpired,
   OG_IMAGE_HEIGHT,
   OG_IMAGE_WIDTH,
   ogPayloadSchema,
+  verifyExportImagePayload,
   verifyOgPayload,
+  type OgElement,
 } from '../../packages/shared/src/index.ts'
 
 /**
- * 画像生成サービス（Deno Deploy）。#172。
+ * 画像生成サービス（Deno Deploy）。#172 / #191。
  *
  * **やることは1つだけ: 渡されたデータを描いて PNG で返す。**
+ *
+ * 経路は2つ。**中身も見た目も別だが、仕組みは全部共通**（`PRODUCT_SPEC.md` §5.3）。
+ *
+ * | | | |
+ * |---|---|---|
+ * | `GET /og` | SNS のカード | クエリに署名（小さいので URL に載る） |
+ * | `POST /export` | やりたいこと全部 | 本文に署名（100項目は URL に載らない。#189） |
  *
  * 🔴 **公開/非公開をここで判断しない**（`CLAUDE.md` の不変条件）。
  * 認可は呼び出し側（Cloudflare Workers）で済んでいて、
@@ -102,32 +118,107 @@ async function readPayload(url: URL, now: Date) {
   return parsed.data
 }
 
-export async function handler(request: Request): Promise<Response> {
-  const url = new URL(request.url)
+/**
+ * 描いて PNG にする。**2つの経路で共通**（`TECH_STACK.md` §4.3）。
+ *
+ * ⚠️ 戻り値を `Uint8Array<ArrayBuffer>` と書いているのは、
+ * `Response` が `ArrayBufferLike` を受け取らないため（素の `Uint8Array` だと型が合わない）。
+ */
+async function toPng(
+  element: OgElement,
+  width: number,
+  height: number,
+): Promise<Uint8Array<ArrayBuffer>> {
+  const svg = await satori(element as never, { width, height, fonts: FONTS })
 
-  // 生きているかの確認用。**中身は返さない**
-  if (url.pathname === '/health') return new Response('ok')
+  return new Uint8Array(new Resvg(svg).render().asPng())
+}
 
-  if (url.pathname !== '/og') return new Response('Not Found', { status: 404 })
+const forbidden = () => new Response('Forbidden', { status: 403 })
 
-  const payload = await readPayload(url, new Date())
-  if (!payload) return new Response('Forbidden', { status: 403 })
+/**
+ * 画像出力（#191）。**POST。本文に署名する。**
+ *
+ * OGP と違ってクエリに載せられない（100項目 × 22文字。#189）。
+ * 署名は `x-signature` ヘッダで受け取る。
+ */
+async function handleExport(request: Request, now: Date): Promise<Response> {
+  if (request.method !== 'POST') {
+    return new Response('Method Not Allowed', { status: 405 })
+  }
 
-  const svg = await satori(buildOgTemplate(payload) as never, {
-    width: OG_IMAGE_WIDTH,
-    height: OG_IMAGE_HEIGHT,
-    fonts: FONTS,
+  // 🔴 **読む前に切る。** 桁の大きい本文は、読むだけ無駄（`TECH_STACK.md` §9）
+  const declared = Number(request.headers.get('content-length') ?? 0)
+  if (declared > EXPORT_IMAGE_MAX_BODY_BYTES) {
+    console.error('export: 本文が大きすぎる')
+    return new Response('Payload Too Large', { status: 413 })
+  }
+
+  const body: unknown = await request.json().catch(() => null)
+  const parsed = exportImagePayloadSchema.safeParse(body)
+
+  if (!parsed.success) {
+    // どの項目が形として通らなかったか。**値は書かない**
+    console.error(
+      `export: 形が違う（${parsed.error.issues.map((issue) => issue.path.join('.')).join(', ')}）`,
+    )
+    return forbidden()
+  }
+
+  if (isExportImagePayloadExpired(parsed.data, now)) {
+    console.error('export: 期限が切れている（呼び出し側の時計がずれている可能性）')
+    return forbidden()
+  }
+
+  const signature = request.headers.get(EXPORT_IMAGE_SIGNATURE_HEADER) ?? ''
+  if (!(await verifyExportImagePayload(parsed.data, signature, SECRET!, now))) {
+    console.error('export: 署名が合わない（両側の RENDER_HMAC_SECRET が違う可能性）')
+    return forbidden()
+  }
+
+  const png = await toPng(
+    buildExportImageTemplate(parsed.data),
+    EXPORT_IMAGE_WIDTH,
+    EXPORT_IMAGE_HEIGHT,
+  )
+
+  return new Response(png, {
+    headers: {
+      'content-type': 'image/png',
+      // ⚠️ **キャッシュさせない。** URL にバージョンが無く（POST なので）、
+      // 中身は押すたびに変わりうる。OGP とはここが違う
+      'cache-control': 'no-store',
+    },
   })
+}
 
-  const png = new Resvg(svg).render().asPng()
+/** OGP 画像（#172）。**GET。クエリに署名。** */
+async function handleOg(url: URL, now: Date): Promise<Response> {
+  const payload = await readPayload(url, now)
+  if (!payload) return forbidden()
 
-  return new Response(new Uint8Array(png), {
+  const png = await toPng(buildOgTemplate(payload), OG_IMAGE_WIDTH, OG_IMAGE_HEIGHT)
+
+  return new Response(png, {
     headers: {
       'content-type': 'image/png',
       // 呼び出し側（Cloudflare）でもキャッシュするが、ここでも効かせておく
       'cache-control': 'public, max-age=31536000, immutable',
     },
   })
+}
+
+export async function handler(request: Request): Promise<Response> {
+  const url = new URL(request.url)
+  const now = new Date()
+
+  // 生きているかの確認用。**中身は返さない**
+  if (url.pathname === '/health') return new Response('ok')
+
+  if (url.pathname === '/og') return handleOg(url, now)
+  if (url.pathname === '/export') return handleExport(request, now)
+
+  return new Response('Not Found', { status: 404 })
 }
 
 // Deno Deploy はモジュールの既定の輸出を見る

--- a/apps/render/main.ts
+++ b/apps/render/main.ts
@@ -208,7 +208,12 @@ async function handleOg(url: URL, now: Date): Promise<Response> {
   })
 }
 
-export async function handler(request: Request): Promise<Response> {
+/**
+ * ⚠️ `async` を付けていないのは、**この関数自身は待たないから**
+ * （`deno lint` の `require-await` に引っかかる）。
+ * 戻り値に `Response` と `Promise<Response>` の両方があるのはそのため。
+ */
+export function handler(request: Request): Response | Promise<Response> {
   const url = new URL(request.url)
   const now = new Date()
 

--- a/apps/render/main_test.ts
+++ b/apps/render/main_test.ts
@@ -1,6 +1,12 @@
 import { assertEquals, assertStringIncludes } from '@std/assert'
 
-import { signOgPayload, type OgPayload } from '../../packages/shared/src/index.ts'
+import {
+  EXPORT_IMAGE_SIGNATURE_HEADER,
+  signExportImagePayload,
+  signOgPayload,
+  type ExportImagePayload,
+  type OgPayload,
+} from '../../packages/shared/src/index.ts'
 
 /**
  * 画像生成サービスのテスト（#172）。
@@ -129,6 +135,118 @@ Deno.test('🔴 ログに署名を書かない', async () => {
     assertEquals(line.includes(signature), false)
     assertEquals(line.includes(SECRET), false)
   }
+})
+
+/**
+ * 画像出力（#191）。**POST。本文に署名する。**
+ *
+ * 🔴 見るのは OGP と同じ **「署名が合わないものを描かないこと」。**
+ * 経路が増えても、抜けたら踏み台になるのは変わらない。
+ */
+
+function exportPayload(overrides: Partial<ExportImagePayload> = {}): ExportImagePayload {
+  return {
+    title: '人生でやりたいことリスト',
+    items: [
+      { text: '南極に行く', completed: true },
+      { text: 'オーロラを見る', completed: false },
+    ],
+    exp: Math.floor(Date.now() / 1000) + 300,
+    ...overrides,
+  }
+}
+
+async function exportRequest(
+  data: ExportImagePayload,
+  options: { signature?: string; method?: string; headers?: Record<string, string> } = {},
+) {
+  const body = JSON.stringify(data)
+
+  return handler(
+    new Request('http://localhost/export', {
+      method: options.method ?? 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'content-length': String(new TextEncoder().encode(body).length),
+        [EXPORT_IMAGE_SIGNATURE_HEADER]:
+          options.signature ?? (await signExportImagePayload(data, SECRET)),
+        ...options.headers,
+      },
+      body,
+    }),
+  )
+}
+
+Deno.test('署名が合えば PNG を返す', async () => {
+  const res = await exportRequest(exportPayload())
+
+  assertEquals(res.status, 200)
+  assertEquals(res.headers.get('content-type'), 'image/png')
+
+  const head = new Uint8Array(await res.arrayBuffer()).slice(0, 4)
+  assertEquals([...head], [0x89, 0x50, 0x4e, 0x47])
+})
+
+Deno.test('🔴 署名が無ければ描かない', async () => {
+  const res = await exportRequest(exportPayload(), { signature: '' })
+
+  assertEquals(res.status, 403)
+})
+
+Deno.test('🔴 本文を書き換えると描かない', async () => {
+  const data = exportPayload()
+  const signature = await signExportImagePayload(data, SECRET)
+
+  const res = await exportRequest({ ...data, title: '書き換えたタイトル' }, { signature })
+
+  assertEquals(res.status, 403)
+})
+
+Deno.test('🔴 期限が切れていたら描かない', async () => {
+  const expired = exportPayload({ exp: Math.floor(Date.now() / 1000) - 1 })
+
+  assertEquals((await exportRequest(expired)).status, 403)
+})
+
+Deno.test('🔴 GET では受け付けない', async () => {
+  const res = await handler(new Request('http://localhost/export'))
+
+  assertEquals(res.status, 405)
+})
+
+Deno.test('🔴 100件を超える本文は描かない', async () => {
+  const item = { text: '南極に行く', completed: false }
+  const tooMany = exportPayload({ items: Array.from({ length: 101 }, () => item) })
+
+  assertEquals((await exportRequest(tooMany)).status, 403)
+})
+
+Deno.test('🔴 大きすぎる本文は読む前に切る', async () => {
+  // 署名は正しくても、読むだけ無駄なので手前で落とす
+  const data = exportPayload()
+  const res = await exportRequest(data, { headers: { 'content-length': String(200 * 1024) } })
+
+  assertEquals(res.status, 413)
+})
+
+Deno.test('壊れた JSON でも落ちない', async () => {
+  const res = await handler(new Request('http://localhost/export', { method: 'POST', body: '{' }))
+
+  assertEquals(res.status, 403)
+})
+
+Deno.test('描かなかった理由がログに残る（画像出力も）', async () => {
+  const written: string[] = []
+  const original = console.error
+  console.error = (message: unknown) => written.push(String(message))
+
+  try {
+    await exportRequest(exportPayload(), { signature: '' })
+  } finally {
+    console.error = original
+  }
+
+  assertStringIncludes(written[0] ?? '', '署名')
 })
 
 Deno.test('知らない経路は 404', async () => {

--- a/packages/shared/src/export-image.ts
+++ b/packages/shared/src/export-image.ts
@@ -47,6 +47,22 @@ export const exportImagePayloadSchema = z
 export type ExportImagePayload = z.infer<typeof exportImagePayloadSchema>
 
 /**
+ * 署名を載せるヘッダの名前。
+ *
+ * 🔴 **両側で同じ名前を使うため、ここに置く。**
+ * OGP はクエリに `sig` を載せているが、こちらは本文に署名するので置き場が無い。
+ */
+export const EXPORT_IMAGE_SIGNATURE_HEADER = 'x-signature'
+
+/**
+ * 本文の大きさの上限（バイト）。
+ *
+ * 🔴 **Zod で弾く前に切る。** 100件 × 22文字は JSON にしても 10KB 程度。
+ * それより桁が大きいものは、読むだけ無駄（`TECH_STACK.md` §9）。
+ */
+export const EXPORT_IMAGE_MAX_BODY_BYTES = 100 * 1024
+
+/**
  * 署名の有効期間（秒）。
  *
  * OGP（1時間）より短い **5分**。


### PR DESCRIPTION
Closes #191

## 経路が2つになった

| | 中身 | 署名の載せ方 |
|---|---|---|
| `GET /og` | SNS のカード | クエリ（小さいので URL に載る） |
| `POST /export` | やりたいこと全部 | **本文**（100項目は URL に載らない。#189） |

**中身も見た目も別だが、仕組みは全部共通。** WASM とフォントの読み込み、
ラスタライズ（`toPng`）、署名の作法、ログの出し方。
**ここが #8 を先に作った見返り**（`PRODUCT_SPEC.md` §5.3 の「先に OGP を作ると安く済む」）。

## 断る順番

1. **POST でなければ 405**
2. **`content-length` が大きすぎれば 413。** 🔴 読む前に切る（読むだけ無駄）
3. Zod で形を見る → 403
4. 期限 → 403
5. 署名（`x-signature` ヘッダ）→ 403

🔴 **3〜5 はどれも同じ 403。** 理由を返すと叩く側に手がかりを与える。
**理由はログにだけ残す**（#184 と同じ。値・署名・鍵は書かない）。

## キャッシュは効かせない

OGP は URL にバージョンがあるので恒久キャッシュにしているが、
**こちらは POST で、中身は押すたびに変わりうる。** `no-store`。

## テスト（Deno 側 19 件、+9）

- 署名が合えば PNG（先頭が PNG のマジックナンバー）
- 🔴 署名が無い / 本文を書き換えた / 期限切れ → 描かない
- 🔴 GET では受け付けない（405）
- 🔴 100件を超える本文 / 大きすぎる本文を弾く
- 壊れた JSON でも落ちない
- 拒否した理由がログに残る

🤖 Generated with [Claude Code](https://claude.com/claude-code)