### PR TITLE
利用規約とプライバシーポリシーを追加する（#304）

### DIFF
--- a/apps/web/src/client/App.tsx
+++ b/apps/web/src/client/App.tsx
@@ -6,7 +6,9 @@ import { ExportPage } from './ExportPage'
 import { Layout } from './Layout'
 import { ListPage } from './ListPage'
 import { ListsPage } from './ListsPage'
+import { PrivacyPage } from './PrivacyPage'
 import { SharePage } from './SharePage'
+import { TermsPage } from './TermsPage'
 import { Notice } from './Notice'
 import { signOutRequestInit, toSessionState, type SessionState } from './model'
 
@@ -104,6 +106,18 @@ export function App() {
 
         <Route path="/lists/:listId">
           {(params) => <ListPage session={session} listId={params.listId} />}
+        </Route>
+
+        {/*
+          規約とポリシー（#304）。**ログインの有無で出し分けない。**
+          読むのに何も要らない
+        */}
+        <Route path="/terms">
+          <TermsPage />
+        </Route>
+
+        <Route path="/privacy">
+          <PrivacyPage />
         </Route>
 
         <Route>

--- a/apps/web/src/client/Layout.tsx
+++ b/apps/web/src/client/Layout.tsx
@@ -58,7 +58,32 @@ export function Layout({
         </header>
 
         {children}
+
+        <SiteFooter />
       </div>
     </div>
+  )
+}
+
+/**
+ * フッター（#304）。**規約とポリシーへの入口。**
+ *
+ * 🔴 **共有ページ（`src/share.ts`）にも同じものを置く。** あちらは別実装なので、
+ * ここに足しただけでは出ない（`Layout` の冒頭のコメント）。
+ *
+ * ⚠️ **目立たせない。** 日常的に押すものではないので、
+ * 本文の邪魔をしない大きさと色にする。
+ */
+function SiteFooter() {
+  return (
+    <footer className="mt-16 border-t border-brand/40 pt-4 text-center text-xs text-slate-500">
+      <Link href="/terms" className="underline">
+        利用規約
+      </Link>
+      <span className="px-2">·</span>
+      <Link href="/privacy" className="underline">
+        プライバシーポリシー
+      </Link>
+    </footer>
   )
 }

--- a/apps/web/src/client/LegalPage.tsx
+++ b/apps/web/src/client/LegalPage.tsx
@@ -1,0 +1,75 @@
+import { LEGAL_EFFECTIVE_DATE } from '@yaritai100list/shared'
+
+/**
+ * 利用規約とプライバシーポリシーの枠（#304）。
+ *
+ * 🔴 **見た目を1箇所にまとめる。** 2つの長い文書を別々に組むと、
+ * 見出しの大きさや行間がすぐにずれる（`Modal.tsx` を切り出したのと同じ理由）。
+ *
+ * ⚠️ **ここは読ませる文書。** 画面の他の場所より**行間を広く**取っている。
+ * 100行の一覧とは目的が違う。
+ */
+
+/** 見出し。**節ごとに番号を振る**（「第4条の話」と指せるようにするため）。 */
+export function LegalHeading({ children }: { children: React.ReactNode }) {
+  return <h2 className="mt-8 text-base font-bold text-slate-900">{children}</h2>
+}
+
+/** 本文。 */
+export function LegalText({ children }: { children: React.ReactNode }) {
+  return <p className="mt-3 text-sm leading-7 text-slate-700">{children}</p>
+}
+
+/** 箇条書き。 */
+export function LegalList({ children }: { children: React.ReactNode }) {
+  return (
+    <ul className="mt-3 list-disc space-y-2 pl-5 text-sm leading-7 text-slate-700">{children}</ul>
+  )
+}
+
+/**
+ * 「何が」「どこへ」を並べるところ（#304）。
+ *
+ * 🔴 **表にしない。** 3列の表は**電話の幅に収まらず、横スクロールになる。**
+ * 読ませる文書で横に流すのは筋が悪い（主対象はモバイル縦1カラム。`PRODUCT_SPEC.md` §4.5）。
+ * **1件ずつ縦に積む。**
+ *
+ * ⚠️ 広い画面では余白が増えるが、**読みにくくはならない。**
+ */
+export function LegalRecords({
+  items,
+}: {
+  items: { term: string; rows: { label: string; value: string }[] }[]
+}) {
+  return (
+    <div className="mt-3 space-y-3">
+      {items.map((item) => (
+        <div key={item.term} className="rounded bg-white px-3 py-3">
+          <p className="text-sm font-bold text-slate-900">{item.term}</p>
+
+          <dl className="mt-1 space-y-1">
+            {item.rows.map((row) => (
+              <div key={row.label} className="text-xs leading-6 text-slate-700">
+                <dt className="inline font-bold">{row.label}: </dt>
+                <dd className="inline">{row.value}</dd>
+              </div>
+            ))}
+          </dl>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export function LegalPage({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="pb-8">
+      <h1 className="text-xl font-bold text-slate-900">{title}</h1>
+
+      {children}
+
+      {/* 🔴 **いつからのものかを出す。**「掲載した時点から適用する」と書く以上、必須 */}
+      <p className="mt-10 text-xs text-slate-500">制定日: {LEGAL_EFFECTIVE_DATE}</p>
+    </div>
+  )
+}

--- a/apps/web/src/client/PrivacyPage.tsx
+++ b/apps/web/src/client/PrivacyPage.tsx
@@ -1,0 +1,246 @@
+import {
+  CONTACT_FORM_URL,
+  OPERATOR_HANDLE,
+  OPERATOR_NAME,
+  OPERATOR_URL,
+} from '@yaritai100list/shared'
+
+import { LegalHeading, LegalList, LegalPage, LegalRecords, LegalText } from './LegalPage'
+
+/**
+ * プライバシーポリシー（#304）。
+ *
+ * 🔴 **開示している内容は、実装から拾った実際の経路。**
+ * 雛形を埋めたものではない。**次を変えたらここも直す。**
+ *
+ * | 変えたら直すもの | いまの実装 |
+ * |---|---|
+ * | 判定に AI を使うのをやめた／別のものを足した | `src/pool-judge.ts` |
+ * | 画像生成の渡し先を変えた | `src/og.ts` / `src/export-image.ts` |
+ * | Sentry に送る内容を増やした | `src/sentry.ts` の `scrubEvent` |
+ * | 取得する項目を増やした | `src/db/schema/` |
+ *
+ * 🔴 **「誰に」はぼかしてよいが、「何が起きるか」はぼかさない**（2026-08-15 の判断）。
+ * 委託先の名前は求めに応じて開示する形にしているが、
+ * **自動で判定していること**と**第三者の閲覧で本文が外に出ること**は書く。
+ */
+export function PrivacyPage() {
+  return (
+    <LegalPage title="プライバシーポリシー">
+      <LegalText>
+        「やりたいことリスト100」（以下「本サービス」）における個人情報の取り扱いについて定めます。
+      </LegalText>
+
+      <LegalHeading>1. 運営者</LegalHeading>
+      <LegalText>
+        本サービスは {OPERATOR_NAME}（
+        <a
+          href={OPERATOR_URL}
+          target="_blank"
+          rel="noreferrer"
+          className="text-brand-deep underline"
+        >
+          {OPERATOR_HANDLE}
+        </a>
+        ）が個人で運営しています。
+      </LegalText>
+
+      <LegalHeading>2. 取得する情報</LegalHeading>
+      <LegalRecords
+        items={[
+          {
+            term: 'アカウント情報',
+            rows: [
+              {
+                label: '項目',
+                value: 'メールアドレス、表示名、プロフィール画像の URL、メールアドレスの確認状態',
+              },
+              {
+                label: '取得の方法',
+                value: 'Google アカウントによるログインの際に、Google から取得します',
+              },
+            ],
+          },
+          {
+            term: '認証情報',
+            rows: [
+              { label: '項目', value: '認証に用いるトークン、セッションの識別子' },
+              { label: '取得の方法', value: 'ログインの際に生成し、保存します' },
+            ],
+          },
+          {
+            term: '投稿内容',
+            rows: [
+              {
+                label: '項目',
+                value:
+                  'リストのタイトル、やりたいことの本文、メモ、達成日およびその記録の粒度、公開範囲の設定、項目ごとの表示設定',
+              },
+              { label: '取得の方法', value: '利用者の入力により取得します' },
+            ],
+          },
+          {
+            term: 'お問い合わせ',
+            rows: [
+              { label: '項目', value: '種別、内容、返信先として記入された連絡先' },
+              { label: '取得の方法', value: 'お問い合わせフォームの送信により取得します' },
+            ],
+          },
+        ]}
+      />
+      <LegalText>
+        クッキーは、ログイン状態の保持にのみ使用します。
+        広告の配信およびアクセス解析のための計測は行っていません。
+      </LegalText>
+
+      <LegalHeading>3. 利用目的</LegalHeading>
+      <LegalList>
+        <li>本サービスの提供（リストの保存・表示・共有、画像の生成）</li>
+        <li>不具合の把握と対応</li>
+        <li>お問い合わせへの回答</li>
+      </LegalList>
+
+      <LegalHeading>4. 第三者提供および委託</LegalHeading>
+      <LegalText>
+        法令に基づく場合を除き、あらかじめ本人の同意を得ることなく、
+        個人情報を第三者に提供することはありません。
+      </LegalText>
+      <LegalText>
+        本サービスの提供に必要な範囲で、外国にある事業者に個人情報の取り扱いを委託しています。
+        委託の内容は次のとおりです。
+      </LegalText>
+      <LegalRecords
+        items={[
+          {
+            term: '実行環境およびデータベースの提供',
+            rows: [{ label: '対象となる情報', value: '保存しているすべての情報' }],
+          },
+          {
+            term: '公開の可否の判定および表記の統一（自動処理）',
+            rows: [
+              {
+                label: '対象となる情報',
+                value: '「全体に公開」に設定されたリストの、やりたいことの本文',
+              },
+            ],
+          },
+          {
+            term: '画像の生成',
+            rows: [{ label: '対象となる情報', value: 'リストのタイトル、やりたいことの本文' }],
+          },
+          {
+            term: '認証',
+            rows: [{ label: '対象となる情報', value: 'アカウント情報および認証情報' }],
+          },
+          {
+            term: 'お問い合わせの受付と回答の保管',
+            rows: [{ label: '対象となる情報', value: 'お問い合わせの内容' }],
+          },
+          {
+            term: '不具合の把握',
+            rows: [
+              {
+                label: '対象となる情報',
+                value: '利用者を識別する ID、エラーが発生したページの URL',
+              },
+            ],
+          },
+        ]}
+      />
+      <LegalText>
+        委託先はいずれも米国に所在します。
+        <strong className="font-bold text-slate-900">
+          委託先の名称、当該国の個人情報の保護に関する制度、および委託先が講じている措置については、
+          お問い合わせ窓口までご請求ください。
+        </strong>
+      </LegalText>
+      <LegalList>
+        <li>
+          <strong className="font-bold text-slate-900">
+            公開の可否の判定は自動（AI）で行われます。
+          </strong>
+          人が内容を読んで判断しているわけではありません
+        </li>
+        <li>
+          <strong className="font-bold text-slate-900">
+            画像の生成は、共有ページが第三者により閲覧された際にも行われます。
+          </strong>
+          利用者自身が操作していない場合でも、その時点で対象の情報が送信されます
+        </li>
+        <li>
+          不具合の把握のために送信する情報には、入力された内容・クッキー・通信の内容を含めていません
+        </li>
+      </LegalList>
+
+      <LegalHeading>5. 公開される情報</LegalHeading>
+      <LegalList>
+        <li>
+          <strong className="font-bold text-slate-900">
+            どの公開面にも、書いた人の名前・メールアドレスは表示しません
+          </strong>
+        </li>
+        <li>
+          「リンクを知っている人だけ」「全体に公開」にしたリストは、URL を知っている人が見られます
+        </li>
+        <li>「全体に公開」にしたリストの項目は、作者を伏せた形で「さがす」に並びます</li>
+        <li>
+          <strong className="font-bold text-slate-900">メモは、どの公開面にも表示しません。</strong>
+          自分だけが読むものとして扱います
+        </li>
+      </LegalList>
+
+      <LegalHeading>6. 安全管理措置</LegalHeading>
+      <LegalText>
+        通信は暗号化しています。データベースへのアクセスは、
+        本サービスのプログラムからのみ行える構成としています。
+      </LegalText>
+
+      <LegalHeading>7. 保存期間と削除</LegalHeading>
+      <LegalList>
+        <li>
+          アカウントを削除すると、リスト・やりたいこと・メモ・ログイン情報は
+          <strong className="font-bold text-slate-900">すべて消えます</strong>
+        </li>
+        <li>削除は、ログイン後の「すべてのリスト」からいつでも行えます</li>
+        <li>
+          「さがす」のために保持している判定結果のうち、削除後にどこからも参照されなくなったものは、
+          あわせて消えます
+        </li>
+      </LegalList>
+
+      <LegalHeading>8. 開示・訂正・利用停止の請求</LegalHeading>
+      <LegalText>
+        保有する個人情報の開示・訂正・削除・利用停止をご希望の場合は、
+        <ContactLink />
+        からご連絡ください。本人確認のうえ、法令に従って対応します。
+      </LegalText>
+
+      <LegalHeading>9. お問い合わせ</LegalHeading>
+      <LegalText>
+        本ポリシーおよび個人情報の取り扱いに関するお問い合わせは、
+        <ContactLink />
+        までお願いします。
+      </LegalText>
+
+      <LegalHeading>10. 変更</LegalHeading>
+      <LegalText>
+        必要に応じて本ポリシーを変更することがあります。
+        変更後の内容は、このページに掲載した時点から適用されます。
+      </LegalText>
+    </LegalPage>
+  )
+}
+
+/** 問い合わせ窓口。**URL は `service.ts` の1箇所。** */
+function ContactLink() {
+  return (
+    <a
+      href={CONTACT_FORM_URL}
+      target="_blank"
+      rel="noreferrer"
+      className="font-bold text-brand-deep underline"
+    >
+      お問い合わせフォーム
+    </a>
+  )
+}

--- a/apps/web/src/client/TermsPage.tsx
+++ b/apps/web/src/client/TermsPage.tsx
@@ -1,0 +1,159 @@
+import {
+  CONTACT_FORM_URL,
+  OPERATOR_HANDLE,
+  OPERATOR_NAME,
+  OPERATOR_URL,
+} from '@yaritai100list/shared'
+
+import { LegalHeading, LegalList, LegalPage, LegalText } from './LegalPage'
+
+/**
+ * 利用規約（#304）。
+ *
+ * 🔴 **書いてあることは実装と一致していること。**
+ * 「取り入れられたものは戻らない」「判定は自動」は、**このアプリが実際にそうなっている**
+ * から書いている（`PRODUCT_SPEC.md` §5.4 / #253）。
+ * **仕様を変えたらここも直す。**
+ *
+ * ⚠️ **免責（第7条）は消費者契約法8条に触れる。**
+ * 「一切の責任を負わない」と書くと**無効になりうる**ので、
+ * 故意・重過失を除く形にしてある。**軽くしようとして書き換えないこと。**
+ */
+export function TermsPage() {
+  return (
+    <LegalPage title="利用規約">
+      <LegalText>
+        この規約は「やりたいことリスト100」（以下「本サービス」）の利用条件を定めるものです。
+        本サービスを利用した時点で、この規約に同意したものとみなします。
+      </LegalText>
+
+      <LegalHeading>1. 運営者</LegalHeading>
+      <LegalText>
+        本サービスは {OPERATOR_NAME}（
+        <a
+          href={OPERATOR_URL}
+          target="_blank"
+          rel="noreferrer"
+          className="text-brand-deep underline"
+        >
+          {OPERATOR_HANDLE}
+        </a>
+        ）が個人で運営しています。無償で提供しています。
+      </LegalText>
+
+      <LegalHeading>2. アカウント</LegalHeading>
+      <LegalList>
+        <li>
+          Google アカウントでログインして利用できます。
+          <strong className="font-bold text-slate-900">
+            ログインしなくても、書くことはできます。
+          </strong>
+        </li>
+        <li>
+          アカウントは「すべてのリスト」からいつでも削除できます。削除すると、書いた内容はすべて消え、
+          <strong className="font-bold text-slate-900">元に戻せません。</strong>
+        </li>
+      </LegalList>
+
+      <LegalHeading>3. 投稿内容の扱い</LegalHeading>
+      <LegalText>
+        この規約において「投稿内容」とは、利用者が本サービスに入力した情報
+        （リストのタイトル、やりたいことの本文、メモ、達成日およびその記録の粒度、
+        公開範囲の設定、項目ごとの表示設定）をいいます。
+      </LegalText>
+      <LegalList>
+        <li>投稿内容の権利は、書いた本人のものです。運営者はこれを取得しません</li>
+        <li>運営者は、本サービスを提供・維持するために必要な範囲で、投稿内容を保存・表示します</li>
+        <li>
+          公開範囲は利用者が選べます。
+          <strong className="font-bold text-slate-900">
+            「全体に公開」にしたリストの項目は、作者を伏せた形で「さがす」に並び、
+            ほかの利用者が自分のリストに取り入れられます。
+          </strong>
+        </li>
+        <li>
+          <strong className="font-bold text-slate-900">
+            すでに取り入れられたものは、後から公開範囲を変えても戻りません。
+          </strong>
+        </li>
+      </LegalList>
+
+      <LegalHeading>4. 禁止事項</LegalHeading>
+      <LegalText>次の内容を書いたり、送信したりしないでください。</LegalText>
+      <LegalList>
+        <li>法令に違反するもの、犯罪を助長するもの</li>
+        <li>他人の権利（著作権・プライバシー・名誉など）を侵害するもの</li>
+        <li>本人の同意なく、特定の個人が分かる情報を含むもの</li>
+        <li>差別的なもの、わいせつなもの、他人を著しく不快にさせるもの</li>
+        <li>広告・勧誘を目的とするもの</li>
+        <li>本サービスの運営を妨げる行為（過度な自動アクセスなど）</li>
+      </LegalList>
+
+      <LegalHeading>5. 内容の削除</LegalHeading>
+      <LegalText>
+        運営者は、前条に反すると判断した内容を、事前の通知なく削除できます。
+        繰り返す場合はアカウントの利用を停止できます。
+      </LegalText>
+      <LegalText>
+        <strong className="font-bold text-slate-900">判断の一部は自動（AI）で行っています。</strong>
+        「さがす」に出す内容は、掲載してよいかを自動で判定していますが、完全ではありません。
+        問題のある内容を見つけた場合は、
+        <ContactLink />
+        からお知らせください。
+      </LegalText>
+
+      <LegalHeading>6. サービスの変更・終了</LegalHeading>
+      <LegalText>
+        運営者は、本サービスの内容を変更したり、提供を終了したりできます。
+        終了する場合は、可能な限り事前にお知らせします。
+      </LegalText>
+      <LegalText>
+        <strong className="font-bold text-slate-900">
+          個人が無償で運営しているため、予告なく利用できなくなる可能性があります。
+        </strong>
+        大切な内容は「書き出す」から手元に保存してください。
+      </LegalText>
+
+      <LegalHeading>7. 免責</LegalHeading>
+      <LegalList>
+        <li>
+          運営者は、本サービスが
+          <strong className="font-bold text-slate-900">
+            常に利用できること、不具合がないこと、利用者の目的に適合すること
+          </strong>
+          を保証しません
+        </li>
+        <li>
+          本サービスの利用によって生じた損害について、運営者は責任を負いません。
+          <strong className="font-bold text-slate-900">
+            ただし、運営者に故意または重大な過失がある場合を除きます。
+          </strong>
+        </li>
+        <li>通信の障害や不具合により、投稿内容が失われることがあります</li>
+      </LegalList>
+
+      <LegalHeading>8. 規約の変更</LegalHeading>
+      <LegalText>
+        必要に応じてこの規約を変更することがあります。
+        変更後の規約は、このページに掲載した時点から適用されます。
+      </LegalText>
+
+      <LegalHeading>9. 準拠法</LegalHeading>
+      <LegalText>この規約は日本法に準拠します。</LegalText>
+    </LegalPage>
+  )
+}
+
+/** 問い合わせ窓口。**URL は `service.ts` の1箇所。** */
+function ContactLink() {
+  return (
+    <a
+      href={CONTACT_FORM_URL}
+      target="_blank"
+      rel="noreferrer"
+      className="font-bold text-brand-deep underline"
+    >
+      お問い合わせフォーム
+    </a>
+  )
+}

--- a/apps/web/src/share.ts
+++ b/apps/web/src/share.ts
@@ -70,6 +70,11 @@ const PAGE_STYLE = `
   .date { color: var(--brand-deep); font-size: .65rem; font-variant-numeric: tabular-nums; }
 
   /* 下の導線（#225）。**人のリストの続きに見えないよう、はっきり離す** */
+  .site-footer {
+    margin-top: 4rem; padding-top: 1rem; border-top: 1px solid var(--brand);
+    text-align: center; font-size: .75rem; color: #64748b;
+  }
+  .site-footer a { color: inherit; }
   .invite { margin-top: 2.5rem; padding: 1.25rem 1rem; background: #fff; border-radius: .25rem; text-align: center; }
   .invite h2 { font-size: 1rem; margin: 0; }
   .invite p { font-size: .75rem; color: #475569; margin: .5rem 0 0; }
@@ -168,6 +173,17 @@ function layout(options: {
         <div class="page">
           <header><a href="/">${SERVICE_NAME}</a></header>
           <main>${options.body}</main>
+
+          <!--
+            フッター（#304）。🔴 SPA 側（src/client/Layout.tsx）にも同じものがある。
+            共有ページは別実装なので、片方だけ直すとここだけ規約に行けなくなる。
+            ⚠️ この中でバッククォートを使わないこと（テンプレートリテラルが閉じる）
+          -->
+          <footer class="site-footer">
+            <a href="/terms">利用規約</a>
+            <span> · </span>
+            <a href="/privacy">プライバシーポリシー</a>
+          </footer>
         </div>
       </body>
     </html>`

--- a/apps/web/test/share-page.test.ts
+++ b/apps/web/test/share-page.test.ts
@@ -270,6 +270,20 @@ describe('公開されているリスト', () => {
     expect(await res.text()).toContain('0 / 0 達成')
   })
 
+  /**
+   * 🔴 **共有ページは SPA と別実装**（`src/share.ts`）。
+   * SPA 側のフッターを足しただけでは出ないので、**ここだけ規約に行けない**状態が作れる。
+   */
+  it('🔴 フッターから規約とポリシーに行ける（共有ページは別実装）', async () => {
+    const list = await createList({ visibility: 'unlisted' })
+    await addItems(list.id, [{ text: '南極に行く' }])
+
+    const body = await (await request(`/share/${list.shareId}`)).text()
+
+    expect(body).toContain('href="/terms"')
+    expect(body).toContain('href="/privacy"')
+  })
+
   describe('自分のリストを作る導線（#225）', () => {
     it('下にトップへのリンクが出る', async () => {
       const list = await createList({ visibility: 'unlisted' })

--- a/packages/shared/src/service.ts
+++ b/packages/shared/src/service.ts
@@ -30,6 +30,36 @@ export const SERVICE_NAME = 'やりたいことリスト100'
 export const SERVICE_URL = 'yaritai100list.aiandrox.workers.dev'
 
 /**
+ * 運営者（#304）。**利用規約とプライバシーポリシーに出す。**
+ *
+ * 🔴 **本名と住所は出さない**（2026-08-15 の判断）。無償の個人サービスで取引が無いため、
+ * 特定商取引法の表記義務（氏名・住所）はかからない。
+ * 連絡は問い合わせフォーム（`CONTACT_FORM_URL`）で受ける。
+ */
+export const OPERATOR_NAME = 'END'
+export const OPERATOR_HANDLE = '@aiandrox'
+export const OPERATOR_URL = 'https://x.com/aiandrox'
+
+/**
+ * 問い合わせ窓口（#304）。**Google フォーム。**
+ *
+ * 🔴 **埋め込まずにリンクにする**（2026-08-15 の判断）。iframe は
+ * **高さが自動で合わず**、モバイルで二重スクロールになる（主対象がモバイル縦1カラム）。
+ *
+ * ⚠️ **ここを唯一の情報源にする。** 画面に URL を直書きしない。
+ * フォームを作り直したら、この1行だけ差し替える。
+ */
+export const CONTACT_FORM_URL = 'https://forms.gle/B4ZPTdQife4LfHJt5'
+
+/**
+ * 規約・ポリシーの制定日（#304）。**画面に出す。**
+ *
+ * ⚠️ **中身を変えたら日付も変える。** 変えた事実が利用者から見えないと、
+ * 「掲載した時点から適用する」と書いてある意味が無い。
+ */
+export const LEGAL_EFFECTIVE_DATE = '2026年8月21日'
+
+/**
  * サービスを一言で言ったもの。**OGP 画像に載せる**（#229）。
  *
  * 🔴 **利用者が書いた文をそのまま使う**（2026-08-09）。**言い換えない。**


### PR DESCRIPTION
Closes #304

## やったこと

`/terms` と `/privacy` を追加し、**SPA と共有ページの両方**にフッターを置いた。

| フッター | 利用規約 | プライバシーポリシー |
|---|---|---|
| <img src="https://raw.githubusercontent.com/aiandrox/yaritai100list/previews/304-footer.png" width="240"> | <img src="https://raw.githubusercontent.com/aiandrox/yaritai100list/previews/304-terms.png" width="240"> | <img src="https://raw.githubusercontent.com/aiandrox/yaritai100list/previews/304-privacy.png" width="240"> |

## なぜ要るか

- 🔴 **Google の同意画面を「外部 / 公開」にしてある**（`docs/console-settings.md`）。
  OAuth のポリシーはプライバシーポリシーの提示を求める。**一番はっきりした外部要件**
- 氏名とメールを保存している（利用目的の公表）
- **全公開リストの項目は不特定多数に流通する。** 規約が無いと**不適切な投稿を消す根拠が無い**

## 🔴 開示している内容は、コードから拾った実際の経路

雛形を埋めたものではない。**利用者から見えない受け渡しが3つあった**ので、そこを書いた。

| 書いたこと | 実装 |
|---|---|
| 公開の可否の判定は**自動（AI）** | `src/pool-judge.ts` |
| **画像の生成は、第三者が共有ページを開いたときにも走る** | `src/og.ts` |
| 不具合の把握に送るのは ID と URL だけ | `src/sentry.ts` の `scrubEvent` |

⚠️ **仕様を変えたらここも直す。** どこを見ればよいかは `PrivacyPage.tsx` の冒頭に表で書いてある。

## 判断したこと（利用者との相談の結果）

- **運営者は END（@aiandrox）。** 本名と住所は出さない（無償・取引無しなので特商法の表記義務は無い）
- **委託先の名前はぼかす。** 一般的な消費者向けサービスに合わせた。
  **国名（米国）と、求めに応じて開示することを明記**（法28条3項の枠組み）
- 🔴 **ただし「何が起きるか」はぼかさない。** 上の3点は事業者名と関係なく書く
- **問い合わせは Google フォーム。** 埋め込みではなくリンク
  （iframe は高さが合わず、モバイルで二重スクロールになる）
- **管轄裁判所の条項は入れていない。** 書くと裁判所名から居住地が推測される。
  無くても法定管轄で決まる

## 踏んだこと

- **共有ページのテンプレートは1つの大きなテンプレートリテラル。**
  HTML コメントに ``` ` ``` を書いたら**文字列がそこで閉じて構文エラー**になった。
  同じことをしないよう、コメントに注意書きを残した
- **3列の表は電話の幅に収まらず横スクロールになった。**
  読ませる文書で横に流すのは筋が悪いので、**1件ずつ縦に積む形**に変えた（`LegalRecords`）

## テスト

677 件中 677 件が緑（29 ファイル。+1）。typecheck / lint / format:check も緑。

足したのは1つ:

- 🔴 **共有ページのフッターから規約に行ける。**
  共有ページは SPA と別実装なので、**片方だけ直すとここだけ規約に行けなくなる**

## 🔴 確認をお願いしたいこと

**私は法律の専門家ではありません。** 特に次の2点は人の目を入れてください。

1. **利用規約 第7条（免責）。** 「一切の責任を負わない」は消費者契約法8条で無効になりうるため、
   **故意・重過失を除く形**にしてある。実際に有効かは判断が要る
2. **外国にある第三者への提供**（法28条）。委託先が基準適合体制を備えていることに乗った書き方をしている

🤖 Generated with [Claude Code](https://claude.com/claude-code)
