### PR TITLE
アカウント削除の導線を作る（#308）

### DIFF
--- a/apps/web/src/client/ListsPage.tsx
+++ b/apps/web/src/client/ListsPage.tsx
@@ -291,6 +291,13 @@ export function ListsPage({
 
         {signOutFailed && <p className="mt-1 text-xs text-brand-deep">ログアウトに失敗しました</p>}
       </div>
+
+      {/*
+        アカウントの削除（#308）。**ログアウトと同じ場所に置く**（#114）。
+        🔴 **一番下に、いちばん目立たない見た目で。** 日常的に押すものではないうえ、
+        押した先が取り消せない
+      */}
+      <DeleteAccount />
     </div>
   )
 }
@@ -394,6 +401,98 @@ function RestoreField({ onPick }: { onPick: (file: File) => Promise<void> }) {
       >
         ファイルからリストを読み込む
       </button>
+    </div>
+  )
+}
+
+/**
+ * アカウントの削除（#308）。**取り消せない。**
+ *
+ * 🔴 **2段階にする**（共有リンクの作り直しと同じ作法）。
+ * 押した先が戻せないので、1回の誤タップで消えないようにする。
+ *
+ * 🔴 **消す前に「書き出せること」を伝える。**
+ * 戻す手段が無い操作では、**戻せるうちに持ち出せる**ことを先に示す。
+ *
+ * ⚠️ **消えた後は自分のセッションも無効**（サーバー側で cascade）。
+ * 画面を作り直させるため、応答が返ったら**トップへ移す**。
+ */
+function DeleteAccount() {
+  const [confirming, setConfirming] = useState(false)
+  const [failed, setFailed] = useState(false)
+
+  const remove = async () => {
+    setFailed(false)
+
+    try {
+      const res = await api.api.account.$delete()
+
+      if (!res.ok) {
+        setFailed(true)
+        return
+      }
+
+      // 🔴 **状態を持ち回らない。** セッションごと消えているので、
+      // 画面の状態を作り直す方が確実（React の state を1つずつ戻さない）
+      window.location.href = '/'
+    } catch {
+      setFailed(true)
+    }
+  }
+
+  if (!confirming) {
+    return (
+      <div className="mt-8 text-center">
+        <button
+          type="button"
+          onClick={() => {
+            setConfirming(true)
+          }}
+          className="text-xs text-slate-400 underline"
+        >
+          アカウントを削除する
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="mt-8 rounded border border-brand-deep/40 px-3 py-3 text-sm">
+      <p className="font-bold text-brand-deep">アカウントを削除しますか</p>
+
+      <ul className="mt-2 list-disc pl-5 text-xs leading-6 text-slate-600">
+        <li>すべてのリストと、書いたやりたいことが消えます</li>
+        <li>共有した URL は、その場で開けなくなります</li>
+        <li>
+          <strong className="text-slate-900">元に戻せません。</strong>
+          残したいものは、先に各リストの「書き出す」から保存してください
+        </li>
+      </ul>
+
+      {failed && (
+        <p role="alert" className="mt-2 text-xs text-brand-deep">
+          削除できませんでした。通信を確かめて、もう一度お試しください
+        </p>
+      )}
+
+      <div className="mt-3 flex gap-2">
+        <button
+          type="button"
+          onClick={() => void remove()}
+          className="flex-1 rounded bg-brand-deep px-3 py-2 text-white"
+        >
+          削除する
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            setConfirming(false)
+          }}
+          className="flex-1 rounded border border-brand px-3 py-2 text-slate-600"
+        >
+          やめる
+        </button>
+      </div>
     </div>
   )
 }

--- a/apps/web/src/index.ts
+++ b/apps/web/src/index.ts
@@ -34,7 +34,7 @@ import { z } from 'zod'
 import { createAuth } from './auth'
 import { requireOwnedItem, requireOwnedList, requireUser } from './authorization'
 import { createDb, type Db } from './db'
-import { items, lists, pool, wishTexts } from './db/schema'
+import { items, lists, pool, users, wishTexts } from './db/schema'
 import type { AppEnv } from './env'
 import { newId, newShareId } from './id'
 import { buildExportImagePayload, EXPORT_IMAGE_FILE_NAME, exportImageRequest } from './export-image'
@@ -631,6 +631,54 @@ const app = new Hono<AppEnv>()
     await createDb(c.env.DB)
       .delete(lists)
       .where(eq(lists.id, c.get('list').id))
+
+    return c.json({ deleted: true } as const)
+  })
+
+  /**
+   * アカウントを消す（#308）。**取り消せない。**
+   *
+   * 🔴 **自分のアカウントしか消せない。** `userId` を要求から受け取らず、
+   * **セッションから引く**（`requireUser`）。受け取る口を作らなければ、他人を消せない。
+   *
+   * 消えるもの:
+   *
+   * | | どうやって |
+   * |---|---|
+   * | `users` / `sessions` / `accounts` | `on delete cascade` |
+   * | `lists` → `items` | 同上（リスト1件の削除と同じ経路） |
+   * | `pool` | **作り直す**（下記） |
+   * | `wish_texts` | **参照されなくなった行を消す**（下記） |
+   *
+   * ⚠️ **セッションも消える**ので、この応答の後は同じ Cookie で何も通らない。
+   */
+  .delete('/api/account', requireUser, async (c) => {
+    const db = createDb(c.env.DB)
+
+    await db.delete(users).where(eq(users.id, c.get('userId')))
+
+    /*
+     * 🔴 **消し残る2つを片付ける。**
+     *
+     * `wish_texts` は**書かれたままの本文をキー**にしていて、誰が書いたかを持たない。
+     * アカウントを消しても**その人が書いた文章が残る**ので、
+     * **どこからも参照されなくなった行**を消す。
+     * ⚠️ 他の人が同じ本文を書いていれば残る（それはその人のもの）。
+     *
+     * `pool` はバッチが1時間ごとに作り直すので、放っておくと
+     * **「消したのに `/discover` に出ている」が最大1時間続く。** ここで作り直す。
+     *
+     * 🔴 **削除と同じトランザクションにしない。** ここが失敗しても
+     * **アカウントの削除は確定させる**（逆だと、消したはずのものが戻る）。
+     * 失敗しても次のバッチが直すので、記録だけ残して先へ進む。
+     */
+    try {
+      await db.run(sql`delete from wish_texts where raw_text not in (select text from items)`)
+      await rebuildPool(db)
+    } catch (error) {
+      Sentry.captureException(error)
+      console.error(`delete-account: 後片付けに失敗した: ${String(error)}`)
+    }
 
     return c.json({ deleted: true } as const)
   })

--- a/apps/web/test/delete-account.test.ts
+++ b/apps/web/test/delete-account.test.ts
@@ -1,0 +1,181 @@
+import { exports } from 'cloudflare:workers'
+import { eq } from 'drizzle-orm'
+import { describe, expect, it } from 'vitest'
+
+import { items, lists, users, wishTexts } from '../src/db/schema'
+import { signIn, testBaseUrl, testDb } from './helpers'
+import { makeList, runBatch } from './pool-helpers'
+
+/**
+ * アカウントの削除（#308）。**取り消せない操作なので、消える範囲を固定する。**
+ *
+ * 🔴 見るのは3つ。
+ *
+ * - **他人を消せないこと**（`userId` を受け取る口が無い）
+ * - **消し残らないこと。** cascade で消えないものが2つある（`pool` と `wish_texts`）
+ * - **消しすぎないこと。** 同じ本文を書いている別の人のものは残る
+ */
+
+const request = (path: string, init?: RequestInit) =>
+  exports.default.fetch(new Request(`${testBaseUrl()}${path}`, init))
+
+const deleteAccount = (headers?: Headers) =>
+  request('/api/account', {
+    method: 'DELETE',
+    ...(headers === undefined ? {} : { headers: Object.fromEntries(headers) }),
+  })
+
+const readPool = async () => {
+  const res = await request('/api/discover')
+  const body = await res.json<{ items: { text: string }[] }>()
+
+  return body.items.map((item) => item.text)
+}
+
+describe('DELETE /api/account', () => {
+  it('🔴 未ログインでは消せない', async () => {
+    expect((await deleteAccount()).status).toBe(401)
+  })
+
+  /**
+   * 🔴 **`userId` を受け取る口が無い**ので、他人を指定する方法が無い。
+   * ここで見ているのは「**指定しても自分が消えるだけ**」という形。
+   */
+  it('🔴 他人のアカウントは消せない（指定する口が無い）', async () => {
+    const me = await signIn('me@example.com')
+    const other = await signIn('other@example.com')
+
+    // 本文に他人の id を入れても、消えるのは自分だけ
+    const res = await request('/api/account', {
+      method: 'DELETE',
+      headers: { ...Object.fromEntries(me.headers), 'content-type': 'application/json' },
+      body: JSON.stringify({ userId: other.userId }),
+    })
+
+    expect(res.status).toBe(200)
+
+    const remaining = await testDb().select().from(users)
+    expect(remaining.map((row) => row.id)).toEqual([other.userId])
+  })
+
+  it('リストと項目も消える（cascade）', async () => {
+    const me = await signIn('me@example.com')
+    await testDb().insert(lists).values({ id: 'my-list', userId: me.userId, title: 'x' })
+    await testDb()
+      .insert(items)
+      .values({ id: 'i1', listId: 'my-list', text: '南極に行く', position: 0 })
+
+    expect((await deleteAccount(me.headers)).status).toBe(200)
+
+    expect(await testDb().select().from(lists)).toHaveLength(0)
+    expect(await testDb().select().from(items)).toHaveLength(0)
+  })
+
+  it('🔴 消した後、そのセッションでは何も通らない', async () => {
+    const me = await signIn('me@example.com')
+    await deleteAccount(me.headers)
+
+    const res = await request('/api/lists', { headers: Object.fromEntries(me.headers) })
+
+    expect(res.status).toBe(401)
+  })
+
+  it('共有 URL が開けなくなる', async () => {
+    const me = await signIn('me@example.com')
+    await testDb().insert(lists).values({
+      id: 'my-list',
+      userId: me.userId,
+      title: 'x',
+      shareId: 'sharedsharedshared01',
+      visibility: 'unlisted',
+    })
+
+    expect((await request('/share/sharedsharedshared01')).status).toBe(200)
+
+    await deleteAccount(me.headers)
+
+    expect((await request('/share/sharedsharedshared01')).status).toBe(404)
+  })
+
+  describe('消し残るものを片付ける', () => {
+    /**
+     * 🔴 **プールはバッチが1時間ごとに作り直す。**
+     * 放っておくと「消したのに `/discover` に出ている」が最大1時間続くので、
+     * 削除の直後に作り直している。
+     */
+    it('🔴 さがす画面から消える（最大1時間の残留を作らない）', async () => {
+      const me = await signIn('owner@example.com')
+      await makeList({
+        id: 'mine',
+        visibility: 'public',
+        texts: ['南極に行く'],
+        userId: me.userId,
+      })
+      await runBatch()
+
+      expect(await readPool()).toContain('南極に行く')
+
+      await deleteAccount(me.headers)
+
+      expect(await readPool()).not.toContain('南極に行く')
+    })
+
+    it('🔴 同じ本文を書いている人が残っていれば、さがす画面に残る', async () => {
+      const me = await signIn('owner@example.com')
+      await makeList({
+        id: 'mine',
+        visibility: 'public',
+        texts: ['南極に行く'],
+        userId: me.userId,
+      })
+      await makeList({ id: 'theirs', visibility: 'public', texts: ['南極に行く'] })
+      await runBatch()
+
+      await deleteAccount(me.headers)
+
+      expect(await readPool()).toContain('南極に行く')
+    })
+
+    /**
+     * 🔴 **判定のキャッシュは「書かれたままの本文」をキーにしていて、誰が書いたかを持たない。**
+     * 消さないと、**アカウントを消した人の文章がテーブルに残る。**
+     */
+    it('🔴 参照されなくなった判定のキャッシュを消す', async () => {
+      const me = await signIn('owner@example.com')
+      await makeList({
+        id: 'mine',
+        visibility: 'public',
+        texts: ['南極に行く'],
+        userId: me.userId,
+      })
+      await runBatch()
+
+      expect(await testDb().select().from(wishTexts)).not.toHaveLength(0)
+
+      await deleteAccount(me.headers)
+
+      expect(await testDb().select().from(wishTexts)).toHaveLength(0)
+    })
+
+    it('🔴 まだ誰かが書いている本文の判定は残す（消しすぎない）', async () => {
+      const me = await signIn('owner@example.com')
+      await makeList({
+        id: 'mine',
+        visibility: 'public',
+        texts: ['南極に行く'],
+        userId: me.userId,
+      })
+      await makeList({ id: 'theirs', visibility: 'public', texts: ['南極に行く'] })
+      await runBatch()
+
+      await deleteAccount(me.headers)
+
+      const remaining = await testDb()
+        .select()
+        .from(wishTexts)
+        .where(eq(wishTexts.rawText, '南極に行く'))
+
+      expect(remaining).toHaveLength(1)
+    })
+  })
+})


### PR DESCRIPTION
Closes #308

## やったこと

`DELETE /api/account` と、「すべてのリスト」の一番下の導線。

<img src="https://raw.githubusercontent.com/aiandrox/yaritai100list/previews/308-confirm.png" width="330">

## 🔴 cascade だけでは消え残るものが2つあった

| | cascade | どうしたか |
|---|---|---|
| `users` / `sessions` / `accounts` / `lists` → `items` | ✅ | そのまま |
| **`pool`（さがす画面）** | ❌ | **削除の直後に作り直す。** バッチは1時間ごとなので、放っておくと**「消したのに `/discover` に出ている」が最大1時間続く** |
| **`wish_texts`（判定のキャッシュ）** | ❌ | **参照されなくなった行を消す。** キーが「書かれたままの本文」で**誰が書いたかを持たない**ので、消さないと**その人の文章が残る** |

⚠️ **消しすぎない。** 他の人が同じ本文を書いていれば残す（それはその人のもの）。テストで固定した。

## 🔴 後片付けは削除と同じトランザクションにしない

**ここが失敗してもアカウントの削除は確定させる。** 逆にすると「消したはずのものが戻る」。
失敗しても次のバッチが直すので、Sentry とログに残して先へ進む。

**プールの作り直しでさがす画面が一瞬空になることはない。**
`db.batch()` は D1 で1トランザクションなので、**途中の状態は外から見えない**（#254 でそう作ってある）。

## 認可

🔴 **`userId` を要求から受け取らない。** セッションから引くので、**他人を指定する口が無い。**
本文に他人の `userId` を入れても自分が消えるだけ、というテストを置いた。

## テスト

676 件中 676 件が緑（29 ファイル。+9）。typecheck / lint / format:check も緑。

**効くことを確かめた**（後片付けを外すと落ちる）:

```
× 🔴 さがす画面から消える（最大1時間の残留を作らない）
× 🔴 参照されなくなった判定のキャッシュを消す
```

## 確認したこと・していないこと

ローカルにセッションを差し込んで実物で通した。

| | 結果 |
|---|---|
| 2段階の確認 | 1段目は文言だけ。「削除する」「やめる」が出る |
| 「やめる」 | 元の表示に戻る |
| 「削除する」 | トップへ移り、**ログアウト状態**になっている |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
