### PR TITLE
共有のお誘いの見出しを「何が起きたか」にする

### DIFF
--- a/apps/web/src/client/ListPage.tsx
+++ b/apps/web/src/client/ListPage.tsx
@@ -9,13 +9,16 @@ import {
   canInviteToShare,
   inviteKind,
   listProgress,
+  newlyCompletedText,
   parseInvitedAt,
   rejectionMessage,
   shareInviteStorageKey,
   shareInviteTrigger,
   toCompletionPermission,
+  type Achievement,
   type InviteKind,
   type ListProgress,
+  type LocalList,
   type SessionState,
 } from './model'
 import { useList, type ImportOutcome, type ListController } from './useList'
@@ -80,11 +83,18 @@ function SignInRequired({ session }: { session: SessionState }) {
  * 開いただけで誘いが出る。
  */
 function useShareInvite(screen: ListController['screen']): {
-  kind: InviteKind | null
+  /** 出しているお誘い。**何が起きて出たのかを一緒に持つ**（#306） */
+  invite: { kind: InviteKind; achievement: Achievement } | null
   close: () => void
 } {
-  const [kind, setKind] = useState<InviteKind | null>(null)
-  const previous = useRef<{ key: string; progress: ListProgress } | null>(null)
+  const [invite, setInvite] = useState<{ kind: InviteKind; achievement: Achievement } | null>(null)
+  /**
+   * 直前の状態。
+   *
+   * 🔴 **リストそのものを持つ**（#306）。進み具合（数）だけでは
+   * **どの項目を達成したかが分からず、見出しに書けない**（`newlyCompletedText`）。
+   */
+  const previous = useRef<{ key: string; progress: ListProgress; list: LocalList } | null>(null)
 
   const key = screen.status === 'ready' ? screen.key : null
   const list = screen.status === 'ready' ? screen.list : null
@@ -104,7 +114,7 @@ function useShareInvite(screen: ListController['screen']): {
 
     const progress = listProgress(list)
     const before = previous.current
-    previous.current = { key, progress }
+    previous.current = { key, progress, list }
 
     if (before?.key !== key) return
 
@@ -114,6 +124,23 @@ function useShareInvite(screen: ListController['screen']): {
     // どちらのお誘いか。**未ログインで完了だけ、のときは出さない**（#284）
     const next = inviteKind(trigger, shared)
     if (next === null) return
+
+    /**
+     * 何が起きたか（#306）。見出しに出す。
+     *
+     * 🔴 **達成した項目が分からないなら出さない。**
+     * 「を達成しました」のような見出しを出す方が、出さないより悪い。
+     */
+    let achievement: Achievement | null = null
+
+    if (trigger === 'filled') {
+      achievement = { kind: 'filled' }
+    } else {
+      const text = newlyCompletedText(before.list, list)
+      if (text !== null) achievement = { kind: 'completed', text }
+    }
+
+    if (achievement === null) return
 
     /*
      * 🔴 **間隔を守る**（同じリストでは30日に1回）。
@@ -130,16 +157,16 @@ function useShareInvite(screen: ListController['screen']): {
       }
 
       localStorage.setItem(storageKey, String(now))
-      setKind(next)
+      setInvite({ kind: next, achievement })
     } catch {
       // 記録できない環境。**黙って出さない**（利用者に伝えることが無い）
     }
   }, [key, list, shared])
 
   return {
-    kind,
+    invite,
     close: () => {
-      setKind(null)
+      setInvite(null)
     },
   }
 }
@@ -154,7 +181,7 @@ function ListPageBody({
 }) {
   const controller = useList(session, listId ?? null)
   const { screen, rejection } = controller
-  const invite = useShareInvite(screen)
+  const { invite, close: closeInvite } = useShareInvite(screen)
 
   return (
     <>
@@ -228,18 +255,23 @@ function ListPageBody({
             節目のお誘い（#276 / #284）。
             **出すかどうかは `useShareInvite`。** ここは置き場所だけ
           */}
-          {screen.share !== null && (
+          {/*
+            🔴 **出すときだけ組み立てる**（#306）。
+            見出しに「何が起きたか」（`achievement`）が要るので、
+            出さないときに渡す値を作らなくて済む形にする
+          */}
+          {screen.share !== null && invite?.kind === 'share' && (
             <ShareInvite
               listId={screen.key}
               share={screen.share}
-              open={invite.kind === 'share'}
-              onClose={invite.close}
+              achievement={invite.achievement}
+              onClose={closeInvite}
             />
           )}
 
           {/* 未ログインで100個書き終えたとき。**共有ではなくログインへ誘う**（#284） */}
           {screen.share === null && (
-            <WroteAllInvite open={invite.kind === 'sign-in'} onClose={invite.close} />
+            <WroteAllInvite open={invite?.kind === 'sign-in'} onClose={closeInvite} />
           )}
         </>
       )}

--- a/apps/web/src/client/Modal.tsx
+++ b/apps/web/src/client/Modal.tsx
@@ -75,7 +75,12 @@ export function Modal({
           ×
         </button>
 
-        <h2 id={titleId} className="text-center text-lg font-bold">
+        {/*
+          ⚠️ **長い見出しで崩れないようにする**（#306）。
+          見出しに項目の本文（最大100文字）が入るようになったので、
+          区切りの無い長い文字列でも枠から出ないよう折り返す
+        */}
+        <h2 id={titleId} className="text-center text-lg font-bold break-words">
           {title}
         </h2>
 

--- a/apps/web/src/client/ShareInvite.tsx
+++ b/apps/web/src/client/ShareInvite.tsx
@@ -2,7 +2,13 @@ import { useEffect, useRef, useState } from 'react'
 import { Link } from 'wouter'
 
 import { Modal } from './Modal'
-import { canUseShareSheet, isShareCancelled, shareUrl } from './model'
+import {
+  achievementTitle,
+  canUseShareSheet,
+  isShareCancelled,
+  shareUrl,
+  type Achievement,
+} from './model'
 import type { ShareState } from './useList'
 
 /**
@@ -12,12 +18,20 @@ import type { ShareState } from './useList'
  * それまでの導線は「共有の設定を開く → 公開範囲を変える → URL をコピー」だけで、
  * **一番気分が乗っている瞬間には何も起きなかった。**
  *
+ * 🔴 **見出しは「何が起きたか」**（2026-08-15 の利用者の指摘、#306）。
+ * 「〈やりたいこと〉を達成しました」「100個、書き終わりました！」。
+ * 以前は共有の話から始まっていて、**なぜ出たのか分からなかった**
+ * （押し間違いで出た広告のように見える）。文言は `model.ts` の `achievementTitle`。
+ *
  * 🔴 **公開範囲で中身を変える**（2026-08-14 の利用者の指示）。いまの状態から次の一歩が違う。
  *
  * | いまの公開範囲 | 出すもの |
  * |---|---|
  * | 非公開 | 「みんなにもリストを見せませんか？」→ 共有の設定へ |
  * | 全公開・リンク限定 | 「SNSでみんなに見せませんか？」→ **その場で送れる** |
+ *
+ * ⚠️ **この2つの文は本文の先頭に移した**（#306）。見出しを達成の報告に譲ったため。
+ * **文言は変えていない**（#276 で利用者が書いたもの）。
  *
  * 🔴 **ここで公開範囲を変えられるようにしない。** 誘いの場で設定を触らせない。
  *
@@ -32,27 +46,25 @@ import type { ShareState } from './useList'
 export function ShareInvite({
   listId,
   share,
-  open,
+  achievement,
   onClose,
 }: {
   listId: string
   share: ShareState
-  open: boolean
+  /** 何が起きて出たのか（#306）。**見出しになる** */
+  achievement: Achievement
   onClose: () => void
 }) {
   const dialog = useRef<HTMLDialogElement>(null)
   const close = () => dialog.current?.close()
 
+  // 出すときだけ組み立てられる（`ListPage`）ので、置かれたら開く
   useEffect(() => {
-    if (open) dialog.current?.showModal()
-  }, [open])
+    dialog.current?.showModal()
+  }, [])
 
   return (
-    <Modal
-      ref={dialog}
-      title={share.visibility === 'private' ? INVITE_TITLE : SHARE_TITLE}
-      onClose={onClose}
-    >
+    <Modal ref={dialog} title={achievementTitle(achievement)} onClose={onClose}>
       {share.visibility === 'private' ? (
         <NotSharedYet listId={listId} onClose={close} />
       ) : (
@@ -63,10 +75,13 @@ export function ShareInvite({
 }
 
 /**
- * 見出し。🔴 **利用者が書いた文をそのまま使う**（2026-08-14）。言い換えない。
+ * 共有を促す文。
+ *
+ * 🔴 **利用者が書いた文をそのまま使う**（2026-08-14）。言い換えない。
+ * #306 で**見出しから本文の先頭へ移した**（見出しは達成の報告になった）。
  */
-const INVITE_TITLE = 'みんなにもリストを見せませんか？'
-const SHARE_TITLE = 'SNSでみんなに見せませんか？'
+const INVITE_LEAD = 'みんなにもリストを見せませんか？'
+const SHARE_LEAD = 'SNSでみんなに見せませんか？'
 
 /**
  * まだ非公開のとき。**渡す先が無いので、まず公開範囲を決めてもらう。**
@@ -74,7 +89,10 @@ const SHARE_TITLE = 'SNSでみんなに見せませんか？'
 function NotSharedYet({ listId, onClose }: { listId: string; onClose: () => void }) {
   return (
     <>
-      <p className="mt-3 text-sm leading-6 text-slate-600">
+      {/* 🔴 **共有を促すのはここから**（#306）。見出しは達成の報告 */}
+      <p className="mt-3 text-center text-sm font-bold">{INVITE_LEAD}</p>
+
+      <p className="mt-2 text-sm leading-6 text-slate-600">
         いまは自分だけが見られる状態です。公開すると、リンクを渡した人に見てもらえます。
       </p>
 
@@ -124,7 +142,9 @@ function AlreadyShared({ shareId }: { shareId: string }) {
 
   return (
     <>
-      <p className="mt-3 text-sm leading-6 text-slate-600">
+      <p className="mt-3 text-center text-sm font-bold">{SHARE_LEAD}</p>
+
+      <p className="mt-2 text-sm leading-6 text-slate-600">
         このリストは、リンクを渡した人が見られる状態です。
       </p>
 

--- a/apps/web/src/client/SignInBenefits.tsx
+++ b/apps/web/src/client/SignInBenefits.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react'
 
 import { Modal } from './Modal'
-import { signInBenefits, type SignInBenefit } from './model'
+import { signInBenefits, WROTE_ALL_TITLE, type SignInBenefit } from './model'
 
 /**
  * ログインすると何ができるかを、まとめて見せる（#204）。
@@ -58,7 +58,8 @@ export function WroteAllInvite({ open, onClose }: { open: boolean; onClose: () =
     if (open) dialog.current?.showModal()
   }, [open])
 
-  return <Dialog ref={dialog} title="100個、書き終わりました！" onClose={onClose} />
+  // 🔴 **共有のお誘い（#306）と同じ文言を使う。** 書き分けると必ずずれる
+  return <Dialog ref={dialog} title={WROTE_ALL_TITLE} onClose={onClose} />
 }
 
 /**

--- a/apps/web/src/client/model.ts
+++ b/apps/web/src/client/model.ts
@@ -511,6 +511,64 @@ export function inviteKind(trigger: ShareInviteTrigger, shared: boolean): Invite
 }
 
 /**
+ * **何が起きて出たのか**（#306）。モーダルの見出しになる。
+ *
+ * 🔴 **見出しで「いま自分が何をしたか」を言う**（2026-08-15 の利用者の指摘）。
+ * 以前は「みんなにもリストを見せませんか？」から始まっていて、
+ * **なぜ出たのか分からず、押し間違いで出た広告のように見えた。**
+ * 共有を促す文は本文の先頭へ移した（文言はそのまま。#276）。
+ */
+export type Achievement =
+  /** 1つ叶えた。**その項目の本文を持つ**（どれを達成したかを見出しで言うため） */
+  | { kind: 'completed'; text: string }
+  /** 100個すべて書き終えた */
+  | { kind: 'filled' }
+
+/**
+ * 100個書き終えたときの見出し。
+ *
+ * 🔴 **未ログインのお誘い（#284）と同じ文言を使う。** 書き分けると必ずずれる
+ * （利用者が書いた文をそのまま使う、という #276 / #284 の扱いも変えない）。
+ */
+export const WROTE_ALL_TITLE = '100個、書き終わりました！'
+
+/**
+ * モーダルの見出し（#306）。
+ *
+ * 🔴 **利用者が指示した形をそのまま使う**（2026-08-15）:
+ * 「〈やりたいこと〉を達成しました」。言い換えない。
+ */
+export function achievementTitle(achievement: Achievement): string {
+  return achievement.kind === 'filled' ? WROTE_ALL_TITLE : `${achievement.text}を達成しました`
+}
+
+/**
+ * 直前の状態と見比べて、**新しく完了した項目の本文**を返す（#306）。
+ *
+ * 見出しに「どれを達成したか」を出すために要る。お誘いの判定は達成数の増減
+ * （`shareInviteTrigger`）だけを見ているので、**項目はここで特定する。**
+ *
+ * 🔴 **`completedPrecision` で見る**（#279）。日付なしの完了も達成に入る。
+ * ⚠️ **同時に2つ以上完了していたら、リストで先に来るものを返す。**
+ * 1回の操作で1つしか完了できないので、実際には起きない
+ * （起きるとしたら別の端末での操作が同時に届いたとき）。
+ *
+ * 分からなければ `null`。**呼び出し側はそのときお誘いを出さない**
+ * （「なぜ出たか」を言えないなら出さない方がよい。#306）。
+ */
+export function newlyCompletedText(before: LocalList, after: LocalList): string | null {
+  const completedBefore = new Set(
+    before.items.filter((item) => isCompleted(item.completedPrecision)).map((item) => item.id),
+  )
+
+  const item = after.items.find(
+    (candidate) => isCompleted(candidate.completedPrecision) && !completedBefore.has(candidate.id),
+  )
+
+  return item?.text ?? null
+}
+
+/**
  * 同じリストで続けて出さない間隔。**30日**（2026-08-14 の利用者の指示）。
  *
  * 🔴 **「1回きり」にしない。** そのとき断っただけの人を、一生誘わないのはやりすぎ。

--- a/apps/web/test/client-model.test.ts
+++ b/apps/web/test/client-model.test.ts
@@ -7,6 +7,7 @@ import {
 import { describe, expect, it } from 'vitest'
 
 import {
+  achievementTitle,
   addItem,
   canInviteToShare,
   canUseShareSheet,
@@ -34,6 +35,8 @@ import {
   shareUrl,
   sortAdoptedLast,
   sortListsByCreated,
+  newlyCompletedText,
+  WROTE_ALL_TITLE,
   COMPLETION_WITHOUT_DATE,
   NOT_COMPLETED,
   setItemCompletion,
@@ -545,6 +548,83 @@ describe('inviteKind', () => {
   it('🔴 未ログインで「やった」が増えても誘わない', () => {
     // そもそも未ログインでは完了にできない（#77）。条件が変わっても勝手に増えないように
     expect(inviteKind('completed', false)).toBeNull()
+  })
+})
+
+/**
+ * モーダルの見出し（#306）。**なぜ出たのかを見出しで言う。**
+ *
+ * 以前は「みんなにもリストを見せませんか？」から始まっていて、
+ * **いま自分が何をしたから出たのか**が分からなかった（2026-08-15 の利用者の指摘）。
+ */
+describe('achievementTitle', () => {
+  it('叶えたときは、その項目の本文を入れる', () => {
+    expect(achievementTitle({ kind: 'completed', text: '南極に行く' })).toBe(
+      '南極に行くを達成しました',
+    )
+  })
+
+  it('100個書き終えたときの文言', () => {
+    expect(achievementTitle({ kind: 'filled' })).toBe(WROTE_ALL_TITLE)
+  })
+
+  it('🔴 未ログインの書き終わり（#284）と同じ文言を使う', () => {
+    // 書き分けると必ずずれる。**同じ定数を指していること**を固定する
+    expect(WROTE_ALL_TITLE).toBe('100個、書き終わりました！')
+  })
+})
+
+describe('newlyCompletedText', () => {
+  /** 完了した状態の項目を作る（粒度で完了を表す。#279） */
+  const done = (list: LocalList, id: string) =>
+    expectOk(setItemCompletion(list, id, COMPLETION_WITHOUT_DATE))
+
+  it('新しく完了した項目の本文を返す', () => {
+    const before = listOf('南極に行く', 'オーロラを見る')
+    const after = done(before, 'i2')
+
+    expect(newlyCompletedText(before, after)).toBe('オーロラを見る')
+  })
+
+  it('🔴 日付なしの完了も見つける（#279）', () => {
+    const before = listOf('南極に行く')
+    const after = done(before, 'i1')
+
+    expect(newlyCompletedText(before, after)).toBe('南極に行く')
+  })
+
+  it('日付ありの完了も見つける', () => {
+    const before = listOf('南極に行く')
+    const after = expectOk(completeOn(before, 'i1', 1_700_000_000_000))
+
+    expect(newlyCompletedText(before, after)).toBe('南極に行く')
+  })
+
+  it('何も変わっていなければ null', () => {
+    const list = done(listOf('南極に行く', 'オーロラを見る'), 'i1')
+
+    expect(newlyCompletedText(list, list)).toBeNull()
+  })
+
+  it('🔴 完了を取り消しただけなら null（お誘いを出さない側に倒す）', () => {
+    const before = done(listOf('南極に行く'), 'i1')
+    const after = expectOk(setItemCompletion(before, 'i1', NOT_COMPLETED))
+
+    expect(newlyCompletedText(before, after)).toBeNull()
+  })
+
+  it('本文を書き換えただけなら null（完了は動いていない）', () => {
+    const before = done(listOf('南極に行く'), 'i1')
+    const after = expectOk(updateItemText(before, 'i1', '北極に行く'))
+
+    expect(newlyCompletedText(before, after)).toBeNull()
+  })
+
+  it('2つ同時に完了していたら、リストで先に来るものを返す', () => {
+    const before = listOf('1つ目', '2つ目')
+    const after = done(done(before, 'i2'), 'i1')
+
+    expect(newlyCompletedText(before, after)).toBe('1つ目')
   })
 })
 


### PR DESCRIPTION
Closes #306

## やったこと

**叶えたときに出る共有のお誘いが、なぜ出たのか分からなかった**（2026-08-15 の利用者の指摘）。
見出しが「みんなにもリストを見せませんか？」だけで、**いま自分が何をしたから出たのか**が
どこにも書いていない。共有の話から始まるので、押し間違いで出た広告のように見える。

**見出しを「何が起きたか」にして、共有を促すのは本文の先頭に移した。**

| | 見出し | 本文の先頭 |
|---|---|---|
| 叶えたとき | **「〈やりたいこと〉を達成しました」** | みんなにもリストを見せませんか？ / SNSでみんなに見せませんか？ |
| 100個書き終えたとき | **「100個、書き終わりました！」** | 同上 |

**他のモーダルも同様に**という指示への対応:

- 100個書き終えて出る共有のお誘い → **未ログイン版（#284）と同じ文言**を使う。
  `WROTE_ALL_TITLE` 1箇所にして、書き分けが起きないようにした
- 未ログインの書き終わり（#284）は**既に「何が起きたか」**なので変えていない
- ⚠️ 「ログインすると、できること」（#204）は**押して開くもの**なので変えていない。
  理由が分からないのは「勝手に出てくる」モーダルだけの問題

## 画面

| 叶えたとき（非公開） | 公開済み（その場で送れる） |
|---|---|
| <img src="https://raw.githubusercontent.com/aiandrox/yaritai100list/previews/306-private.png" width="300"> | <img src="https://raw.githubusercontent.com/aiandrox/yaritai100list/previews/306-shared.png" width="300"> |

**100文字ちょうどの項目**でも崩れないことを確かめた（`ITEM_TEXT_MAX_LENGTH` の上限）:

<img src="https://raw.githubusercontent.com/aiandrox/yaritai100list/previews/306-long.png" width="300">

## 🔴 守っていること・判断したこと

- **利用者が書いた文言をそのまま使う。** 見出しは指示された
  「〈やりたいこと〉を達成しました」の形。#276 で書いてもらった2つの文
  （「みんなにもリストを見せませんか？」「SNSでみんなに見せませんか？」）は
  **1文字も変えずに本文へ移した**だけ
- 🔴 **達成した項目が分からないときはお誘いを出さない。**
  「を達成しました」のような見出しを出す方が、出さないより悪い（#306 の趣旨に反する）
- **文言と判定は `model.ts` の純関数に置いた**（`achievementTitle` / `newlyCompletedText`）。
  `*.tsx` はテストしない層なので（`TECH_STACK.md` §10）、文言を画面に埋めない
- **どの項目を達成したかの特定は `completedPrecision` で見る**（#279）。
  `completedAt` で見ると**日付なしの完了が見つからない**
- **出すかどうかの判断は `ListPage` のまま。** お誘いは
  「進み具合の変化だけを見る」形（#276）を崩していない。項目の特定もその差分から行う
- ⚠️ **`ShareInvite` は出すときだけ組み立てる形にした。** 見出しに「何が起きたか」が
  要るので、出さないときに空の値を渡さなくて済む（`open` の受け渡しが消えた）

## テスト

**667 / 667 緑**（typecheck / lint / format も緑）。足したのは `test/client-model.test.ts` に:

- `achievementTitle`: 達成のときは項目の本文が入ること、100個のときの文言、
  **未ログイン版（#284）と同じ定数を指していること**
- `newlyCompletedText`: 新しく完了した項目を返すこと、**日付なしの完了も見つけること**（#279）、
  変化が無ければ `null`、**取り消しだけなら `null`**、本文の書き換えだけなら `null`、
  同時に2つなら先に来るもの

## 確認したこと・していないこと

`wrangler dev` + ローカル D1 で確認した（上の画面）。

- 非公開のリストで叶える → 「南極に行くを達成しました」＋「みんなにもリストを見せませんか？」
- リンク限定公開のリストで叶える → 「グランピングをするを達成しました」＋「SNSでみんなに…」
- **100文字の項目**で叶える → 見出しが4行に折り返し、枠から出ない（`break-words` を足した）
- **していないこと**: 100個書き終えたときの見出しは**実物で見ていない**
  （100項目を書く必要があるため）。文言はテストで固定してある

🤖 Generated with [Claude Code](https://claude.com/claude-code)
