### PR TITLE
画像をダウンロードする UI

### DIFF
--- a/apps/web/src/client/ExportPage.tsx
+++ b/apps/web/src/client/ExportPage.tsx
@@ -24,12 +24,18 @@ import { type SessionState } from './model'
  *
  * 🔴 **マークダウンはここで作る。** サーバーは閲覧者の時間帯を知らないので、
  * 達成日を UTC のまま日付にすると1日ずれる（#124）。
+ *
+ * 画像（#193）は3つ目の形式。**貼るのでも読み込むのでもなく、そのまま見せるもの。**
+ * こちらだけサーバーで作る（`/api/lists/:listId/image`。#192）。
  */
 
 type State =
   | { status: 'loading' }
   | { status: 'failed' }
   | { status: 'ready'; file: ExportFile; markdown: string }
+
+/** 画像の作成は数秒かかる。**押した後に何も起きないように見せない。** */
+type ImageState = 'idle' | 'working' | 'failed'
 
 export function ExportPage({ session, listId }: { session: SessionState; listId: string }) {
   // ログインが要る画面。**未ログインでは開かせない**（#112 と同じ扱い）
@@ -65,6 +71,7 @@ function SignInRequired({ session }: { session: SessionState }) {
 function ExportPageBody({ listId }: { listId: string }) {
   const [state, setState] = useState<State>({ status: 'loading' })
   const [copied, setCopied] = useState(false)
+  const [image, setImage] = useState<ImageState>('idle')
 
   const load = useCallback(async () => {
     try {
@@ -120,6 +127,37 @@ function ExportPageBody({ listId }: { listId: string }) {
     URL.revokeObjectURL(url)
   }
 
+  /**
+   * 画像を落とす。
+   *
+   * JSON と違って**中身はサーバーで作る**ので、
+   * 押してから返るまで数秒かかる。**その間の表示を出す。**
+   */
+  const downloadImage = async () => {
+    setImage('working')
+
+    try {
+      const res = await api.api.lists[':listId'].image.$get({ param: { listId } })
+      if (!res.ok) {
+        setImage('failed')
+        return
+      }
+
+      const url = URL.createObjectURL(await res.blob())
+      const anchor = document.createElement('a')
+
+      anchor.href = url
+      anchor.download = exportFileName(file.list.title, new Date(), 'png')
+      anchor.click()
+
+      // 解放しないとページを閉じるまでメモリに残る
+      URL.revokeObjectURL(url)
+      setImage('idle')
+    } catch {
+      setImage('failed')
+    }
+  }
+
   const copyMarkdown = async () => {
     try {
       await navigator.clipboard.writeText(markdown)
@@ -157,6 +195,32 @@ function ExportPageBody({ listId }: { listId: string }) {
         >
           JSON をダウンロード
         </button>
+      </section>
+
+      <section className="mt-4 rounded bg-white px-3 py-3">
+        <h2 className="font-bold text-slate-900">画像で見せる（PNG）</h2>
+        <p className="mt-1 text-xs text-slate-600">
+          <strong>やりたいこと100個を1枚に並べた画像</strong>です。SNS に貼ったり、
+          印刷して貼っておくのに使えます。
+          <br />
+          <strong>このアプリに読み込むことはできません。</strong>
+        </p>
+
+        <button
+          type="button"
+          onClick={() => void downloadImage()}
+          disabled={image === 'working'}
+          className="mt-3 w-full rounded bg-brand-deep px-3 py-2 text-white disabled:opacity-60"
+        >
+          {image === 'working' ? '作っています…' : '画像をダウンロード'}
+        </button>
+
+        {/* 🔴 黙って何も起きないのが一番まずい。**理由の分かる表示を出す** */}
+        {image === 'failed' && (
+          <p className="mt-2 text-xs text-red-700">
+            画像を作れませんでした。少し待ってから、もう一度試してください
+          </p>
+        )}
       </section>
 
       <section className="mt-4 rounded bg-white px-3 py-3">

--- a/apps/web/test/export-api.test.ts
+++ b/apps/web/test/export-api.test.ts
@@ -197,6 +197,13 @@ describe('exportFileName', () => {
   it('落とした結果が空なら既定の名前になる', () => {
     expect(exportFileName('///', new Date('2026-08-07T00:00:00.000Z'))).toBe('list-2026-08-07.json')
   })
+
+  it('拡張子を選べる（画像は png。#193）', () => {
+    // 画像だけ中身の作り方が違う（サーバーで作る）が、名前の付け方は揃える
+    expect(exportFileName('2026年の目標', new Date('2026-08-07T00:00:00.000Z'), 'png')).toBe(
+      '2026年の目標-2026-08-07.png',
+    )
+  })
 })
 
 describe('GET /api/lists/:listId/export', () => {

--- a/packages/shared/src/export.ts
+++ b/packages/shared/src/export.ts
@@ -110,14 +110,18 @@ export function hasFutureCompletedAt(file: ExportFile, now: Date): boolean {
  * ファイル名に使えない文字（`/` や `\`、制御文字など）はリスト名に入りうるので落とす。
  * 落とした結果が空になることもある（記号だけのタイトル）ので、そのときは既定の名前にする。
  */
-export function exportFileName(title: string, exportedAt: Date): string {
+export function exportFileName(
+  title: string,
+  exportedAt: Date,
+  extension: 'json' | 'png' = 'json',
+): string {
   const date = exportedAt.toISOString().slice(0, 10)
 
   // 経路の区切りと、OS がファイル名に使えない文字だけを落とす。
   // 落としすぎると何のリストか分からなくなるので、日本語や記号は残す
   const safe = title.replace(/[/\\:*?"<>|]/g, '').trim()
 
-  return `${safe === '' ? 'list' : safe}-${date}.json`
+  return `${safe === '' ? 'list' : safe}-${date}.${extension}`
 }
 
 /**


### PR DESCRIPTION
Closes #193

## 書き出し画面に3つ目の形式を足した

| 形式 | 用途 | 読み込める | 作る場所 |
|---|---|---|---|
| JSON | このアプリに読み込み直す | **できる** | クライアント |
| **画像（PNG）** | **SNS に貼る・印刷する** | しない | **サーバー**（#192） |
| マークダウン | ブログなどに貼る | しない | クライアント |

**画像だけサーバーで作る**ので、押してから返るまで数秒かかる。

- 押している間は「作っています…」にして `disabled` にする
- 🔴 失敗したら**理由の分かる表示**を出す。**黙って何も起きないのが一番まずい**

ログインの導線は触っていない。**この画面は元からログインを要求している**（#194）。

## ファイル名

`exportFileName` に拡張子を渡せるようにした（既定は `json` のまま）。
**名前の付け方は JSON と揃える**（`2026年の目標-2026-08-08.png`）。
日付が入るので、何度落としても上書きされない。

## 確認

`npm test` は 353 件緑。ただし**この PR で実物の画像は確認できない。**
生成サービスの鍵はローカルに無く（`.dev.vars` にも CI にも入れていない）、
`/api/lists/:listId/image` は 503 を返す。

⚠️ **本番にデプロイした後、利用者に押してもらって確認する**（#9 の完了条件）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)