### PR TITLE
/api/lists/:listId/image（認可とレート制限）

### DIFF
--- a/TECH_STACK.md
+++ b/TECH_STACK.md
@@ -336,7 +336,7 @@ DB も認証状態も持たない。渡すデータに HMAC で署名すれば�
 | `/discover` | 取り入れ面（将来） | 不要（取り入れ操作のみ要） | SPA |
 | `/share/:shareId` | 共有公開ページ（OGP メタタグ付き） | 不要 | **SSR** |
 | `/og/:shareId?v=` | OGP 画像（Deno Deploy に署名付きで生成を依頼、CDN でキャッシュ） | 不要 | 画像 |
-| `/export/:listId` | ダウンロード画像 | 要 | 画像 |
+| `/api/lists/:listId/image` | ダウンロード画像（#192）。**`/api/*` に入れた**ので `run_worker_first` の追加が要らず、`requireOwnedList` もそのまま使える | 要 | 画像 |
 | `/api/*` | JSON | 混在 | — |
 
 **`/` で一覧を見せず、最後に更新したリストを直接開く。**

--- a/apps/web/src/export-image.ts
+++ b/apps/web/src/export-image.ts
@@ -1,0 +1,62 @@
+import {
+  EXPORT_IMAGE_SIGNATURE_HEADER,
+  EXPORT_IMAGE_SIGNATURE_TTL_SECONDS,
+  type ExportImagePayload,
+} from '@yaritai100list/shared'
+
+/**
+ * 画像出力の入口（#192）。**認可はここで済ませる。**
+ *
+ * 🔴 **生成サービスに認可を判断させない**（`CLAUDE.md` の不変条件）。
+ * `requireOwnedList` を通した行だけを署名して渡す。
+ *
+ * OGP（`og.ts`）との違いは**運び方だけ**。あちらは GET のクエリ、こちらは POST の本文
+ * （100項目は URL に載らない。#189）。
+ */
+
+/**
+ * 画像に描くデータを組み立てる。**純関数**（`TECH_STACK.md` §10）。
+ *
+ * 渡すのは**タイトルと項目だけ。** 作者も完了日時も入れない
+ * （`PRODUCT_SPEC.md` §5.1 / §5.3。そもそも `ExportImagePayload` に入れる場所が無い）。
+ */
+export function buildExportImagePayload(
+  list: { title: string },
+  items: { text: string; completedAt: Date | null }[],
+  now: Date,
+): ExportImagePayload {
+  return {
+    title: list.title,
+    items: items.map((item) => ({ text: item.text, completed: item.completedAt !== null })),
+    exp: Math.floor(now.getTime() / 1000) + EXPORT_IMAGE_SIGNATURE_TTL_SECONDS,
+  }
+}
+
+/**
+ * 生成サービスへの問い合わせ。**POST で、署名はヘッダに載せる。**
+ *
+ * `Request` を組み立てて返すのは、**中身をテストで見られるようにするため**
+ * （`fetch` の中で組み立てると、何を送っているか確かめられない）。
+ */
+export function exportImageRequest(
+  base: string,
+  payload: ExportImagePayload,
+  signature: string,
+): Request {
+  return new Request(`${base.replace(/\/$/, '')}/export`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      [EXPORT_IMAGE_SIGNATURE_HEADER]: signature,
+    },
+    body: JSON.stringify(payload),
+  })
+}
+
+/**
+ * ダウンロードするときのファイル名。
+ *
+ * ⚠️ **ASCII だけにする。** `content-disposition` に日本語をそのまま書くと文字化けする。
+ * 見せる名前はクライアント側で付ける（#193）。ここは直接開かれたときの保険。
+ */
+export const EXPORT_IMAGE_FILE_NAME = 'yaritai100list.png'

--- a/apps/web/src/index.ts
+++ b/apps/web/src/index.ts
@@ -9,6 +9,7 @@ import {
   LISTS_PER_USER_MAX,
   SHARED_VISIBILITIES,
   itemTextSchema,
+  signExportImagePayload,
   signOgPayload,
   listTitleSchema,
   visibilitySchema,
@@ -24,8 +25,9 @@ import { createDb, type Db } from './db'
 import { items, lists } from './db/schema'
 import type { AppEnv } from './env'
 import { newId, newShareId } from './id'
+import { buildExportImagePayload, EXPORT_IMAGE_FILE_NAME, exportImageRequest } from './export-image'
 import { buildOgPayload, cacheControlFor, ogImageUrl, renderRequestUrl } from './og'
-import { rateLimitCreates } from './rate-limit'
+import { rateLimitCreates, rateLimitImages } from './rate-limit'
 import { renderSharePage, renderShareNotFound } from './share'
 import { sentryOptions } from './sentry'
 
@@ -420,6 +422,63 @@ const app = new Hono<AppEnv>()
     const rows = await selectItems(createDb(c.env.DB), list.id)
 
     return c.json(buildExportFile({ title: list.title, items: rows }, new Date()))
+  })
+
+  /**
+   * ダウンロード画像（#192）。**やりたいこと全部を1枚に描く。**
+   *
+   * 🔴 **`requireOwnedList` を通す。** ハンドラは `listId` を受け取らず、
+   * **すでに認可を通った行**を `c.get('list')` で受け取る（`src/authorization.ts`）。
+   * 他人の `listId` は「見つからない」と同じ 404 になる。
+   *
+   * 🔴 **ログインが要る**（#194 で決定）。未ログインだとクライアントが本文を送る形になり、
+   * **誰でも叩ける POST でラスタライズが走る。**
+   *
+   * OGP（`/og/:shareId`）との違いは**運び方だけ。** あちらは GET のクエリ、
+   * こちらは POST の本文（100項目は URL に載らない。#189）。
+   */
+  .get('/api/lists/:listId/image', requireUser, requireOwnedList, rateLimitImages, async (c) => {
+    const list = c.get('list')
+    const { RENDER_URL, RENDER_HMAC_SECRET } = c.env
+
+    /** 出せないときの返し。**理由は利用者に見せず、ログに残す**（#180 と同じ）。 */
+    const unavailable = (reason: string) => {
+      console.error(`export: ${reason}`)
+      return c.json({ error: 'Image Not Available' } as const, 503)
+    }
+
+    // 🔴 **鍵が無ければ画像を出さない。** 署名なしで叩ける状態を作らない
+    if (!RENDER_HMAC_SECRET) {
+      return unavailable('RENDER_HMAC_SECRET が設定されていない')
+    }
+
+    const rows = await selectItems(createDb(c.env.DB), list.id)
+    const payload = buildExportImagePayload(list, rows, new Date())
+    const signature = await signExportImagePayload(payload, RENDER_HMAC_SECRET)
+
+    // ⚠️ **繋がらないときは fetch が投げる。** 捕まえないと 500 になり、
+    // **失敗を「壊れた」として扱ってしまう**
+    let rendered: Response
+    try {
+      rendered = await fetch(exportImageRequest(RENDER_URL, payload, signature))
+    } catch {
+      return unavailable(`生成サービスに繋がらない（${RENDER_URL}）`)
+    }
+
+    if (!rendered.ok) {
+      // **403 なら両側の鍵が違う**（生成サービスは理由を返さない）
+      return unavailable(`生成サービスが ${String(rendered.status)} を返した`)
+    }
+
+    return new Response(rendered.body, {
+      headers: {
+        'content-type': rendered.headers.get('content-type') ?? 'image/png',
+        // ⚠️ **キャッシュさせない。** URL にバージョンが無く、中身は押すたびに変わりうる
+        'cache-control': 'no-store',
+        // 直接開かれたときの保険。見せる名前はクライアント側で付ける（#193）
+        'content-disposition': `attachment; filename="${EXPORT_IMAGE_FILE_NAME}"`,
+      },
+    })
   })
 
   /**

--- a/apps/web/src/rate-limit.ts
+++ b/apps/web/src/rate-limit.ts
@@ -24,3 +24,22 @@ export const rateLimitCreates = createMiddleware<AppEnv>(async (c, next) => {
 
   return next()
 })
+
+/**
+ * 画像出力のレート制限。**`requireUser` の後に置く。**
+ *
+ * 🔴 **作成系と別の枠にする。** 1回で 100 項目をラスタライズするので、
+ * 他の操作とは重さが桁違い（生成サービスの CPU 枠を溶かす。`TECH_STACK.md` §9）。
+ * 同じ枠にすると、**画像を連打した人が項目の編集まで止めてしまう。**
+ *
+ * 設定（回数と期間）は `wrangler.jsonc` の `ratelimits`。
+ */
+export const rateLimitImages = createMiddleware<AppEnv>(async (c, next) => {
+  const { success } = await c.env.IMAGE_RATE_LIMIT.limit({ key: c.get('userId') })
+
+  if (!success) {
+    return c.json({ error: 'Too Many Requests' } as const, 429)
+  }
+
+  return next()
+})

--- a/apps/web/test/export-image-route.test.ts
+++ b/apps/web/test/export-image-route.test.ts
@@ -1,0 +1,209 @@
+import { exports } from 'cloudflare:workers'
+import {
+  EXPORT_IMAGE_SIGNATURE_HEADER,
+  EXPORT_IMAGE_SIGNATURE_TTL_SECONDS,
+} from '@yaritai100list/shared'
+import { describe, expect, it, vi } from 'vitest'
+
+import { items, lists } from '../src/db/schema'
+import { buildExportImagePayload, exportImageRequest } from '../src/export-image'
+import { signIn, testBaseUrl, testDb } from './helpers'
+
+/**
+ * ダウンロード画像の入口のテスト（#192）。
+ *
+ * 🔴 見るのは **「他人のリストの画像が出ないこと」** と
+ * **「誰でも叩ける状態になっていないこと」**（`TECH_STACK.md` §9）。
+ *
+ * 画像そのものは Deno Deploy 側（#191）。**テスト環境には無いので 503 が正しい応答。**
+ */
+
+const request = (path: string, init?: RequestInit) =>
+  exports.default.fetch(new Request(`${testBaseUrl()}${path}`, init))
+
+/** ログイン済みの利用者としてリストを1つ作る。 */
+async function createList(headers: Headers, userId: string, rows: string[] = ['南極に行く']) {
+  const db = testDb()
+  const id = crypto.randomUUID()
+
+  await db.insert(lists).values({
+    id,
+    userId,
+    title: '人生でやりたいことリスト',
+    shareId: crypto.randomUUID().replaceAll('-', ''),
+  })
+
+  if (rows.length > 0) {
+    await db.insert(items).values(
+      rows.map((text, position) => ({
+        id: crypto.randomUUID(),
+        listId: id,
+        text,
+        position,
+        completedAt: position === 0 ? new Date() : null,
+      })),
+    )
+  }
+
+  return { id, headers }
+}
+
+const imageRequest = (listId: string, headers?: Headers) =>
+  request(
+    `/api/lists/${listId}/image`,
+    headers === undefined ? undefined : { headers: Object.fromEntries(headers) },
+  )
+
+describe('buildExportImagePayload', () => {
+  const now = new Date('2026-08-08T00:00:00.000Z')
+
+  it('「やった」印を真偽値にする（日時は画像に出さない）', () => {
+    const payload = buildExportImagePayload(
+      { title: '人生でやりたいことリスト' },
+      [
+        { text: '南極に行く', completedAt: new Date() },
+        { text: 'オーロラを見る', completedAt: null },
+      ],
+      now,
+    )
+
+    expect(payload.title).toBe('人生でやりたいことリスト')
+    expect(payload.items).toEqual([
+      { text: '南極に行く', completed: true },
+      { text: 'オーロラを見る', completed: false },
+    ])
+  })
+
+  it('期限が入る', () => {
+    const payload = buildExportImagePayload({ title: 'x' }, [], now)
+
+    expect(payload.exp).toBe(Math.floor(now.getTime() / 1000) + EXPORT_IMAGE_SIGNATURE_TTL_SECONDS)
+  })
+
+  it('🔴 作者が入る余地が無い', () => {
+    const payload = buildExportImagePayload({ title: 'x' }, [], now)
+
+    expect(Object.keys(payload).sort()).toEqual(['exp', 'items', 'title'])
+  })
+})
+
+describe('exportImageRequest', () => {
+  const payload = { title: 'x', items: [], exp: 1 }
+
+  it('POST で /export に送る', () => {
+    const built = exportImageRequest('https://example.com', payload, 'abc')
+
+    expect(built.method).toBe('POST')
+    expect(built.url).toBe('https://example.com/export')
+  })
+
+  it('🔴 署名はヘッダに載せる（URL には載らない）', () => {
+    const built = exportImageRequest('https://example.com', payload, 'abc')
+
+    expect(built.headers.get(EXPORT_IMAGE_SIGNATURE_HEADER)).toBe('abc')
+    expect(built.url).not.toContain('abc')
+  })
+
+  it('末尾のスラッシュがあっても壊れない', () => {
+    expect(exportImageRequest('https://example.com/', payload, 'x').url).toBe(
+      'https://example.com/export',
+    )
+  })
+})
+
+describe('GET /api/lists/:listId/image', () => {
+  it('🔴 未ログインでは出ない', async () => {
+    const owner = await signIn(`${crypto.randomUUID()}@example.com`)
+    const list = await createList(owner.headers, owner.userId)
+
+    expect((await imageRequest(list.id)).status).toBe(401)
+  })
+
+  it('🔴 他人のリストでは出ない', async () => {
+    const owner = await signIn(`${crypto.randomUUID()}@example.com`)
+    const list = await createList(owner.headers, owner.userId)
+    const stranger = await signIn(`${crypto.randomUUID()}@example.com`)
+
+    expect((await imageRequest(list.id, stranger.headers)).status).toBe(404)
+  })
+
+  it('🔴 他人のリストと、存在しない ID で応答が完全に一致する', async () => {
+    // 出し分けると「その ID は存在する」ことが分かってしまう
+    const owner = await signIn(`${crypto.randomUUID()}@example.com`)
+    const list = await createList(owner.headers, owner.userId)
+    const stranger = await signIn(`${crypto.randomUUID()}@example.com`)
+
+    const other = await imageRequest(list.id, stranger.headers)
+    const missing = await imageRequest('no-such-list-id', stranger.headers)
+
+    expect(other.status).toBe(missing.status)
+    expect(await other.text()).toBe(await missing.text())
+  })
+
+  it('自分のリストなら 404 にはならない', async () => {
+    // 生成サービスがテスト環境に無いので 503。**認可は通っている**ことの確認
+    const owner = await signIn(`${crypto.randomUUID()}@example.com`)
+    const list = await createList(owner.headers, owner.userId)
+
+    const res = await imageRequest(list.id, owner.headers)
+
+    expect(res.status).toBe(503)
+    expect(await res.json()).toEqual({ error: 'Image Not Available' })
+  })
+
+  it('出せなかった理由がログに残る（応答には出さない）', async () => {
+    const owner = await signIn(`${crypto.randomUUID()}@example.com`)
+    const list = await createList(owner.headers, owner.userId)
+    const logged = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    const res = await imageRequest(list.id, owner.headers)
+
+    expect(logged).toHaveBeenCalledWith(expect.stringContaining('export:'))
+    expect(await res.json()).toEqual({ error: 'Image Not Available' })
+
+    logged.mockRestore()
+  })
+
+  it('🔴 叩き続けると 429 が返る（作成系より厳しい枠）', async () => {
+    // 1回で100項目をラスタライズするので、他の操作とは重さが桁違い
+    const me = await signIn(`${crypto.randomUUID()}@example.com`)
+    const list = await createList(me.headers, me.userId)
+
+    let limited: Response | null = null
+    for (let i = 0; i < 100; i++) {
+      const res = await imageRequest(list.id, me.headers)
+      if (res.status === 429) {
+        limited = res
+        break
+      }
+    }
+
+    expect(limited).not.toBeNull()
+    expect(await limited?.json()).toEqual({ error: 'Too Many Requests' })
+  })
+
+  it('🔴 制限の枠が作成系と分かれている（画像を連打しても編集は止まらない）', async () => {
+    const me = await signIn(`${crypto.randomUUID()}@example.com`)
+    const list = await createList(me.headers, me.userId)
+
+    for (let i = 0; i < 100; i++) {
+      if ((await imageRequest(list.id, me.headers)).status === 429) break
+    }
+
+    // 同じ枠にすると、ここが 429 になる
+    const created = await request('/api/lists', {
+      method: 'POST',
+      headers: { ...Object.fromEntries(me.headers), 'content-type': 'application/json' },
+      body: '{}',
+    })
+
+    expect(created.status).toBe(201)
+  })
+
+  it('1件も書いていなくても認可は通る', async () => {
+    const owner = await signIn(`${crypto.randomUUID()}@example.com`)
+    const list = await createList(owner.headers, owner.userId, [])
+
+    expect((await imageRequest(list.id, owner.headers)).status).toBe(503)
+  })
+})

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -50,7 +50,7 @@
   // - /api/*            JSON API・認証のコールバック（このコミットで有効）
   // - /share/:shareId   共有公開ページの SSR（#137 で有効）
   // - /og/:shareId      OGP 画像（#8）
-  // - /export/:listId   ダウンロード画像（#9）
+  // - /api/lists/:listId/image  ダウンロード画像（#9）。**/api/* に入るので追加は不要**
   //
   // 全部を Worker に通す（run_worker_first: true）ことはしない。
   // 静的ファイルの配信まで Worker の実行回数を消費するため、無料枠に効く。
@@ -72,6 +72,16 @@
       // 名前空間の識別子。**他のバインディングと重複しない整数**であればよい
       "namespace_id": "1001",
       "simple": { "limit": 60, "period": 60 },
+    },
+    {
+      // 画像出力（#192）。**作成系より厳しくする。**
+      // 1回で 100 項目をラスタライズするので、他の操作とは重さが桁違い
+      // （生成サービスの CPU 枠を溶かす。`TECH_STACK.md` §9）。
+      //
+      // 60 秒で 10 回。押し直す分には当たらない。
+      "name": "IMAGE_RATE_LIMIT",
+      "namespace_id": "1002",
+      "simple": { "limit": 10, "period": 60 },
     },
   ],
 


### PR DESCRIPTION
Closes #192

## 認可

🔴 **`requireUser` → `requireOwnedList` を通す。**
ハンドラは `listId` を受け取らず、`c.get('list')` で**すでに認可を通った行**を受け取る。
**ミドルウェアを付け忘れたら、そもそも触れるリストが無い**（`src/authorization.ts` の設計）。

**他人のリストは「存在しない ID」と応答が完全に一致する。** テストで見ている。

## レート制限は作成系と別の枠にした

`IMAGE_RATE_LIMIT`（60秒で10回）を新しく足した。`CREATE_RATE_LIMIT` は 60秒で60回。

🔴 **1回で100項目をラスタライズするので、他の操作とは重さが桁違い**（`TECH_STACK.md` §9）。
同じ枠にすると、**画像を連打した人が項目の編集まで止めてしまう。**
キーは `userId`（#194 でログイン必須にしたので IP に落ちない）。

## 経路を `/api/*` の下に置いた

`TECH_STACK.md` の URL 表は `/export/:listId` だったが、**`/api/lists/:listId/image` にした。**

- `run_worker_first` に足す必要がない（`/api/*` が既に入っている）。**足し忘れると SPA の
  index.html が返って 404 にならない**という踏みやすい罠を避けられる
- `requireOwnedList` が `:listId` を見るので、そのまま使える
- 既に `/api/lists/:listId/export`（JSON。#115）がある。**隣に並ぶ**

表は更新済み。

## テスト（14 件）

- 🔴 未ログインでは 401 / 他人のリストでは 404
- 🔴 **他人のリストと存在しない ID で応答が完全に一致する**
- 🔴 叩き続けると 429 / **制限の枠が作成系と分かれている**
- 出せなかった理由がログに残り、応答には出ない
- 署名は**ヘッダに載り、URL には載らない**

生成サービスはテスト環境に無いので、成功パスは 503 で「認可は通っている」ことを見ている。
実物の確認は #193（UI）で行う。

🤖 Generated with [Claude Code](https://claude.com/claude-code)