### PR TITLE
未ログインで100個書き終えたときにログインへ誘う（#284）

### DIFF
--- a/apps/web/src/client/ListPage.tsx
+++ b/apps/web/src/client/ListPage.tsx
@@ -4,15 +4,17 @@ import { Link } from 'wouter'
 import { ListEditor } from './ListEditor'
 import { Notice } from './Notice'
 import { ShareInvite } from './ShareInvite'
-import { SignInBenefits } from './SignInBenefits'
+import { SignInBenefits, WroteAllInvite } from './SignInBenefits'
 import {
   canInviteToShare,
+  inviteKind,
   listProgress,
   parseInvitedAt,
   rejectionMessage,
   shareInviteStorageKey,
   shareInviteTrigger,
   toCompletionPermission,
+  type InviteKind,
   type ListProgress,
   type SessionState,
 } from './model'
@@ -67,7 +69,7 @@ function SignInRequired({ session }: { session: SessionState }) {
 }
 
 /**
- * 共有のお誘いを出すかどうかを決める（#276）。
+ * 節目のお誘いを出すかどうかを決める（#276 / #284）。
  *
  * 🔴 **操作の側に手を入れない。** 「✓ を押したとき」「項目を足したとき」に
  * 呼び出しを足す形にすると、**足し忘れた経路から出なくなる**し、
@@ -78,19 +80,24 @@ function SignInRequired({ session }: { session: SessionState }) {
  * 開いただけで誘いが出る。
  */
 function useShareInvite(screen: ListController['screen']): {
-  open: boolean
+  kind: InviteKind | null
   close: () => void
 } {
-  const [open, setOpen] = useState(false)
+  const [kind, setKind] = useState<InviteKind | null>(null)
   const previous = useRef<{ key: string; progress: ListProgress } | null>(null)
 
   const key = screen.status === 'ready' ? screen.key : null
   const list = screen.status === 'ready' ? screen.list : null
-  // 未ログイン（`share` が null）では誘わない。渡す先がログインの向こう側にある
+  /**
+   * ログイン中か（`share` が入っているか）。**誘い方が変わる**（#284）。
+   *
+   * 未ログインの人の次の一歩は共有ではなく**まずログイン**。
+   * 共有設定はログインの向こう側にあるので、そちらへ送っても何もできない。
+   */
   const shared = screen.status === 'ready' && screen.share !== null
 
   useEffect(() => {
-    if (key === null || list === null || !shared) {
+    if (key === null || list === null) {
       previous.current = null
       return
     }
@@ -100,7 +107,13 @@ function useShareInvite(screen: ListController['screen']): {
     previous.current = { key, progress }
 
     if (before?.key !== key) return
-    if (shareInviteTrigger(before.progress, progress) === null) return
+
+    const trigger = shareInviteTrigger(before.progress, progress)
+    if (trigger === null) return
+
+    // どちらのお誘いか。**未ログインで完了だけ、のときは出さない**（#284）
+    const next = inviteKind(trigger, shared)
+    if (next === null) return
 
     /*
      * 🔴 **間隔を守る**（同じリストでは30日に1回）。
@@ -117,16 +130,16 @@ function useShareInvite(screen: ListController['screen']): {
       }
 
       localStorage.setItem(storageKey, String(now))
-      setOpen(true)
+      setKind(next)
     } catch {
       // 記録できない環境。**黙って出さない**（利用者に伝えることが無い）
     }
   }, [key, list, shared])
 
   return {
-    open,
+    kind,
     close: () => {
-      setOpen(false)
+      setKind(null)
     },
   }
 }
@@ -212,16 +225,21 @@ function ListPageBody({
           />
 
           {/*
-            叶えたとき・100個書き終えたときのお誘い（#276）。
+            節目のお誘い（#276 / #284）。
             **出すかどうかは `useShareInvite`。** ここは置き場所だけ
           */}
           {screen.share !== null && (
             <ShareInvite
               listId={screen.key}
               share={screen.share}
-              open={invite.open}
+              open={invite.kind === 'share'}
               onClose={invite.close}
             />
+          )}
+
+          {/* 未ログインで100個書き終えたとき。**共有ではなくログインへ誘う**（#284） */}
+          {screen.share === null && (
+            <WroteAllInvite open={invite.kind === 'sign-in'} onClose={invite.close} />
           )}
         </>
       )}

--- a/apps/web/src/client/Modal.tsx
+++ b/apps/web/src/client/Modal.tsx
@@ -84,3 +84,18 @@ export function Modal({
     </dialog>
   )
 }
+
+/**
+ * 断る側のボタン。**こちらから声をかけたモーダルにだけ置く**（#276 / #284）。
+ *
+ * 右上の × でも閉じられるが、**押していないのに出てきたもの**は
+ * 本文の側にも「要らない」と言える場所が要る。
+ * 🔴 **主のボタンと同じ強さにしない。**
+ */
+export function ModalDecline({ onClose }: { onClose: () => void }) {
+  return (
+    <button type="button" onClick={onClose} className="mt-3 w-full py-2 text-sm text-slate-500">
+      閉じる
+    </button>
+  )
+}

--- a/apps/web/src/client/ShareInvite.tsx
+++ b/apps/web/src/client/ShareInvite.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { Link } from 'wouter'
 
-import { Modal } from './Modal'
+import { Modal, ModalDecline } from './Modal'
 import { canUseShareSheet, isShareCancelled, shareUrl } from './model'
 import type { ShareState } from './useList'
 
@@ -86,7 +86,7 @@ function NotSharedYet({ listId, onClose }: { listId: string; onClose: () => void
         共有の設定を開く
       </Link>
 
-      <CloseButton onClose={onClose} />
+      <ModalDecline onClose={onClose} />
     </>
   )
 }
@@ -159,16 +159,7 @@ function AlreadyShared({ shareId, onClose }: { shareId: string; onClose: () => v
         {copied ? 'コピーしました' : 'URL をコピー'}
       </button>
 
-      <CloseButton onClose={onClose} />
+      <ModalDecline onClose={onClose} />
     </>
-  )
-}
-
-/** 断る側。**主のボタンと同じ強さにしない。** */
-function CloseButton({ onClose }: { onClose: () => void }) {
-  return (
-    <button type="button" onClick={onClose} className="mt-3 w-full py-2 text-sm text-slate-500">
-      閉じる
-    </button>
   )
 }

--- a/apps/web/src/client/SignInBenefits.tsx
+++ b/apps/web/src/client/SignInBenefits.tsx
@@ -1,6 +1,6 @@
-import { useRef } from 'react'
+import { useEffect, useRef } from 'react'
 
-import { Modal } from './Modal'
+import { Modal, ModalDecline } from './Modal'
 import { signInBenefits, type SignInBenefit } from './model'
 
 /**
@@ -38,6 +38,34 @@ export function SignInBenefits({ label = 'ほかにできること' }: { label?:
 
       <Dialog ref={dialog} />
     </>
+  )
+}
+
+/**
+ * 未ログインで**100個すべて書き終えた**ときに出す（#284）。
+ *
+ * #276 のお誘い（共有）はログイン中だけだった。誘う先がログインの向こう側にあるため。
+ * しかし**100個書き終えるのは一番大きな節目**で、そこで何も起きないのはもったいない。
+ * 未ログインの人にとっての次の一歩は共有ではなく、**まずログイン**（`PRODUCT_SPEC.md` §2）。
+ *
+ * 🔴 **中身は「ログインすると、できること」と同じものを使う**（#204 の決定）。
+ * **変えるのは見出しだけ。** 書き分けると必ずずれる。
+ */
+export function WroteAllInvite({ open, onClose }: { open: boolean; onClose: () => void }) {
+  const dialog = useRef<HTMLDialogElement>(null)
+
+  useEffect(() => {
+    if (open) dialog.current?.showModal()
+  }, [open])
+
+  return (
+    <Dialog
+      ref={dialog}
+      title="100個、書き終わりました！"
+      onClose={onClose}
+      // 押していないのに出てくるので、断る場所を本文の側にも置く
+      onDecline={() => dialog.current?.close()}
+    />
   )
 }
 
@@ -134,9 +162,21 @@ function GoogleLogo() {
   )
 }
 
-function Dialog({ ref }: { ref: React.RefObject<HTMLDialogElement | null> }) {
+function Dialog({
+  ref,
+  title = 'ログインすると、できること',
+  onClose,
+  onDecline,
+}: {
+  ref: React.RefObject<HTMLDialogElement | null>
+  /** 🔴 **見出しだけを差し替える**（#284）。中身は書き分けない */
+  title?: string
+  onClose?: () => void
+  /** 渡すと「閉じる」が出る。**こちらから声をかけたときだけ**（`ModalDecline`） */
+  onDecline?: () => void
+}) {
   return (
-    <Modal ref={ref} title="ログインすると、できること">
+    <Modal ref={ref} title={title} onClose={onClose}>
       {/*
         🔴 **1つずつ札に分ける**（#213）。
         文だけを縦に並べると、**どこからどこまでが1つの話か分からず読む気にならない。**
@@ -164,6 +204,8 @@ function Dialog({ ref }: { ref: React.RefObject<HTMLDialogElement | null> }) {
         <GoogleLogo />
         Googleでログイン
       </a>
+
+      {onDecline !== undefined && <ModalDecline onClose={onDecline} />}
     </Modal>
   )
 }

--- a/apps/web/src/client/model.ts
+++ b/apps/web/src/client/model.ts
@@ -497,6 +497,32 @@ export function shareInviteTrigger(
 }
 
 /**
+ * 節目に出すお誘いの種類。**ログインしているかで次の一歩が違う。**
+ *
+ * | | 次の一歩 |
+ * |---|---|
+ * | `share` | 共有する（#276） |
+ * | `sign-in` | まずログインする（#284） |
+ */
+export type InviteKind = 'share' | 'sign-in'
+
+/**
+ * どちらのお誘いを出すか（#284）。**出さないなら `null`。**
+ *
+ * 🔴 **未ログインは「書き終えたとき」だけ。**
+ * 共有設定はログインの向こう側にあるので、共有へ誘っても**その場では何もできない。**
+ * 一方 100個書き終えるのは一番大きな節目なので、そこは**ログインへ誘う**。
+ *
+ * ⚠️ 未ログインでは完了にできない（#77）ので `completed` は本来来ないが、
+ * **来ても誘わない**と書いておく（完了の条件が変わったときに勝手に増えないように）。
+ */
+export function inviteKind(trigger: ShareInviteTrigger, shared: boolean): InviteKind | null {
+  if (shared) return 'share'
+
+  return trigger === 'filled' ? 'sign-in' : null
+}
+
+/**
  * 同じリストで続けて出さない間隔。**30日**（2026-08-14 の利用者の指示）。
  *
  * 🔴 **「1回きり」にしない。** そのとき断っただけの人を、一生誘わないのはやりすぎ。

--- a/apps/web/test/client-model.test.ts
+++ b/apps/web/test/client-model.test.ts
@@ -11,6 +11,7 @@ import {
   canInviteToShare,
   canUseShareSheet,
   createEmptyList,
+  inviteKind,
   isShareCancelled,
   parseInvitedAt,
   SHARE_INVITE_INTERVAL_MS,
@@ -545,6 +546,23 @@ describe('shareInviteTrigger', () => {
 
   it('何も変わっていなければ誘わない', () => {
     expect(shareInviteTrigger(at(2, 50), at(2, 50))).toBeNull()
+  })
+})
+
+describe('inviteKind', () => {
+  it('ログイン中は共有へ誘う', () => {
+    expect(inviteKind('completed', true)).toBe('share')
+    expect(inviteKind('filled', true)).toBe('share')
+  })
+
+  it('🔴 未ログインで書き終えたら、共有ではなくログインへ誘う', () => {
+    // 共有設定はログインの向こう側にあるので、共有へ送っても何もできない
+    expect(inviteKind('filled', false)).toBe('sign-in')
+  })
+
+  it('🔴 未ログインで「やった」が増えても誘わない', () => {
+    // そもそも未ログインでは完了にできない（#77）。条件が変わっても勝手に増えないように
+    expect(inviteKind('completed', false)).toBeNull()
   })
 })
 


### PR DESCRIPTION
Closes #284

## やったこと

#276 では**未ログインのときを見送っていた。** 誘う先（共有設定）がログインの向こう側にあり、
「みんなに見せませんか？」と言っても**その場では何もできない**ため。

ただし **100個書き終えるのは一番大きな節目**で、そこで何も起きないのはもったいない。
未ログインの人にとっての次の一歩は共有ではなく、**まずログイン**（`PRODUCT_SPEC.md` §2）。

<img src="https://raw.githubusercontent.com/aiandrox/yaritai100list/previews/284-signin.png" width="300">

## 🔴 守っていること・判断したこと

- 🔴 **中身は「ログインすると、できること」をそのまま使う**（#204 の決定）。
  **変えるのは見出しだけ。** 書き分けると必ずずれる
- 🔴 **きっかけは「書き終えたとき」だけ。** 未ログインでは完了にできない（#77）ので
  `completed` は本来来ないが、**来ても誘わない**と書いてある
  （完了の条件が変わったときに勝手に増えないように）
- **間隔は #276 と同じ仕組み。** 同じリストで30日に1回（未ログインのリストの鍵は `local`）
- **「閉じる」を足した。** こちらから声をかけているので、断る場所を本文の側にも置く
  （押して開く「ほかにできること」には出さない）

## テスト

588 件中 588 件が緑（27 ファイル）。typecheck / lint も緑。足した判断は `inviteKind`:

- ログイン中は共有へ誘う
- 🔴 未ログインで書き終えたら、共有ではなくログインへ誘う
- 🔴 未ログインで「やった」が増えても誘わない

## 確認したこと・していないこと

実物で確かめた。

| | 結果 |
|---|---|
| 未ログインで100個目を書く | 「100個、書き終わりました！」＋ Googleでログイン |
| 🔴 消して書き直す | **出ない**（30日に1回） |
| ログイン中（#276 の5通り） | **変わらず**（共有のお誘いが出る） |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
