### PR TITLE
取り入れ済みを後ろへ回すのをサーバー側でやる（#249）

### DIFF
--- a/apps/web/src/client/DiscoverPage.tsx
+++ b/apps/web/src/client/DiscoverPage.tsx
@@ -1,9 +1,15 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Link, useSearchParams } from 'wouter'
 
 import { api } from './api'
 import { Notice } from './Notice'
-import { hasText, rejectionMessage, sortAdoptedLast, type SessionState } from './model'
+import {
+  hasText,
+  rejectionMessage,
+  sortAdoptedLast,
+  type LocalList,
+  type SessionState,
+} from './model'
 import { useList } from './useList'
 
 /**
@@ -55,21 +61,60 @@ export function DiscoverPage({ session }: { session: SessionState }) {
   const controller = useList(session)
   const { screen, rejection } = controller
 
+  /**
+   * 取り入れ先のリスト。**サーバーに渡すと、そこにある本文が後ろへ回る**（#249）。
+   *
+   * 未ログインのときは `null`（保存先が localStorage なので、サーバーは知らない）。
+   */
+  const listId = screen.status === 'ready' && screen.source === 'server' ? screen.key : null
+
+  /**
+   * 並べ替えに使う手元のリスト。**`useEffect` の外から読むので ref に置く。**
+   *
+   * 依存に入れると、**1件取り入れるたびにプールを取り直す**ことになる。
+   */
+  const listRef = useRef<LocalList | null>(null)
+  if (screen.status === 'ready') listRef.current = screen.list
+
+  /**
+   * 🔴 **リストが分かるまで取りに行かない。**
+   *
+   * 先に取ってしまうと、**リストが読めた後にもう一度取り直すことになり、
+   * 並びが目の前で入れ替わる。**
+   */
+  const canLoad = screen.status === 'ready'
+
   useEffect(() => {
+    if (!canLoad) return
+
     const load = async () => {
       setPool({ status: 'loading' })
 
       try {
-        const res = await api.api.discover.$get({ query: { page: String(page) } })
+        const res = await api.api.discover.$get({
+          query: { page: String(page), ...(listId === null ? {} : { listId }) },
+        })
         if (!res.ok) {
           setPool({ status: 'failed' })
           return
         }
 
         const body = await res.json()
+        const texts = body.items.map((item) => item.text)
+        const list = listRef.current
+
+        /**
+         * 🔴 **並びを受け取った時点で決めて、あとは動かさない。**
+         *
+         * 毎回描くたびに並べ替えると、**1件取り入れた瞬間にその行が下へ飛び、
+         * 下にあった行が全部せり上がる。** 押した本人が見失う。
+         *
+         * ⚠️ ログイン中はサーバーが既に並べているので、ここは効かない。
+         * **未ログインのため**に残してある（サーバーは localStorage を知らない）。
+         */
         setPool({
           status: 'ready',
-          texts: body.items.map((item) => item.text),
+          texts: list === null ? texts : sortAdoptedLast(texts, list),
           hasNext: body.hasNext,
         })
       } catch {
@@ -78,7 +123,7 @@ export function DiscoverPage({ session }: { session: SessionState }) {
     }
 
     void load()
-  }, [page])
+  }, [page, listId, canLoad])
 
   return (
     <div>
@@ -111,14 +156,10 @@ export function DiscoverPage({ session }: { session: SessionState }) {
 
           <ul className="mt-2">
             {/*
-              🔴 **既に持っているものを後ろへ回す**（#246）。
-              探しに来た人にとって、もう持っているものは選択肢ではない。
-              **消さない**のは「取り入れ済み」だと分かることに意味があるため
+              並びは受け取った時点で決まっている（上の `load`）。
+              **ここで並べ替えない。** 取り入れた瞬間に行が飛ぶ
             */}
-            {(screen.status === 'ready'
-              ? sortAdoptedLast(pool.texts, screen.list)
-              : pool.texts
-            ).map((text) => (
+            {pool.texts.map((text) => (
               <li
                 key={text}
                 className="flex items-center gap-2 border-b border-brand/40 py-2.5 text-sm"

--- a/apps/web/src/client/model.ts
+++ b/apps/web/src/client/model.ts
@@ -339,8 +339,13 @@ const REJECTION_MESSAGES: Record<Rejection, string> = {
  * ⚠️ **サーバーの並びは崩さない。** 同じ組の中では受け取った順のまま
  * （`Array.prototype.sort` は安定なので、真偽値の差だけで並べれば元の順が残る）。
  *
- * ⚠️ **効くのは受け取ったページの中だけ。** サーバーは誰のリストかを知らないので、
- * **2ページ目の未取得の項目が1ページ目に繰り上がることはない。**
+ * ⚠️ **使うのは未ログインのときだけ**（#249 で変えた）。
+ * ログイン中は**サーバーが全体を並べ替える**（取り入れ先のリスト ID を渡している）。
+ * 画面側だけで並べ替えると、**1ページ目に自分の項目が固まっていたときに
+ * 2ページ目の知らない項目が繰り上がってこない。**
+ *
+ * ⚠️ **受け取った時点で1回だけ呼ぶ**（`DiscoverPage`）。描くたびに呼ぶと、
+ * 1件取り入れた瞬間にその行が下へ飛び、下にあった行が全部せり上がる。
  */
 export function sortAdoptedLast(texts: string[], list: LocalList): string[] {
   return [...texts].sort((a, b) => Number(hasText(list, a)) - Number(hasText(list, b)))

--- a/apps/web/src/index.ts
+++ b/apps/web/src/index.ts
@@ -20,6 +20,7 @@ import {
 } from '@yaritai100list/shared'
 import { zValidator } from '@hono/zod-validator'
 import { and, asc, desc, eq, gt, inArray, sql } from 'drizzle-orm'
+import { alias } from 'drizzle-orm/sqlite-core'
 import { Hono } from 'hono'
 import { z } from 'zod'
 
@@ -65,6 +66,17 @@ const createListSchema = z.object({ title: listTitleSchema.optional() }).strict(
  */
 const discoverQuerySchema = z.object({
   page: z.coerce.number().int().min(1).max(DISCOVER_MAX_PAGE).optional(),
+
+  /**
+   * 取り入れ先のリスト（#249）。**渡すと、そこに既にある本文が後ろに回る。**
+   *
+   * 🔴 **必ず持ち主か確かめる**（下のハンドラ）。確かめないと、
+   * **他人のリスト ID を渡して並びの変化を読むだけで中身を言い当てられる。**
+   * 非公開リストの中身が漏れるので、ここが一番危ない。
+   *
+   * 省略できる（未ログインは localStorage にリストがあり、サーバーは知らない）。
+   */
+  listId: z.string().optional(),
 })
 
 /** 項目の作成。本文だけ受け取る。**並び順は末尾で、クライアントには決めさせない。** */
@@ -862,7 +874,50 @@ const app = new Hono<AppEnv>()
    */
   .get('/api/discover', zValidator('query', discoverQuerySchema), async (c) => {
     const db = createDb(c.env.DB)
-    const page = c.req.valid('query').page ?? 1
+    const { page = 1, listId } = c.req.valid('query')
+
+    /**
+     * 🔴 **渡されたリストが本当に自分のものか確かめる**（#249）。
+     *
+     * 確かめずに並べ替えに使うと、**他人のリスト ID を渡して
+     * 「どれが後ろに回ったか」を読むだけで中身を言い当てられる。**
+     * 非公開リストの内容が、読み取り専用の口から漏れることになる。
+     *
+     * 見つからない場合と他人のものである場合で**同じ応答を返す**
+     * （`requireOwnedList` と同じ理由。存在を教えない）。
+     */
+    let adopterListId: string | null = null
+    if (listId !== undefined) {
+      const auth = createAuth(db, c.env)
+      const session = await auth.api.getSession({ headers: c.req.raw.headers })
+
+      const [owned] = session
+        ? await db
+            .select({ id: lists.id })
+            .from(lists)
+            .where(and(eq(lists.id, listId), eq(lists.userId, session.user.id)))
+            .limit(1)
+        : []
+
+      if (!owned) {
+        return c.json({ error: 'Not Found' } as const, 404)
+      }
+
+      adopterListId = owned.id
+    }
+
+    /**
+     * 取り入れ先のリストにある本文かどうか。**後ろへ回すためだけに使う。**
+     *
+     * 🔴 **ページの中だけで並べ替えても足りない**（#249 で直した）。
+     * 画面側で並べ替えると、**1ページ目に自分の項目が固まっていたときに
+     * 2ページ目の知らない項目が繰り上がってこない。**
+     *
+     * `adopterListId` が無いとき（未ログイン・省略）は `''` と突き合わせる。
+     * **どの行にも当たらない**ので、全部「持っていない」扱いになる。
+     */
+    const mine = alias(items, 'mine')
+    const adopted = sql<number>`max(case when ${mine.id} is null then 0 else 1 end)`
 
     /**
      * 🔴 **出す本文と、数える範囲が違う**（2026-08-10 の利用者の判断）。
@@ -887,6 +942,7 @@ const app = new Hono<AppEnv>()
       .select({ text: items.text, writers: sql<number>`count(distinct ${lists.userId})` })
       .from(items)
       .innerJoin(lists, eq(lists.id, items.listId))
+      .leftJoin(mine, and(eq(mine.text, items.text), eq(mine.listId, adopterListId ?? '')))
       .where(
         // 🔴 **ここでは公開範囲を絞らない**（人数は全リストで数えるため）。
         // 絞るのは「プールに出す本文か」の方
@@ -900,7 +956,12 @@ const app = new Hono<AppEnv>()
         ),
       )
       .groupBy(items.text)
-      .orderBy(desc(sql`count(distinct ${lists.userId})`), asc(items.text))
+      .orderBy(
+        // **既に持っているものを後ろへ**（#249）。探しに来た人にとって選択肢ではない
+        asc(adopted),
+        desc(sql`count(distinct ${lists.userId})`),
+        asc(items.text),
+      )
       /**
        * 🔴 **1件多く取る。**
        *

--- a/apps/web/test/client-model.test.ts
+++ b/apps/web/test/client-model.test.ts
@@ -723,6 +723,10 @@ describe('rejectionMessage', () => {
   })
 })
 
+/**
+ * ⚠️ **これは未ログインのときだけ使う**（#249）。
+ * ログイン中の並べ替えはサーバー側（`discover-api.test.ts`）。
+ */
 describe('sortAdoptedLast', () => {
   const list = listOf('B', 'D')
 

--- a/apps/web/test/discover-api.test.ts
+++ b/apps/web/test/discover-api.test.ts
@@ -4,7 +4,7 @@ import { eq } from 'drizzle-orm'
 import { describe, expect, it } from 'vitest'
 
 import { items, lists } from '../src/db/schema'
-import { createTestUser, testBaseUrl, testDb } from './helpers'
+import { createTestUser, signIn, testBaseUrl, testDb } from './helpers'
 
 /**
  * 取り入れ面のプールのテスト（#233 / 親 #10）。
@@ -18,11 +18,16 @@ import { createTestUser, testBaseUrl, testDb } from './helpers'
  * - **並び順が毎回同じこと。** 同数のときに揺れると画面が意味もなく並び替わる
  */
 
-const discover = (query = '') =>
-  exports.default.fetch(new Request(`${testBaseUrl()}/api/discover${query}`))
+const discover = (query = '', headers?: Headers) =>
+  exports.default.fetch(
+    new Request(
+      `${testBaseUrl()}/api/discover${query}`,
+      headers === undefined ? undefined : { headers: Object.fromEntries(headers) },
+    ),
+  )
 
-async function readPool(query = '') {
-  const res = await discover(query)
+async function readPool(query = '', headers?: Headers) {
+  const res = await discover(query, headers)
   const body = await res.json<{ items: { text: string }[]; hasNext: boolean }>()
 
   return { status: res.status, items: body.items, hasNext: body.hasNext }
@@ -190,6 +195,113 @@ describe('GET /api/discover', () => {
 
       expect(texts((await readPool()).items)).toEqual(['A', 'B', 'C'])
       expect(texts((await readPool()).items)).toEqual(['A', 'B', 'C'])
+    })
+  })
+
+  /**
+   * 取り入れ済みを後ろへ回す（#249）。
+   *
+   * 🔴 見るのは **「他人のリスト ID で並びを変えられないこと」。**
+   * ここが通ると、**並びの変化を読むだけで非公開リストの中身を言い当てられる。**
+   * 読み取り専用の口から中身が漏れるので、この機能で一番危ないところ。
+   */
+  describe('取り入れ済みを後ろへ（#249）', () => {
+    /** 自分のリストを1つ作る（`texts` は既に持っている本文）。 */
+    async function myList(texts: string[]) {
+      const me = await signIn(`me-${crypto.randomUUID()}@example.com`)
+      const id = `mine-${crypto.randomUUID()}`
+
+      await testDb()
+        .insert(lists)
+        .values({
+          id,
+          userId: me.userId,
+          title: '自分のリスト',
+          visibility: 'private',
+          shareId: crypto.randomUUID().replaceAll('-', ''),
+        })
+      if (texts.length > 0) {
+        await testDb()
+          .insert(items)
+          .values(
+            texts.map((text, i) => ({ id: `${id}-${String(i)}`, listId: id, text, position: i })),
+          )
+      }
+
+      return { ...me, listId: id }
+    }
+
+    it('持っている本文が後ろへ回る', async () => {
+      await makeList({ id: 'p1', visibility: 'public', texts: ['A', 'B', 'C'] })
+      const me = await myList(['A'])
+
+      const pool = await readPool(`?listId=${me.listId}`, me.headers)
+
+      expect(texts(pool.items)).toEqual(['B', 'C', 'A'])
+    })
+
+    it('🔴 ページをまたいで効く（1ページ目に持っている本文が残らない）', async () => {
+      // 画面側で並べ替えるだけだと、2ページ目の知らない本文が繰り上がってこない
+      const all = Array.from({ length: DISCOVER_PAGE_SIZE + 3 }, (_, i) =>
+        String(i).padStart(4, '0'),
+      )
+      await makeList({ id: 'p1', visibility: 'public', texts: all })
+      // 1ページ目に入るはずの本文を3つ持っている
+      const me = await myList(['0000', '0001', '0002'])
+
+      const first = await readPool(`?listId=${me.listId}`, me.headers)
+
+      expect(texts(first.items)).not.toContain('0000')
+      // 押し出された分だけ、2ページ目にあったはずの本文が繰り上がる
+      expect(texts(first.items)).toContain(String(DISCOVER_PAGE_SIZE).padStart(4, '0'))
+    })
+
+    it('持っていないものの間では人気順のまま', async () => {
+      await makeList({ id: 'p1', visibility: 'public', texts: ['ひとり', 'みんな', '持っている'] })
+      await makeList({ id: 'p2', visibility: 'public', texts: ['みんな'] })
+      const me = await myList(['持っている'])
+
+      const pool = await readPool(`?listId=${me.listId}`, me.headers)
+
+      expect(texts(pool.items)).toEqual(['みんな', 'ひとり', '持っている'])
+    })
+
+    describe('断るもの', () => {
+      it('🔴 他人のリスト ID では並べ替えられない', async () => {
+        // 通ると、並びの変化から非公開リストの中身を読める
+        await makeList({ id: 'p1', visibility: 'public', texts: ['A', 'B'] })
+        const owner = await myList(['A'])
+        const stranger = await signIn(`stranger-${crypto.randomUUID()}@example.com`)
+
+        const res = await discover(`?listId=${owner.listId}`, stranger.headers)
+
+        expect(res.status).toBe(404)
+      })
+
+      it('🔴 未ログインでは並べ替えられない', async () => {
+        await makeList({ id: 'p1', visibility: 'public', texts: ['A', 'B'] })
+        const owner = await myList(['A'])
+
+        expect((await discover(`?listId=${owner.listId}`)).status).toBe(404)
+      })
+
+      it('🔴 存在しない ID と他人の ID で応答が一致する', async () => {
+        await makeList({ id: 'p1', visibility: 'public', texts: ['A'] })
+        const owner = await myList(['A'])
+        const stranger = await signIn(`stranger2-${crypto.randomUUID()}@example.com`)
+
+        const other = await discover(`?listId=${owner.listId}`, stranger.headers)
+        const missing = await discover('?listId=no-such-list', stranger.headers)
+
+        expect(other.status).toBe(missing.status)
+        expect(await other.text()).toBe(await missing.text())
+      })
+    })
+
+    it('渡さなければ今まで通り（未ログインでも読める）', async () => {
+      await makeList({ id: 'p1', visibility: 'public', texts: ['A', 'B'] })
+
+      expect(texts((await readPool()).items)).toEqual(['A', 'B'])
     })
   })
 


### PR DESCRIPTION
#246 で入れた「取り入れ済みを後ろへ」が、**受け取った1ページの中でしか効いていなかった。**

**1ページ目に自分の項目が固まっていると、2ページ目の知らない項目が繰り上がってこない。**
自分の公開リストがプールの大半を占めているとき（＝いまの本番）、
1ページ目がほとんど「リストにあります」で埋まる。

## サーバー側で並べる

`GET /api/discover?listId=xxx`。そのリストにある本文を後ろへ回す。

## 🔴 他人のリスト ID を渡されると中身が漏れる

「持っている本文が後ろに回る」ので、**後ろに回ったものがそのリストの持ち物**だと分かる。
**非公開リストの内容が、読み取り専用の口から漏れる。**

だから `listId` は**必ず持ち主か確かめる。**
見つからない場合と他人のものである場合で**同じ応答**にしてある（存在を教えない）。

テストを3本足した。

- 🔴 他人のリスト ID では並べ替えられない（404）
- 🔴 未ログインでは並べ替えられない（404）
- 🔴 存在しない ID と他人の ID で応答が一致する

## 未ログインは今まで通り画面側

保存先が localStorage なので**サーバーは知らない。**
未ログインの取り入れ内容をサーバーに送るのは、
「未ログインの保存はブラウザで完結する」（#10）に反するのでやらない。

未ログインのリストは書き始めたばかりで小さいので、1ページの中だけでも実害が出にくい。

## ついでに直した: 取り入れた瞬間に行が飛ぶ

描くたびに並べ替えていたので、**押した行が下へ飛び、下にあった行が全部せり上がっていた。**
並びは**受け取った時点で1回だけ**決めるようにした。

## 確認したこと

105 件のプール、うち1ページ目に入るはずの2件を自分のリストに持っている状態。

```
1ページ目 件数: 100
末尾3件: やりたいこと099 / やりたいこと100 / やりたいこと101   ← 2ページ目にあった分が繰り上がった
1ページ目に「リストにあります」: 0 件
取り入れた後も先頭のまま: true → やりたいこと001 リストにあります
```

442 件すべて緑。

Closes #249