### PR TITLE
共有ページの下に「自分のリストを作る」導線を置く（#225）

### DIFF
--- a/apps/web/src/share.ts
+++ b/apps/web/src/share.ts
@@ -62,6 +62,16 @@ const PAGE_STYLE = `
   li.done .text { text-decoration: line-through; color: #94a3b8; }
   li.done .number { color: var(--brand-deep); }
   .date { color: var(--brand-deep); font-size: .65rem; font-variant-numeric: tabular-nums; }
+
+  /* 下の導線（#225）。**人のリストの続きに見えないよう、はっきり離す** */
+  .invite { margin-top: 2.5rem; padding: 1.25rem 1rem; background: #fff; border-radius: .25rem; text-align: center; }
+  .invite h2 { font-size: 1rem; margin: 0; }
+  .invite p { font-size: .75rem; color: #475569; margin: .5rem 0 0; }
+  .invite a {
+    display: inline-block; margin-top: 1rem; padding: .625rem 1.5rem;
+    background: var(--brand-deep); color: #fff; border-radius: .25rem;
+    font-weight: 700; text-decoration: none;
+  }
 `
 
 export interface SharedItem {
@@ -186,8 +196,35 @@ export function renderSharePage(list: SharedList): HtmlEscapedString | Promise<H
           `,
         )}
       </ol>
+
+      ${invite()}
     `,
   })
+}
+
+/**
+ * 下に置く導線（#225）。**共有ページはこのサービスの入口。**
+ *
+ * URL を渡されて開く人は、たいてい**ここで初めてこのサービスを見る。**
+ * それなのに読み終わったら行き止まりで、自分も書けることがどこにも書いていなかった。
+ *
+ * 🔴 **リンク先は `/`。ログインの導線にしない。**
+ * 未ログインでもその場で書けること（`PRODUCT_SPEC.md` §1）が一番の売りで、
+ * **入口でログインを要求したら台無しになる。**
+ * 共有ページにログインの導線を出さないという方針（`src/client/Layout.tsx`）とも揃う。
+ *
+ * 🔴 **`<button>` を使わない。** 「読み取り専用。編集の入口を出さない」の
+ * テストが `<form>` / `<input>` / `<button>` を見張っている（`test/share-page.test.ts`）。
+ * 実際これはリンクなので、`<a>` が正しい。
+ */
+function invite(): HtmlEscapedString {
+  return html`
+    <aside class="invite">
+      <h2>やりたいこと、書いてみませんか</h2>
+      <p>登録は要りません。開いたその場で書き始められます。</p>
+      <a href="/">自分のリストを作る</a>
+    </aside>
+  ` as HtmlEscapedString
 }
 
 /**

--- a/apps/web/test/share-page.test.ts
+++ b/apps/web/test/share-page.test.ts
@@ -210,6 +210,35 @@ describe('公開されているリスト', () => {
     expect(res.status).toBe(200)
     expect(await res.text()).toContain('0 / 0 達成')
   })
+
+  describe('自分のリストを作る導線（#225）', () => {
+    it('下にトップへのリンクが出る', async () => {
+      const list = await createList({ visibility: 'unlisted' })
+      await addItems(list.id, [{ text: '南極に行く' }])
+
+      const body = await (await request(`/share/${list.shareId}`)).text()
+
+      expect(body).toContain('自分のリストを作る')
+      // リストの後に出す。**人のリストの続きに見せない**
+      expect(body.indexOf('自分のリストを作る')).toBeGreaterThan(body.indexOf('南極に行く'))
+    })
+
+    it('🔴 ログインの導線にしない（未ログインでもその場で書けるのが売り）', async () => {
+      // 入口でログインを要求したら PRODUCT_SPEC.md §1 が台無しになる
+      const list = await createList({ visibility: 'public' })
+
+      const body = await (await request(`/share/${list.shareId}`)).text()
+
+      expect(body).not.toContain('/api/login')
+      expect(body).not.toContain('ログイン')
+    })
+
+    it('🔴 「見つかりません」には出さない（外した理由を伝える場面で宣伝しない）', async () => {
+      const body = await (await request('/share/no-such-share-id')).text()
+
+      expect(body).not.toContain('自分のリストを作る')
+    })
+  })
 })
 
 describe('見えてはいけないもの', () => {


### PR DESCRIPTION
Closes #225

## 何が問題だったか

**共有ページは行き止まりだった。** URL を渡されて開く人は、たいてい**ここで初めてこのサービスを見る**のに、自分も書けることがどこにも書いていない。ヘッダにサービス名のリンクはあるが、押す理由が示されていなかった。

## 実物

![共有ページの下の導線](https://raw.githubusercontent.com/aiandrox/yaritai100list/previews/share-cta-225.png)

## 判断したこと

- 🔴 **リンク先は `/`。ログインの導線にしない。**
  未ログインでもその場で書けること（`PRODUCT_SPEC.md` §1「ログインも初期設定も要求しない」）が
  一番の売りで、**入口でログインを要求したら台無しになる。**
  共有ページにログインの導線を出さないという既存の方針（`src/client/Layout.tsx`）とも揃う
- **「登録は要りません」を本文に書いた。** 押す前の一番の障壁がそこ
- 🔴 **`<button>` を使わない。** 「読み取り専用。編集の入口を出さない」のテストが
  `<form>` / `<input>` / `<button>` を見張っている。実際これはリンクなので `<a>` が正しい
- **「見つかりません」のページには出さない。** 外した理由を伝える場面で宣伝しない
  （#225 で決めることに挙げていた点。テストで固定した）
- **色と幅は `tokens.css` から読む**（#159）。共有ページは Tailwind を通らないので素の CSS だが、値はここに書かない
- **リストの下にはっきり離して置く。** 人のリストの続きに見えると誤読される

## テスト

- 下にトップへのリンクが出る（**リストより後に出る**ことも見る）
- 🔴 `/api/login` も「ログイン」の文字も含まれない
- 🔴 「見つかりません」には出ない
- 既存の「読み取り専用。編集の入口を出さない」「非公開と存在しない ID で応答が一致する」はそのまま通る

`npm run typecheck && npm run lint && npm test` はローカルで緑（367件）。
`wrangler dev` にローカルの D1 を仕込んで実際に描かせ、上の画像を撮った。

🤖 Generated with [Claude Code](https://claude.com/claude-code)