### PR TITLE
モーダルの「閉じる」を外す（#286）

### DIFF
--- a/apps/web/src/client/Modal.tsx
+++ b/apps/web/src/client/Modal.tsx
@@ -84,18 +84,3 @@ export function Modal({
     </dialog>
   )
 }
-
-/**
- * 断る側のボタン。**こちらから声をかけたモーダルにだけ置く**（#276 / #284）。
- *
- * 右上の × でも閉じられるが、**押していないのに出てきたもの**は
- * 本文の側にも「要らない」と言える場所が要る。
- * 🔴 **主のボタンと同じ強さにしない。**
- */
-export function ModalDecline({ onClose }: { onClose: () => void }) {
-  return (
-    <button type="button" onClick={onClose} className="mt-3 w-full py-2 text-sm text-slate-500">
-      閉じる
-    </button>
-  )
-}

--- a/apps/web/src/client/ShareInvite.tsx
+++ b/apps/web/src/client/ShareInvite.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { Link } from 'wouter'
 
-import { Modal, ModalDecline } from './Modal'
+import { Modal } from './Modal'
 import { canUseShareSheet, isShareCancelled, shareUrl } from './model'
 import type { ShareState } from './useList'
 
@@ -56,7 +56,7 @@ export function ShareInvite({
       {share.visibility === 'private' ? (
         <NotSharedYet listId={listId} onClose={close} />
       ) : (
-        <AlreadyShared shareId={share.shareId} onClose={close} />
+        <AlreadyShared shareId={share.shareId} />
       )}
     </Modal>
   )
@@ -85,8 +85,6 @@ function NotSharedYet({ listId, onClose }: { listId: string; onClose: () => void
       >
         共有の設定を開く
       </Link>
-
-      <ModalDecline onClose={onClose} />
     </>
   )
 }
@@ -95,7 +93,7 @@ function NotSharedYet({ listId, onClose }: { listId: string; onClose: () => void
  * もう公開しているとき。**設定画面へ回さず、その場で送れるようにする**
  * （2026-08-14 の利用者の指示）。
  */
-function AlreadyShared({ shareId, onClose }: { shareId: string; onClose: () => void }) {
+function AlreadyShared({ shareId }: { shareId: string }) {
   const [copied, setCopied] = useState(false)
   const [failed, setFailed] = useState<string | null>(null)
   const url = shareUrl(window.location.origin, shareId)
@@ -158,8 +156,6 @@ function AlreadyShared({ shareId, onClose }: { shareId: string; onClose: () => v
       >
         {copied ? 'コピーしました' : 'URL をコピー'}
       </button>
-
-      <ModalDecline onClose={onClose} />
     </>
   )
 }

--- a/apps/web/src/client/SignInBenefits.tsx
+++ b/apps/web/src/client/SignInBenefits.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react'
 
-import { Modal, ModalDecline } from './Modal'
+import { Modal } from './Modal'
 import { signInBenefits, type SignInBenefit } from './model'
 
 /**
@@ -58,15 +58,7 @@ export function WroteAllInvite({ open, onClose }: { open: boolean; onClose: () =
     if (open) dialog.current?.showModal()
   }, [open])
 
-  return (
-    <Dialog
-      ref={dialog}
-      title="100個、書き終わりました！"
-      onClose={onClose}
-      // 押していないのに出てくるので、断る場所を本文の側にも置く
-      onDecline={() => dialog.current?.close()}
-    />
-  )
+  return <Dialog ref={dialog} title="100個、書き終わりました！" onClose={onClose} />
 }
 
 /**
@@ -166,14 +158,11 @@ function Dialog({
   ref,
   title = 'ログインすると、できること',
   onClose,
-  onDecline,
 }: {
   ref: React.RefObject<HTMLDialogElement | null>
   /** 🔴 **見出しだけを差し替える**（#284）。中身は書き分けない */
   title?: string
   onClose?: () => void
-  /** 渡すと「閉じる」が出る。**こちらから声をかけたときだけ**（`ModalDecline`） */
-  onDecline?: () => void
 }) {
   return (
     <Modal ref={ref} title={title} onClose={onClose}>
@@ -204,8 +193,6 @@ function Dialog({
         <GoogleLogo />
         Googleでログイン
       </a>
-
-      {onDecline !== undefined && <ModalDecline onClose={onDecline} />}
     </Modal>
   )
 }


### PR DESCRIPTION
Closes #286

## やったこと

**× があるなら「閉じる」は要らない**（2026-08-14 の利用者の指示）。

#276 / #284 では「押していないのに出てきたものは、本文の側にも断る場所が要る」として
「閉じる」を置いていたが、これは **#276 で × を落としていた時期の名残**。
#282 で × が戻ったあとも残っていて、**同じことをする場所が2つ**あった。

`ModalDecline` ごと消した。

## 画面

| 共有のお誘い（非公開） | 共有のお誘い（公開済み） | 100個書き終えたとき |
|---|---|---|
| <img src="https://raw.githubusercontent.com/aiandrox/yaritai100list/previews/286-private.png" width="240"> | <img src="https://raw.githubusercontent.com/aiandrox/yaritai100list/previews/286-shared.png" width="240"> | <img src="https://raw.githubusercontent.com/aiandrox/yaritai100list/previews/286-signin.png" width="240"> |

## 🔴 守っていること・判断したこと

- ⚠️ **閉じ方が減ったわけではない。** × のほかに **Esc と背景押し**が効く
  （`<dialog>` が面倒を見ている。`Modal.tsx`）
- **「ほかにできること」は元から × だけ**だったので、これで3つとも揃った

## テスト

588 件中 588 件が緑（27 ファイル）。typecheck / lint も緑。
**ボタンを消しただけなので、増やしたテストは無い**（判断を1つも足していない）。

## 確認したこと・していないこと

実物で、3つとも「閉じる」が無くなっていることと、
× / Esc / 背景押しで閉じられることを確認した。
お誘いを出す条件（30日に1回、公開範囲での出し分け）も**変わっていない**ことを確かめている。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
