### PR TITLE
ドラッグして離した後のちらつきを直す

### DIFF
--- a/apps/web/src/client/useList.ts
+++ b/apps/web/src/client/useList.ts
@@ -386,6 +386,19 @@ export function useList(
       const id = listId.current
       if (id === null) return false
 
+      /**
+       * 🔴 **送る前に画面を新しい並びにする**（#204）。
+       *
+       * 待ってから反映すると、**離した瞬間に一度だけ元の並びに戻って見える。**
+       * ドラッグ中の見た目は dnd-kit が作っているもので、離すと消えるため、
+       * サーバーの応答が返るまでの間だけ古い並びが出る。
+       *
+       * 他の操作（本文・完了・削除）は待ってから反映しているが、
+       * **並べ替えだけは「動かした」という手応えが要る。**
+       * 失敗したときは下で取り直すので、ずれたままにはならない。
+       */
+      setScreen({ status: 'ready', key: id, list: moved.list, source: 'server' })
+
       try {
         const res = await api.api.lists[':listId'].items.order.$put({
           param: { listId: id },
@@ -400,15 +413,20 @@ export function useList(
 
         if (!res.ok) {
           setRejection('server-error')
+          // 先に画面を動かしてあるので、**戻さないとサーバーとずれたままになる**
+          await loadFromServer()
           return false
         }
 
         setRejection(null)
-        await loadFromServer()
 
+        // 🔴 **取り直さない。** 先に反映した並びと同じものが返るだけで、
+        // 往復のぶん画面がもう一度描き直される（そこでまた一瞬ちらつく）。
+        // 並べ替えは**項目の集合が変わらない**ので、削除のように詰め直しも要らない
         return true
       } catch {
         setRejection('server-error')
+        await loadFromServer()
         return false
       }
     },


### PR DESCRIPTION
Closes #205

## なぜ起きていたか

並べ替えは「送る → 応答を待つ → 取り直す → 画面に反映」の順だった。

**ドラッグ中の見た目は dnd-kit が作っているもので、指を離すと消える。**
そこから応答が返るまでの間、画面には**まだ古い並び**が出る。

上下のボタン（#142）のときも同じ経路だったが、
**押した場所と動く場所が近く、1行しか動かない**ので目立たなかった。
ドラッグで何行も飛ばすようになって見えるようになった。

## 直したこと

1. **送る前に画面を新しい並びにする**
2. 成功したら**取り直さない。** 同じ並びが返るだけで、
   もう一度描き直すと**そこでまたちらつく**。
   並べ替えは項目の集合が変わらないので、削除のような詰め直しも要らない
3. 失敗（409・エラー・通信断）したら**取り直す。**
   先に反映してある以上、戻さないとサーバーとずれたままになる

⚠️ **他の操作（本文・完了・削除）は「待ってから反映」のまま。**
先に反映するのは手応えが要るものだけにする。
削除は後ろの並び順が詰まるので、応答だけでは画面を正しく作れない。

## 確認してほしいこと

- [ ] ドラッグして離したとき、**元の並びが一瞬も見えない**
- [ ] 別のタブで項目を足してから並べ替えると、案内が出て正しい状態に戻る（409 の経路）

🤖 Generated with [Claude Code](https://claude.com/claude-code)