### PR TITLE
モーダルの外枠を1つにまとめる（#282）

### DIFF
--- a/apps/web/src/client/Modal.tsx
+++ b/apps/web/src/client/Modal.tsx
@@ -1,0 +1,86 @@
+import { useEffect, useId } from 'react'
+
+/**
+ * モーダルの外枠（#282）。**中身以外は全部ここが決める。**
+ *
+ * 🔴 **見た目を揃えるために切り出した**（2026-08-14 の利用者の指示）。
+ * 「ログインすると、できること」（#213）と共有のお誘い（#276）で、
+ * 角の丸み・余白・見出しの位置・閉じ方が**別々に書かれていた。**
+ * 増えるたびに少しずつずれるので、**枠は1つにする。**
+ *
+ * 🔴 **`<dialog>` を使う。自前で作らない。**
+ * Esc で閉じる・背景を押せなくする・フォーカスを閉じ込める・
+ * 背景に `inert` を効かせる、を**ブラウザがやってくれる**
+ * （`TECH_STACK.md` §1 の「概念の数が少ないか」）。
+ *
+ * ⚠️ **背景のスクロールだけは止めてくれない。** そこはここで止める。
+ *
+ * ⚠️ **開け閉めはここでやらない。** 呼ぶ側が `ref` を持って
+ * `showModal()` / `close()` する。開く条件は画面ごとに違う
+ * （押したら開く／条件が揃ったら開く）ので、ここに持ち込むと分岐が増える。
+ */
+export function Modal({
+  ref,
+  title,
+  onClose,
+  children,
+}: {
+  ref: React.RefObject<HTMLDialogElement | null>
+  /** 見出し。**読み上げの名前にもなる**（`aria-labelledby`） */
+  title: string
+  /** 閉じたあとに呼ばれる。開いた側の状態を戻すため */
+  onClose?: (() => void) | undefined
+  children: React.ReactNode
+}) {
+  const titleId = useId()
+
+  /**
+   * 開いている間は背景を動かさない。
+   *
+   * 閉じたときは `onToggle` で戻すが、**開いたまま画面が消える**こともある
+   * （リンクを押して別の画面へ移るなど）。そのときのために片付けも置く。
+   */
+  useEffect(() => () => void (document.body.style.overflow = ''), [])
+
+  return (
+    <dialog
+      ref={ref}
+      aria-labelledby={titleId}
+      onClick={(event) => {
+        // 背景を押したら閉じる。`<dialog>` 自身の矩形は背景を含むので、
+        // **中身の外側を押したかどうか**で判断する
+        if (event.target === event.currentTarget) event.currentTarget.close()
+      }}
+      onToggle={(event) => {
+        document.body.style.overflow = event.currentTarget.open ? 'hidden' : ''
+      }}
+      {...(onClose === undefined ? {} : { onClose })}
+      className="m-auto w-[calc(100%-2rem)] max-w-(--page-max-width) rounded-xl bg-white p-0 text-slate-900 backdrop:bg-slate-900/50"
+    >
+      {/* 画面より高くなったら中だけ流す（長い中身でもボタンに届く） */}
+      <div className="max-h-[85dvh] overflow-auto px-5 pt-5 pb-6">
+        {/*
+          閉じるを右上に置く。**読み終わる前でも抜けられる場所が要る。**
+          ⚠️ `float` にしてあるので、**見出しはこの分だけ回り込む。**
+          `absolute` にすると長い見出しが下を通って重なる
+        */}
+        <button
+          type="button"
+          aria-label="閉じる"
+          onClick={() => {
+            ref.current?.close()
+          }}
+          className="float-right -mt-1 -mr-1 px-2 py-1 text-lg text-slate-400"
+        >
+          ×
+        </button>
+
+        <h2 id={titleId} className="text-center text-lg font-bold">
+          {title}
+        </h2>
+
+        {children}
+      </div>
+    </dialog>
+  )
+}

--- a/apps/web/src/client/ShareInvite.tsx
+++ b/apps/web/src/client/ShareInvite.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { Link } from 'wouter'
 
+import { Modal } from './Modal'
 import { canUseShareSheet, isShareCancelled, shareUrl } from './model'
 import type { ShareState } from './useList'
 
@@ -25,10 +26,8 @@ import type { ShareState } from './useList'
  */
 
 /**
- * `<dialog>` を使う。**自前で作らない**（`SignInBenefits.tsx` と同じ理由）。
- *
- * Esc で閉じる・背景を押せなくする・フォーカスを閉じ込める、を
- * ブラウザがやってくれる。**背景のスクロールだけは自分で止める。**
+ * 枠は `Modal.tsx`（#282）。**`<dialog>` の作法はそちらに寄せてある。**
+ * ここが決めるのは中身と、開くきっかけだけ。
  */
 export function ShareInvite({
   listId,
@@ -42,58 +41,39 @@ export function ShareInvite({
   onClose: () => void
 }) {
   const dialog = useRef<HTMLDialogElement>(null)
+  const close = () => dialog.current?.close()
 
   useEffect(() => {
     if (open) dialog.current?.showModal()
   }, [open])
 
-  // 開いたまま画面が消えることがある（共有の設定へ移るなど）。そのときの片付け
-  useEffect(() => () => void (document.body.style.overflow = ''), [])
-
   return (
-    <dialog
+    <Modal
       ref={dialog}
-      aria-labelledby="share-invite-title"
-      onClick={(event) => {
-        // 背景を押したら閉じる。`<dialog>` 自身の矩形は背景を含むので、
-        // **中身の外側を押したかどうか**で判断する
-        if (event.target === event.currentTarget) event.currentTarget.close()
-      }}
-      onToggle={(event) => {
-        document.body.style.overflow = event.currentTarget.open ? 'hidden' : ''
-      }}
+      title={share.visibility === 'private' ? INVITE_TITLE : SHARE_TITLE}
       onClose={onClose}
-      className="m-auto w-[calc(100%-2rem)] max-w-(--page-max-width) rounded-xl bg-white p-0 text-slate-900 backdrop:bg-slate-900/50"
     >
-      {/*
-        ⚠️ **右上の × は置かない**（`SignInBenefits` とは違う）。
-        こちらは下に「閉じる」があるので**抜け道が2つになる**うえ、
-        見出しが長いので × を避けると「か？」だけが2行目に落ちた。
-        Esc と背景押しは `<dialog>` が面倒を見ている
-      */}
-      <div className="px-5 pt-5 pb-6">
-        {share.visibility === 'private' ? (
-          <NotSharedYet listId={listId} onClose={() => dialog.current?.close()} />
-        ) : (
-          <AlreadyShared shareId={share.shareId} onClose={() => dialog.current?.close()} />
-        )}
-      </div>
-    </dialog>
+      {share.visibility === 'private' ? (
+        <NotSharedYet listId={listId} onClose={close} />
+      ) : (
+        <AlreadyShared shareId={share.shareId} onClose={close} />
+      )}
+    </Modal>
   )
 }
 
 /**
+ * 見出し。🔴 **利用者が書いた文をそのまま使う**（2026-08-14）。言い換えない。
+ */
+const INVITE_TITLE = 'みんなにもリストを見せませんか？'
+const SHARE_TITLE = 'SNSでみんなに見せませんか？'
+
+/**
  * まだ非公開のとき。**渡す先が無いので、まず公開範囲を決めてもらう。**
- *
- * 🔴 **文言は利用者が書いたもの**（2026-08-14）。言い換えない。
  */
 function NotSharedYet({ listId, onClose }: { listId: string; onClose: () => void }) {
   return (
     <>
-      <h2 id="share-invite-title" className="text-center text-lg font-bold">
-        みんなにもリストを見せませんか？
-      </h2>
-
       <p className="mt-3 text-sm leading-6 text-slate-600">
         いまは自分だけが見られる状態です。公開すると、リンクを渡した人に見てもらえます。
       </p>
@@ -146,10 +126,6 @@ function AlreadyShared({ shareId, onClose }: { shareId: string; onClose: () => v
 
   return (
     <>
-      <h2 id="share-invite-title" className="text-center text-lg font-bold">
-        SNSでみんなに見せませんか？
-      </h2>
-
       <p className="mt-3 text-sm leading-6 text-slate-600">
         このリストは、リンクを渡した人が見られる状態です。
       </p>

--- a/apps/web/src/client/SignInBenefits.tsx
+++ b/apps/web/src/client/SignInBenefits.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useRef } from 'react'
+import { useRef } from 'react'
 
+import { Modal } from './Modal'
 import { signInBenefits, type SignInBenefit } from './model'
 
 /**
@@ -14,13 +15,8 @@ import { signInBenefits, type SignInBenefit } from './model'
  */
 
 /**
- * `<dialog>` を使う。**自前で作らない。**
- *
- * Esc で閉じる・背景を押せなくする・フォーカスを閉じ込める・
- * 背景に `inert` を効かせる、を**ブラウザがやってくれる**
- * （`TECH_STACK.md` §1 の「概念の数が少ないか」）。
- *
- * ⚠️ **背景のスクロールだけは止めてくれない。** そこは自分で止める。
+ * 枠は `Modal.tsx`（#282）。**`<dialog>` の作法はそちらに寄せてある。**
+ * ここが決めるのは中身と、開くきっかけだけ。
  */
 export function SignInBenefits({ label = 'ほかにできること' }: { label?: string }) {
   const dialog = useRef<HTMLDialogElement>(null)
@@ -139,73 +135,35 @@ function GoogleLogo() {
 }
 
 function Dialog({ ref }: { ref: React.RefObject<HTMLDialogElement | null> }) {
-  /**
-   * 開いている間は背景を動かさない。**`<dialog>` はここまで面倒を見てくれない。**
-   *
-   * 閉じたときは `onToggle` で戻すが、**開いたまま画面が消える**こともある
-   * （ログインへ飛ぶなど）。そのときのために片付けも置く。
-   */
-  useEffect(() => () => void (document.body.style.overflow = ''), [])
-
   return (
-    <dialog
-      ref={ref}
-      aria-labelledby="sign-in-benefits-title"
-      onClick={(event) => {
-        // 背景を押したら閉じる。`<dialog>` 自身の矩形は背景を含むので、
-        // **中身の外側を押したかどうか**で判断する
-        if (event.target === event.currentTarget) event.currentTarget.close()
-      }}
-      onToggle={(event) => {
-        document.body.style.overflow = event.currentTarget.open ? 'hidden' : ''
-      }}
-      className="m-auto w-[calc(100%-2rem)] max-w-(--page-max-width) rounded-xl bg-white p-0 text-slate-900 backdrop:bg-slate-900/50"
-    >
-      <div className="max-h-[85dvh] overflow-auto px-5 pt-5 pb-6">
-        {/* 閉じるを右上に置く。**読み終わる前でも抜けられる場所が要る** */}
-        <button
-          type="button"
-          aria-label="閉じる"
-          onClick={() => {
-            ref.current?.close()
-          }}
-          className="float-right -mt-1 -mr-1 px-2 py-1 text-lg text-slate-400"
-        >
-          ×
-        </button>
+    <Modal ref={ref} title="ログインすると、できること">
+      {/*
+        🔴 **1つずつ札に分ける**（#213）。
+        文だけを縦に並べると、**どこからどこまでが1つの話か分からず読む気にならない。**
+        目印（絵文字）・余白・背景の3つで区切りを作る。文面そのものは変えない
+      */}
+      <ul className="mt-4 flex flex-col gap-2">
+        {/* 年を含む文言があるので、**開くたびに今の年で作る**（`signInBenefits`） */}
+        {signInBenefits(new Date()).map((benefit) => (
+          <li
+            key={benefit.text}
+            className="flex items-start gap-3 rounded-lg bg-brand-soft px-3 py-3"
+          >
+            <BenefitIcon name={benefit.icon} />
+            <span className="flex-1 text-sm leading-6">{benefit.text}</span>
+          </li>
+        ))}
+      </ul>
 
-        <h2 id="sign-in-benefits-title" className="text-center text-lg font-bold">
-          ログインすると、できること
-        </h2>
-
-        {/*
-          🔴 **1つずつ札に分ける**（#213）。
-          文だけを縦に並べると、**どこからどこまでが1つの話か分からず読む気にならない。**
-          目印（絵文字）・余白・背景の3つで区切りを作る。文面そのものは変えない
-        */}
-        <ul className="mt-4 flex flex-col gap-2">
-          {/* 年を含む文言があるので、**開くたびに今の年で作る**（`signInBenefits`） */}
-          {signInBenefits(new Date()).map((benefit) => (
-            <li
-              key={benefit.text}
-              className="flex items-start gap-3 rounded-lg bg-brand-soft px-3 py-3"
-            >
-              <BenefitIcon name={benefit.icon} />
-              <span className="flex-1 text-sm leading-6">{benefit.text}</span>
-            </li>
-          ))}
-        </ul>
-
-        {/*
-          🔴 **この中にもログインの入口を置く。**
-          読んで「したくなった」ときに、閉じて探し直させない。
-          ログインの開始は POST なので <a> から叩けない（GET の入口はサーバー側）
-        */}
-        <a href="/api/login/google" className={GOOGLE_BUTTON}>
-          <GoogleLogo />
-          Googleでログイン
-        </a>
-      </div>
-    </dialog>
+      {/*
+        🔴 **この中にもログインの入口を置く。**
+        読んで「したくなった」ときに、閉じて探し直させない。
+        ログインの開始は POST なので <a> から叩けない（GET の入口はサーバー側）
+      */}
+      <a href="/api/login/google" className={GOOGLE_BUTTON}>
+        <GoogleLogo />
+        Googleでログイン
+      </a>
+    </Modal>
   )
 }


### PR DESCRIPTION
Closes #282

## やったこと

モーダルが2つあり、**`<dialog>` の作法をそれぞれが自分で持っていた**
（角の丸み・余白・見出しの位置・背景を押したら閉じる・背景のスクロールを止める）。
増えるたびに少しずつずれる。

実際 #276 では、**見出しが長いという理由だけで右上の × を落としていた。**
枠を `Modal.tsx` に寄せて、**呼ぶ側に残すのは中身と開くきっかけだけ**にした。

## 画面

| ログインすると、できること | 共有のお誘い（非公開） | 共有のお誘い（公開済み） |
|---|---|---|
| <img src="https://raw.githubusercontent.com/aiandrox/yaritai100list/previews/282-benefits.png" width="240"> | <img src="https://raw.githubusercontent.com/aiandrox/yaritai100list/previews/282-private.png" width="240"> | <img src="https://raw.githubusercontent.com/aiandrox/yaritai100list/previews/282-shared.png" width="240"> |

**× が3つとも同じ位置に戻った。** 長い見出しも1行に収まっている。

## 🔴 守っていること・判断したこと

- 🔴 **開け閉めは `Modal` に持ち込まない。** 開く条件が画面ごとに違う
  （押したら開く／条件が揃ったら開く）ので、持ち込むと分岐が増える。
  `ref` を呼ぶ側が持って `showModal()` / `close()` する
- ⚠️ **× は `float`。** `absolute` にすると**長い見出しが下を通って重なる。**
  `float` なら見出しがその分だけ回り込む（#276 で2行に折り返したのはこれを
  `padding` で解こうとしたため）
- **見出しは `useId` で読み上げに繋ぐ。** 手で書いた id を2つのモーダルが
  それぞれ持っていた（同じ id が2つ出る余地があった）
- 共有のお誘いには **× と「閉じる」の両方**がある。
  こちらは**こちらから声をかけている**ので、断る側の場所を本文の側にも置く

## テスト

585 件中 585 件が緑（27 ファイル）。typecheck / lint も緑。
**枠の入れ替えなので、増やしたテストは無い**（判断を1つも足していない）。
見た目は実物で確かめた（上の画像）。

## 確認したこと・していないこと

ローカルの `npm run dev` に Chrome を繋いで、3つとも開いた。
`×` / `閉じる` / Esc / 背景押しで閉じることを確認している。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
