### PR TITLE
叶えたとき・書き終えたときに共有へ誘う（#276）

### DIFF
--- a/apps/web/src/client/ListPage.tsx
+++ b/apps/web/src/client/ListPage.tsx
@@ -1,9 +1,21 @@
+import { useEffect, useRef, useState } from 'react'
 import { Link } from 'wouter'
 
 import { ListEditor } from './ListEditor'
 import { Notice } from './Notice'
+import { ShareInvite } from './ShareInvite'
 import { SignInBenefits } from './SignInBenefits'
-import { rejectionMessage, toCompletionPermission, type SessionState } from './model'
+import {
+  canInviteToShare,
+  listProgress,
+  parseInvitedAt,
+  rejectionMessage,
+  shareInviteStorageKey,
+  shareInviteTrigger,
+  toCompletionPermission,
+  type ListProgress,
+  type SessionState,
+} from './model'
 import { useList, type ImportOutcome, type ListController } from './useList'
 
 /**
@@ -54,6 +66,71 @@ function SignInRequired({ session }: { session: SessionState }) {
   )
 }
 
+/**
+ * 共有のお誘いを出すかどうかを決める（#276）。
+ *
+ * 🔴 **操作の側に手を入れない。** 「✓ を押したとき」「項目を足したとき」に
+ * 呼び出しを足す形にすると、**足し忘れた経路から出なくなる**し、
+ * 楽観更新の巻き戻しまで拾ってしまう。
+ * ここでは**進み具合の変化だけを見る**（増えたときだけ誘う）。
+ *
+ * ⚠️ **別のリストに切り替わった直後は比べない。** 数が飛ぶので、
+ * 開いただけで誘いが出る。
+ */
+function useShareInvite(screen: ListController['screen']): {
+  open: boolean
+  close: () => void
+} {
+  const [open, setOpen] = useState(false)
+  const previous = useRef<{ key: string; progress: ListProgress } | null>(null)
+
+  const key = screen.status === 'ready' ? screen.key : null
+  const list = screen.status === 'ready' ? screen.list : null
+  // 未ログイン（`share` が null）では誘わない。渡す先がログインの向こう側にある
+  const shared = screen.status === 'ready' && screen.share !== null
+
+  useEffect(() => {
+    if (key === null || list === null || !shared) {
+      previous.current = null
+      return
+    }
+
+    const progress = listProgress(list)
+    const before = previous.current
+    previous.current = { key, progress }
+
+    if (before?.key !== key) return
+    if (shareInviteTrigger(before.progress, progress) === null) return
+
+    /*
+     * 🔴 **間隔を守る**（同じリストでは30日に1回）。
+     *
+     * ⚠️ **localStorage が使えないときは出さない。** 出した記録を残せないので、
+     * **叶えるたびに毎回出る**ことになる。静かな方に倒す
+     */
+    try {
+      const storageKey = shareInviteStorageKey(key)
+      const now = Date.now()
+
+      if (!canInviteToShare({ invitedAt: parseInvitedAt(localStorage.getItem(storageKey)), now })) {
+        return
+      }
+
+      localStorage.setItem(storageKey, String(now))
+      setOpen(true)
+    } catch {
+      // 記録できない環境。**黙って出さない**（利用者に伝えることが無い）
+    }
+  }, [key, list, shared])
+
+  return {
+    open,
+    close: () => {
+      setOpen(false)
+    },
+  }
+}
+
 function ListPageBody({
   session,
   listId,
@@ -64,6 +141,7 @@ function ListPageBody({
 }) {
   const controller = useList(session, listId ?? null)
   const { screen, rejection } = controller
+  const invite = useShareInvite(screen)
 
   return (
     <>
@@ -132,6 +210,19 @@ function ListPageBody({
             onRemoveItem={controller.removeItem}
             onMoveItem={controller.moveItem}
           />
+
+          {/*
+            叶えたとき・100個書き終えたときのお誘い（#276）。
+            **出すかどうかは `useShareInvite`。** ここは置き場所だけ
+          */}
+          {screen.share !== null && (
+            <ShareInvite
+              listId={screen.key}
+              share={screen.share}
+              open={invite.open}
+              onClose={invite.close}
+            />
+          )}
         </>
       )}
     </>

--- a/apps/web/src/client/ShareInvite.tsx
+++ b/apps/web/src/client/ShareInvite.tsx
@@ -1,0 +1,198 @@
+import { useEffect, useRef, useState } from 'react'
+import { Link } from 'wouter'
+
+import { canUseShareSheet, isShareCancelled, shareUrl } from './model'
+import type { ShareState } from './useList'
+
+/**
+ * 叶えたとき・100個書き終えたときに出す、共有へのお誘い（#276）。
+ *
+ * **人が貼りたくなるのは、空のリストではなく達成したとき。**
+ * それまでの導線は「共有の設定を開く → 公開範囲を変える → URL をコピー」だけで、
+ * **一番気分が乗っている瞬間には何も起きなかった。**
+ *
+ * 🔴 **公開範囲で中身を変える**（2026-08-14 の利用者の指示）。いまの状態から次の一歩が違う。
+ *
+ * | いまの公開範囲 | 出すもの |
+ * |---|---|
+ * | 非公開 | 「みんなにもリストを見せませんか？」→ 共有の設定へ |
+ * | 全公開・リンク限定 | 「SNSでみんなに見せませんか？」→ **その場で送れる** |
+ *
+ * 🔴 **ここで公開範囲を変えられるようにしない。** 誘いの場で設定を触らせない。
+ *
+ * ⚠️ **出すかどうかを決めるのはここではない**（`ListPage`）。
+ * ここは「開けと言われたら開く」だけ。判断は `model.ts` の純関数に置いてある。
+ */
+
+/**
+ * `<dialog>` を使う。**自前で作らない**（`SignInBenefits.tsx` と同じ理由）。
+ *
+ * Esc で閉じる・背景を押せなくする・フォーカスを閉じ込める、を
+ * ブラウザがやってくれる。**背景のスクロールだけは自分で止める。**
+ */
+export function ShareInvite({
+  listId,
+  share,
+  open,
+  onClose,
+}: {
+  listId: string
+  share: ShareState
+  open: boolean
+  onClose: () => void
+}) {
+  const dialog = useRef<HTMLDialogElement>(null)
+
+  useEffect(() => {
+    if (open) dialog.current?.showModal()
+  }, [open])
+
+  // 開いたまま画面が消えることがある（共有の設定へ移るなど）。そのときの片付け
+  useEffect(() => () => void (document.body.style.overflow = ''), [])
+
+  return (
+    <dialog
+      ref={dialog}
+      aria-labelledby="share-invite-title"
+      onClick={(event) => {
+        // 背景を押したら閉じる。`<dialog>` 自身の矩形は背景を含むので、
+        // **中身の外側を押したかどうか**で判断する
+        if (event.target === event.currentTarget) event.currentTarget.close()
+      }}
+      onToggle={(event) => {
+        document.body.style.overflow = event.currentTarget.open ? 'hidden' : ''
+      }}
+      onClose={onClose}
+      className="m-auto w-[calc(100%-2rem)] max-w-(--page-max-width) rounded-xl bg-white p-0 text-slate-900 backdrop:bg-slate-900/50"
+    >
+      {/*
+        ⚠️ **右上の × は置かない**（`SignInBenefits` とは違う）。
+        こちらは下に「閉じる」があるので**抜け道が2つになる**うえ、
+        見出しが長いので × を避けると「か？」だけが2行目に落ちた。
+        Esc と背景押しは `<dialog>` が面倒を見ている
+      */}
+      <div className="px-5 pt-5 pb-6">
+        {share.visibility === 'private' ? (
+          <NotSharedYet listId={listId} onClose={() => dialog.current?.close()} />
+        ) : (
+          <AlreadyShared shareId={share.shareId} onClose={() => dialog.current?.close()} />
+        )}
+      </div>
+    </dialog>
+  )
+}
+
+/**
+ * まだ非公開のとき。**渡す先が無いので、まず公開範囲を決めてもらう。**
+ *
+ * 🔴 **文言は利用者が書いたもの**（2026-08-14）。言い換えない。
+ */
+function NotSharedYet({ listId, onClose }: { listId: string; onClose: () => void }) {
+  return (
+    <>
+      <h2 id="share-invite-title" className="text-center text-lg font-bold">
+        みんなにもリストを見せませんか？
+      </h2>
+
+      <p className="mt-3 text-sm leading-6 text-slate-600">
+        いまは自分だけが見られる状態です。公開すると、リンクを渡した人に見てもらえます。
+      </p>
+
+      <Link
+        href={`/lists/${listId}/share`}
+        onClick={onClose}
+        className="mt-5 block rounded-lg bg-brand-deep px-3 py-3 text-center font-bold text-white"
+      >
+        共有の設定を開く
+      </Link>
+
+      <CloseButton onClose={onClose} />
+    </>
+  )
+}
+
+/**
+ * もう公開しているとき。**設定画面へ回さず、その場で送れるようにする**
+ * （2026-08-14 の利用者の指示）。
+ */
+function AlreadyShared({ shareId, onClose }: { shareId: string; onClose: () => void }) {
+  const [copied, setCopied] = useState(false)
+  const [failed, setFailed] = useState<string | null>(null)
+  const url = shareUrl(window.location.origin, shareId)
+
+  const share = async () => {
+    setFailed(null)
+
+    try {
+      await navigator.share({ url })
+    } catch (error) {
+      // 🔴 **閉じただけなら何も出さない**（#275 と同じ判断）
+      if (isShareCancelled(error)) return
+
+      setFailed('共有できませんでした。URL をコピーして渡してください')
+    }
+  }
+
+  const copy = async () => {
+    setFailed(null)
+
+    try {
+      await navigator.clipboard.writeText(url)
+      setCopied(true)
+    } catch {
+      setFailed('コピーできませんでした。共有の設定から URL を選んでコピーしてください')
+    }
+  }
+
+  return (
+    <>
+      <h2 id="share-invite-title" className="text-center text-lg font-bold">
+        SNSでみんなに見せませんか？
+      </h2>
+
+      <p className="mt-3 text-sm leading-6 text-slate-600">
+        このリストは、リンクを渡した人が見られる状態です。
+      </p>
+
+      {failed !== null && (
+        <p role="alert" className="mt-3 text-sm text-brand-deep">
+          {failed}
+        </p>
+      )}
+
+      {/* 🔴 **共有シートが使えるときだけ出す**（#275 と同じ。押せて何も起きないボタンを作らない） */}
+      {canUseShareSheet(navigator) && (
+        <button
+          type="button"
+          onClick={() => void share()}
+          className="mt-5 w-full rounded-lg bg-brand-deep px-3 py-3 font-bold text-white"
+        >
+          共有する
+        </button>
+      )}
+
+      <button
+        type="button"
+        onClick={() => void copy()}
+        className={
+          canUseShareSheet(navigator)
+            ? 'mt-2 w-full rounded-lg border border-brand-deep px-3 py-3 font-bold text-brand-deep'
+            : 'mt-5 w-full rounded-lg bg-brand-deep px-3 py-3 font-bold text-white'
+        }
+      >
+        {copied ? 'コピーしました' : 'URL をコピー'}
+      </button>
+
+      <CloseButton onClose={onClose} />
+    </>
+  )
+}
+
+/** 断る側。**主のボタンと同じ強さにしない。** */
+function CloseButton({ onClose }: { onClose: () => void }) {
+  return (
+    <button type="button" onClick={onClose} className="mt-3 w-full py-2 text-sm text-slate-500">
+      閉じる
+    </button>
+  )
+}

--- a/apps/web/src/client/model.ts
+++ b/apps/web/src/client/model.ts
@@ -452,6 +452,94 @@ export function completedCount(list: LocalList): number {
   return list.items.filter((item) => item.completedAt !== null).length
 }
 
+// --- 共有のお誘い（#276） ---------------------------------------------------
+
+/**
+ * 何をきっかけに誘うか（#276）。
+ *
+ * **人が貼りたくなるのは、空のリストではなく達成したとき。**
+ * それまでの導線は「共有の設定を開く → 公開範囲を変える → URL をコピー」だけで、
+ * **一番気分が乗っている瞬間には何も起きなかった。**
+ */
+export type ShareInviteTrigger =
+  /** 「やった」印を1つ増やした */
+  | 'completed'
+  /** 100個すべて埋まった。**書き上げた瞬間で、見せるものが揃った瞬間** */
+  | 'filled'
+
+/** 誘うかどうかの判定に使う分だけの進み具合。 */
+export interface ListProgress {
+  completed: number
+  filled: number
+}
+
+export function listProgress(list: LocalList): ListProgress {
+  return { completed: completedCount(list), filled: filledCount(list) }
+}
+
+/**
+ * 進み具合の変化から、誘うきっかけを決める（#276）。
+ *
+ * 🔴 **増えたときだけ。** 減ったとき（完了の取り消し、項目の削除）には出さない。
+ * ⚠️ **100個目を消して書き直すたびに出さない**のは、ここでは止めきれない
+ * （また `filled` が上限に達するため）。**間隔の方で吸収する**（`canInviteToShare`）。
+ *
+ * 両方が同時に起きたら `filled` を選ぶ。**100個書き上げた方が大きな節目。**
+ */
+export function shareInviteTrigger(
+  before: ListProgress,
+  after: ListProgress,
+): ShareInviteTrigger | null {
+  if (after.filled >= ITEMS_PER_LIST_MAX && before.filled < ITEMS_PER_LIST_MAX) return 'filled'
+  if (after.completed > before.completed) return 'completed'
+
+  return null
+}
+
+/**
+ * 同じリストで続けて出さない間隔。**30日**（2026-08-14 の利用者の指示）。
+ *
+ * 🔴 **「1回きり」にしない。** そのとき断っただけの人を、一生誘わないのはやりすぎ。
+ * ⚠️ **きっかけごとに分けない。** リスト単位で「最後に出した日」を1つ持つ。
+ * 分けると、叶えた直後に100個目を書いた人に**続けて2回出る。**
+ */
+export const SHARE_INVITE_INTERVAL_MS = 30 * 24 * 60 * 60 * 1000
+
+/**
+ * いま誘ってよいか（#276）。
+ *
+ * `invitedAt` は**そのリストで最後に出した時刻**。まだ一度も出していなければ `null`。
+ */
+export function canInviteToShare({
+  invitedAt,
+  now,
+}: {
+  invitedAt: number | null
+  now: number
+}): boolean {
+  return invitedAt === null || now - invitedAt >= SHARE_INVITE_INTERVAL_MS
+}
+
+/**
+ * 最後に誘った時刻の保存先。**読み書きそのものは `*.tsx` 側**（`LIST_STORAGE_KEY` と同じ）。
+ *
+ * 🔴 **リストごとに分ける。** 1つにまとめると、リストを5つ持っている人は
+ * **どれか1つで断ったら全部で30日出なくなる。**
+ */
+export function shareInviteStorageKey(listId: string): string {
+  return `yaritai100list:share-invite:v1:${listId}`
+}
+
+/** 保存されていなければ `null` を渡す（`getItem` の戻り値をそのまま）。 */
+export function parseInvitedAt(raw: string | null): number | null {
+  if (raw === null) return null
+
+  const value = Number(raw)
+
+  // 壊れていたら「出したことが無い」に倒す。**誘いを1回多く出すだけ**で害が無い
+  return Number.isFinite(value) ? value : null
+}
+
 // --- 保存 -------------------------------------------------------------------
 
 /**

--- a/apps/web/src/client/useList.ts
+++ b/apps/web/src/client/useList.ts
@@ -1,3 +1,4 @@
+import type { Visibility } from '@yaritai100list/shared'
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { api } from './api'
@@ -51,7 +52,36 @@ export type ListScreen =
    * **別のリストに切り替わったら入力欄の下書きを作り直す。**
    * 無いと、ログアウトしたのに前のタイトルが入力欄に残る（#102 で踏んだ）。
    */
-  | { status: 'ready'; key: string; list: LocalList; source: ListSource }
+  | (ReadyScreen & {
+      /**
+       * 共有の状態（#276）。**未ログイン（`source === 'local'`）では `null`。**
+       *
+       * 編集画面が持つのは**誘い方を決めるため**だけ
+       * （非公開なら設定へ、公開済みならその場で送れる）。
+       * ⚠️ **ここで公開範囲を変えない。** 変えるのは共有の設定の画面1箇所。
+       */
+      share: ShareState | null
+    })
+
+/** 共有の状態。**サーバーから取ったリストにだけ付く。** */
+export interface ShareState {
+  visibility: Visibility
+  shareId: string
+}
+
+/**
+ * `useList` の中で持っている形。**`share` を含まない。**
+ *
+ * 🔴 **画面の状態を作り直す場所が9箇所ある**（楽観更新のたびに作り直す）。
+ * `share` をそこに混ぜると、**1箇所でも書き忘れたら共有の状態が消える。**
+ * 別に持って、外に出すときに1回だけ足す。
+ */
+interface ReadyScreen {
+  status: 'ready'
+  key: string
+  list: LocalList
+  source: ListSource
+}
 
 /**
  * ブラウザの保存を取り込めたか。
@@ -93,7 +123,17 @@ export function useList(
   session: SessionState,
   requestedListId: string | null = null,
 ): ListController {
-  const [screen, setScreen] = useState<ListScreen>({ status: 'loading' })
+  const [screen, setScreen] = useState<Exclude<ListScreen, { status: 'ready' }> | ReadyScreen>({
+    status: 'loading',
+  })
+
+  /**
+   * 共有の状態（#276）。**サーバーから取り直したときだけ入れ替える。**
+   *
+   * 🔴 **公開範囲はこの画面から変わらない**（変えるのは共有の設定の画面）ので、
+   * 楽観更新のたびに持ち回らなくてよい。
+   */
+  const [share, setShare] = useState<ShareState | null>(null)
   const [storage, setStorage] = useState<LocalStorage>({ status: 'ok' })
   const [importOutcome, setImportOutcome] = useState<ImportOutcome>('none')
   const [rejection, setRejection] = useState<Rejection | null>(null)
@@ -169,6 +209,9 @@ export function useList(
       }
 
       const body = await res.json()
+
+      // 共有の状態は別に持つ（#276。`ReadyScreen` のコメント）
+      setShare({ visibility: body.list.visibility, shareId: body.list.shareId })
       setScreen({
         status: 'ready',
         key: body.list.id,
@@ -331,7 +374,11 @@ export function useList(
   }
 
   return {
-    screen,
+    // 共有の状態は**外に出すときに1回だけ足す**（#276。`ReadyScreen` のコメント）
+    screen:
+      screen.status === 'ready'
+        ? { ...screen, share: screen.source === 'server' ? share : null }
+        : screen,
     storage,
     importOutcome,
     rejection,

--- a/apps/web/test/client-model.test.ts
+++ b/apps/web/test/client-model.test.ts
@@ -8,9 +8,14 @@ import { describe, expect, it } from 'vitest'
 
 import {
   addItem,
+  canInviteToShare,
   canUseShareSheet,
   createEmptyList,
   isShareCancelled,
+  parseInvitedAt,
+  SHARE_INVITE_INTERVAL_MS,
+  shareInviteStorageKey,
+  shareInviteTrigger,
   completedCount,
   filledCount,
   formatItemNumber,
@@ -497,6 +502,90 @@ describe('canUseShareSheet', () => {
   it('🔴 関数でないものが入っていても false', () => {
     // 「鍵があるか」で見ると、別物が入っている環境で押せるボタンが出る
     expect(canUseShareSheet({ share: true })).toBe(false)
+  })
+})
+
+/**
+ * 共有のお誘い（#276）。
+ *
+ * **うるさくしないための判断**なので、ここで固定しておく。
+ * 出す条件を間違えると「叶えるたびに毎回出る」になり、一番やってはいけない。
+ */
+describe('shareInviteTrigger', () => {
+  const at = (completed: number, filled: number) => ({ completed, filled })
+
+  it('「やった」が増えたら誘う', () => {
+    expect(shareInviteTrigger(at(0, 3), at(1, 3))).toBe('completed')
+  })
+
+  it('100個そろったら誘う', () => {
+    expect(shareInviteTrigger(at(0, 99), at(0, 100))).toBe('filled')
+  })
+
+  it('🔴 100個そろうまでは誘わない', () => {
+    expect(shareInviteTrigger(at(0, 98), at(0, 99))).toBeNull()
+  })
+
+  it('🔴 完了を取り消したときは誘わない', () => {
+    expect(shareInviteTrigger(at(1, 3), at(0, 3))).toBeNull()
+  })
+
+  it('🔴 項目を消したときは誘わない', () => {
+    expect(shareInviteTrigger(at(0, 100), at(0, 99))).toBeNull()
+  })
+
+  it('🔴 100個のまま完了を付けても、また誘いにはなる（きっかけが違う）', () => {
+    // 埋まったのは前のことなので `filled` ではなく `completed`
+    expect(shareInviteTrigger(at(0, 100), at(1, 100))).toBe('completed')
+  })
+
+  it('同時に起きたら「書き終えた」を選ぶ（大きい節目）', () => {
+    expect(shareInviteTrigger(at(0, 99), at(1, 100))).toBe('filled')
+  })
+
+  it('何も変わっていなければ誘わない', () => {
+    expect(shareInviteTrigger(at(2, 50), at(2, 50))).toBeNull()
+  })
+})
+
+describe('canInviteToShare', () => {
+  const now = Date.parse('2026-08-14T00:00:00.000Z')
+
+  it('一度も出していなければ出す', () => {
+    expect(canInviteToShare({ invitedAt: null, now })).toBe(true)
+  })
+
+  it('🔴 直後には出さない（続けて2回出さない）', () => {
+    expect(canInviteToShare({ invitedAt: now - 1000, now })).toBe(false)
+  })
+
+  it('🔴 30日経っていれば、同じリストでもまた出す', () => {
+    expect(canInviteToShare({ invitedAt: now - SHARE_INVITE_INTERVAL_MS, now })).toBe(true)
+  })
+
+  it('29日目はまだ出さない', () => {
+    expect(canInviteToShare({ invitedAt: now - 29 * 24 * 60 * 60 * 1000, now })).toBe(false)
+  })
+})
+
+describe('shareInviteStorageKey / parseInvitedAt', () => {
+  it('🔴 リストごとに別のキー（1つ断っても他のリストに響かない）', () => {
+    expect(shareInviteStorageKey('a')).not.toBe(shareInviteStorageKey('b'))
+  })
+
+  it('保存されていなければ null', () => {
+    expect(parseInvitedAt(null)).toBeNull()
+  })
+
+  it('壊れていたら「出したことが無い」に倒す', () => {
+    // 誘いが1回多く出るだけで害が無い。読めないことを理由に永久に出さない方が困る
+    expect(parseInvitedAt('こわれている')).toBeNull()
+  })
+
+  it('保存した値を読み戻せる', () => {
+    const now = Date.now()
+
+    expect(parseInvitedAt(String(now))).toBe(now)
   })
 })
 


### PR DESCRIPTION
Closes #276

## やったこと

**人が貼りたくなるのは、空のリストではなく達成したとき。**
それなのに共有導線は「共有の設定を開く → 公開範囲を変える → URL をコピー」だけで、
**一番気分が乗っている瞬間には何も起きなかった。**

2つのきっかけでお誘いのモーダルを出す。

| | いつ |
|---|---|
| ① 叶えたとき | 「やった」（✓）が1つ増えた |
| ② 書き終えたとき | 100個すべて埋まった |

## 画面

🔴 **公開範囲で中身が変わる。** いまの状態から次の一歩が違うため。

| 非公開のとき | 全公開・リンク限定のとき |
|---|---|
| <img src="https://raw.githubusercontent.com/aiandrox/yaritai100list/previews/276-private.png" width="330"> | <img src="https://raw.githubusercontent.com/aiandrox/yaritai100list/previews/276-shared.png" width="330"> |
| 渡す先がまだ無いので、設定へ送る | **もうリンクがあるので、その場で送れる**（#275 の共有シート） |

## 🔴 守っていること・判断したこと

- **同じリストでは 30 日に1回まで。** 「1回きり」にしない
  （そのとき断っただけの人を一生誘わないのはやりすぎ）。
  記録は localStorage に**リストごと**。1つ断っても他のリストに響かない
- 🔴 **操作の側に手を入れていない。** 「✓ を押したとき」に呼び出しを足す形にすると、
  **足し忘れた経路から出なくなる**うえ、楽観更新の巻き戻しまで拾う。
  **進み具合の変化だけを見る**（増えたときだけ誘う）
- 🔴 **ここで公開範囲を変えられるようにしない。** 誘いの場で設定を触らせない
- **未ログインでは出ない。** 誘う先がログインの向こう側にある（#77）
- ⚠️ **localStorage が使えないときは出さない。** 記録が残せないと
  **叶えるたびに毎回出る**ことになるので、静かな方に倒した
- **判断は `model.ts` の純関数**（`shareInviteTrigger` / `canInviteToShare`）。
  画面のテスト基盤が無いので、判断だけでも固定できる形にする（`TECH_STACK.md` §10）

## 踏んだこと

**`useList` の中で画面の状態を作り直す場所が9箇所あった**（楽観更新のたびに作り直す）。
公開範囲をそこに混ぜると**1箇所でも書き忘れたら共有の状態が消える**ので、
別に持って**外に出すときに1回だけ足す**形にした。

**右上の × を置くのをやめた。** 下に「閉じる」があるので抜け道が2つになるうえ、
見出しが長く、× を避けると「か？」だけが2行目に落ちた。
Esc と背景押しは `<dialog>` が面倒を見ている。

## テスト

585 件中 585 件が緑（27 ファイル）。typecheck / lint も緑。足したのは判断の分:

- 増えたときだけ誘う（完了の取り消し・項目の削除では誘わない）
- 100個そろうまでは誘わない／同時に起きたら「書き終えた」を選ぶ
- 30日の間隔（直後は出ない・29日目も出ない・30日で出る）
- 保存が壊れていたら「出したことが無い」に倒す

## 確認したこと・していないこと

ローカルの D1 にセッションとリスト3つを入れて、実物で確かめた。

| | 結果 |
|---|---|
| 非公開のリストで完了 | 「みんなにもリストを見せませんか？」＋「共有の設定を開く」 |
| 🔴 同じリストで続けて完了 | **出ない** |
| リンク限定のリストで完了 | 「SNSでみんなに見せませんか？」＋「共有する」「URL をコピー」 |
| 100個目を書き終えた | 出る |
| 🔴 30日前に出したことにする | **また出る** |

**実機の共有シートそのものは開いていない**（OS 側の画面。#278 と同じ）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
