### PR TITLE
ジャンルを選んでも横スクロールの位置を保つ（#271）

### DIFF
--- a/apps/web/src/client/DiscoverPage.tsx
+++ b/apps/web/src/client/DiscoverPage.tsx
@@ -53,10 +53,22 @@ interface GenreEntry {
 type PoolState =
   | { status: 'loading' }
   | { status: 'failed' }
-  | { status: 'ready'; items: PoolItem[]; hasNext: boolean; genres: GenreEntry[] }
+  | { status: 'ready'; items: PoolItem[]; hasNext: boolean }
 
 export function DiscoverPage({ session }: { session: SessionState }) {
   const [pool, setPool] = useState<PoolState>({ status: 'loading' })
+
+  /**
+   * ジャンルの入口（#255）。**一覧と別の状態にする**（#271）。
+   *
+   * 🔴 **読み込み中に消さないため。** 一覧と同じ状態に入れていたときは、
+   * ジャンルを選ぶと `loading` に戻って `<nav>` が DOM から消えていた。
+   * **横スクロールの位置は要素が持っている**ので、消えた時点で失われる。
+   * 右へ流して奥のジャンルを押すと、**押した先が画面の外へ出ていた。**
+   *
+   * ⚠️ **読み込みに失敗しても消さない。** 入口だけ残っていれば選び直せる。
+   */
+  const [genres, setGenres] = useState<GenreEntry[]>([])
 
   /**
    * ページとジャンルは URL に載せる（`?page=2&genre=travel`）。
@@ -137,11 +149,11 @@ export function DiscoverPage({ session }: { session: SessionState }) {
          * ⚠️ ログイン中はサーバーが既に並べているので、ここは効かない。
          * **未ログインのため**に残してある（サーバーは localStorage を知らない）。
          */
+        setGenres(body.genres)
         setPool({
           status: 'ready',
           items: list === null ? body.items : sortAdoptedLast(body.items, list),
           hasNext: body.hasNext,
-          genres: body.genres,
         })
       } catch {
         setPool({ status: 'failed' })
@@ -161,6 +173,14 @@ export function DiscoverPage({ session }: { session: SessionState }) {
         </p>
       )}
 
+      {/*
+        🔴 **一覧より先に、条件を付けずに置く**（#271）。
+        `pool.status` で出し分けると、ジャンルを選ぶたびに消えて描き直され、
+        **横スクロールの位置が左端に戻る。** 1件目を読むまでは中身が空なので、
+        `GenreNav` 自身が何も描かない
+      */}
+      <GenreNav genres={genres} current={genre} />
+
       {pool.status === 'loading' && <p className="mt-4 text-sm text-slate-600">読み込み中…</p>}
 
       {pool.status === 'failed' && (
@@ -168,8 +188,6 @@ export function DiscoverPage({ session }: { session: SessionState }) {
           読み込めませんでした。通信を確かめて、ページを開き直してください
         </Notice>
       )}
-
-      {pool.status === 'ready' && <GenreNav genres={pool.genres} current={genre} />}
 
       {pool.status === 'ready' && pool.items.length === 0 && <EmptyPool genre={genre} />}
 
@@ -247,6 +265,10 @@ function discoverHref({ page = 1, genre }: { page?: number; genre?: string | nul
  *
  * ⚠️ **ジャンルを変えたら1ページ目に戻す**（`discoverHref` に `page` を渡さない）。
  * 3ページ目から件数の少ないジャンルへ移ると、**空の画面に着地する。**
+ *
+ * 🔴 **描き続けること。読み込み中に消さない**（#271）。
+ * 横スクロールの位置は `<nav>` が持っているので、**一度消すと左端に戻る。**
+ * 空のときにここが `null` を返すのは、**まだ1件も読めていないときだけ**にする。
  */
 function GenreNav({ genres, current }: { genres: GenreEntry[]; current: string | null }) {
   // 1つも無ければ入口ごと出さない（「すべて」だけの行に意味が無い）


### PR DESCRIPTION
Closes #271

## やったこと

`/discover` のジャンルの行を右へ流して奥のジャンルを押すと、**行が左端に戻っていた。**
押したジャンルは画面の外へ出るので、いま何で絞っているのかが見えない。

原因はジャンルの入口を `pool.status === 'ready'` のときだけ描いていたこと。
ジャンルを選ぶと読み込み直しで `loading` に戻り、**`<nav>` が一度 DOM から消える。**
横スクロールの位置はその要素が持っているので、消えた時点で失われていた。

ジャンルの一覧を一覧本体と**別の状態**に分けて、条件を付けずに描き続けるようにした。
1件目を読むまでは中身が空なので、`GenreNav` 自身が何も描かない（入口が空で出ることはない）。

## 画面

奥のジャンル（`挑戦・体験`）まで流して押した直後。**一覧はどちらも絞れている。**

| 前 | 後 |
|---|---|
| <img src="https://raw.githubusercontent.com/aiandrox/yaritai100list/previews/271-before.png" width="360"> | <img src="https://raw.githubusercontent.com/aiandrox/yaritai100list/previews/271-after.png" width="360"> |

左端に戻り、**選んだジャンルが画面の外**（前）→ 押した位置のまま、選んだジャンルが見えている（後）。

## 🔴 守っていること・判断したこと

- **入口が空のまま出ることはない。** 空の状態から始まり、`GenreNav` は空なら `null` を返す
- **読み込みに失敗しても入口は消さない。** 残っていれば選び直せる
- ちらつきも一緒に消える。これまではジャンルを押すたびに行ごと消えて出てきていた
- **見送り:** 共有された `?genre=...` を開いたときは、選ばれたジャンルが最初から画面の外にありうる。
  こちらは「選んだ位置が飛ぶ」とは別の話で、今回の症状ではないので触っていない

## 踏んだこと

**テストでは捕まえられない類。** 消えて描き直されただけで、DOM 上の見た目は同じものが出る。
実物で `scrollLeft` を測って初めて分かる（下記）。

## テスト

560 件中 560 件が緑（27 ファイル）。typecheck / lint も緑。
**この変更に対応するテストは足していない。** マウントし続けるかどうかの話で、
このリポジトリには DOM を描くテストの土台が無い（`TECH_STACK.md` §10 の判断）。
代わりに実物で測った。

## 確認したこと・していないこと

ローカルの `npm run dev`（ローカル D1 に 8 ジャンル 18 件を入れた状態）を Chrome に繋いで、
右端まで流してから `挑戦・体験` を押し、`<nav>` の `scrollLeft` を測った。

| | 押す前 | 読み込み中 | 読み込み後 |
|---|---|---|---|
| 前 | 451 | 0 | **0** |
| 後 | 451 | 451 | **451** |

ログインは要らない画面なので、未ログインのまま確認している。

## 完了条件

- [x] 実物で、右へ流した位置のままジャンルを選べる（`scrollLeft` を測る）
- [x] 1件目の読み込みが終わるまでは、ジャンルの行を出さない（中身が無いため）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
