### PR TITLE
規約とポリシーに同意してもらう（#319）

### DIFF
--- a/apps/web/migrations/0018_add_agreements.sql
+++ b/apps/web/migrations/0018_add_agreements.sql
@@ -1,0 +1,9 @@
+CREATE TABLE `agreements` (
+	`id` text PRIMARY KEY NOT NULL,
+	`user_id` text NOT NULL,
+	`effective_on` text NOT NULL,
+	`agreed_at` integer DEFAULT (unixepoch('subsec') * 1000) NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `agreements_user_id_effective_on_idx` ON `agreements` (`user_id`,`effective_on`);

--- a/apps/web/migrations/meta/0018_snapshot.json
+++ b/apps/web/migrations/meta/0018_snapshot.json
@@ -1,0 +1,717 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "ef96c7d4-8254-4b11-8575-e056d4356a66",
+  "prevId": "916564a5-c460-4c51-ae25-cce0dba74caf",
+  "tables": {
+    "agreements": {
+      "name": "agreements",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "effective_on": {
+          "name": "effective_on",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agreed_at": {
+          "name": "agreed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('subsec') * 1000)"
+        }
+      },
+      "indexes": {
+        "agreements_user_id_effective_on_idx": {
+          "name": "agreements_user_id_effective_on_idx",
+          "columns": [
+            "user_id",
+            "effective_on"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "agreements_user_id_users_id_fk": {
+          "name": "agreements_user_id_users_id_fk",
+          "tableFrom": "agreements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "accounts": {
+      "name": "accounts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verifications": {
+      "name": "verifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "items": {
+      "name": "items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "list_id": {
+          "name": "list_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "memo": {
+          "name": "memo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_precision": {
+          "name": "completed_precision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hidden_in_share": {
+          "name": "hidden_in_share",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('subsec') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('subsec') * 1000)"
+        }
+      },
+      "indexes": {
+        "items_list_id_position_idx": {
+          "name": "items_list_id_position_idx",
+          "columns": [
+            "list_id",
+            "position"
+          ],
+          "isUnique": false
+        },
+        "items_text_idx": {
+          "name": "items_text_idx",
+          "columns": [
+            "text"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "items_list_id_lists_id_fk": {
+          "name": "items_list_id_lists_id_fk",
+          "tableFrom": "items",
+          "tableTo": "lists",
+          "columnsFrom": [
+            "list_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "items_position_check": {
+          "name": "items_position_check",
+          "value": "\"items\".\"position\" >= 0"
+        }
+      }
+    },
+    "lists": {
+      "name": "lists",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "share_id": {
+          "name": "share_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'private'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('subsec') * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('subsec') * 1000)"
+        }
+      },
+      "indexes": {
+        "lists_share_id_unique": {
+          "name": "lists_share_id_unique",
+          "columns": [
+            "share_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "lists_user_id_users_id_fk": {
+          "name": "lists_user_id_users_id_fk",
+          "tableFrom": "lists",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "lists_visibility_check": {
+          "name": "lists_visibility_check",
+          "value": "\"lists\".\"visibility\" in ('private', 'unlisted', 'public')"
+        }
+      }
+    },
+    "pool": {
+      "name": "pool",
+      "columns": {
+        "canonical": {
+          "name": "canonical",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "genre": {
+          "name": "genre",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "writers": {
+          "name": "writers",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pool_writers_idx": {
+          "name": "pool_writers_idx",
+          "columns": [
+            "writers"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "wish_texts": {
+      "name": "wish_texts",
+      "columns": {
+        "raw_text": {
+          "name": "raw_text",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "canonical": {
+          "name": "canonical",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "genre": {
+          "name": "genre",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompt_version": {
+          "name": "prompt_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch('subsec') * 1000)"
+        }
+      },
+      "indexes": {
+        "wish_texts_canonical_idx": {
+          "name": "wish_texts_canonical_idx",
+          "columns": [
+            "canonical"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/apps/web/migrations/meta/_journal.json
+++ b/apps/web/migrations/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1786749395379,
       "tag": "0017_add_items_memo",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "6",
+      "when": 1788226684365,
+      "tag": "0018_add_agreements",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/src/client/AgreementGate.tsx
+++ b/apps/web/src/client/AgreementGate.tsx
@@ -1,0 +1,101 @@
+import { useState } from 'react'
+import { Link } from 'wouter'
+
+/**
+ * 規約とポリシーの確認（#319）。**同意の記録が無い人にだけ出す。**
+ *
+ * 🔴 **全文を出さない。** 出しても読まれない。
+ * **知らずに使うと困ることだけ**を並べて、全文はリンクにする。
+ * 一番効くのは「**全体に公開すると、他の人に取り入れられる**」。
+ *
+ * 🔴 **「同意しない」の出口を必ず置く。** ログアウトしてトップへ戻る。
+ * **このアプリは未ログインでも書ける**ので、断っても何も失わない。
+ *
+ * ⚠️ **これは認可の仕組みではない。** 押させるための画面であって、
+ * API を守るものではない（守るのは `requireUser` と `requireOwnedList`）。
+ */
+export function AgreementGate({
+  onAgree,
+  onDecline,
+}: {
+  onAgree: () => Promise<void>
+  onDecline: () => void
+}) {
+  const [sending, setSending] = useState(false)
+  const [failed, setFailed] = useState(false)
+
+  const agree = () => {
+    setSending(true)
+    setFailed(false)
+
+    void onAgree()
+      .catch(() => {
+        setFailed(true)
+      })
+      .finally(() => {
+        setSending(false)
+      })
+  }
+
+  return (
+    <div className="mx-auto max-w-md rounded-lg bg-white px-5 py-6">
+      <h1 className="text-lg font-bold text-slate-900">はじめる前に</h1>
+
+      <p className="mt-3 text-sm leading-6 text-slate-600">
+        利用規約とプライバシーポリシーを用意しました。要点は次の3つです。
+      </p>
+
+      <ul className="mt-4 flex flex-col gap-2">
+        <Point>書いたものは、あなたのものです</Point>
+        <Point>
+          <strong className="font-bold text-slate-900">「全体に公開」にしたやりたいこと</strong>
+          は、作者を伏せた形で「さがす」に並び、ほかの人が自分のリストに取り入れられます
+        </Point>
+        <Point>アカウントはいつでも削除できます。書いたものもすべて消えます</Point>
+      </ul>
+
+      <p className="mt-4 text-sm leading-6 text-slate-600">
+        全文は
+        <Link href="/terms" className="font-bold text-brand-deep underline">
+          利用規約
+        </Link>
+        と
+        <Link href="/privacy" className="font-bold text-brand-deep underline">
+          プライバシーポリシー
+        </Link>
+        をご覧ください。
+      </p>
+
+      {failed && (
+        <p role="alert" className="mt-3 text-sm text-brand-deep">
+          記録できませんでした。通信を確かめて、もう一度お試しください
+        </p>
+      )}
+
+      <button
+        type="button"
+        disabled={sending}
+        onClick={agree}
+        className="mt-5 w-full rounded-lg bg-brand-deep px-3 py-3 font-bold text-white disabled:opacity-50"
+      >
+        同意して始める
+      </button>
+
+      {/*
+        断る側。**主のボタンと同じ強さにしない**（`ModalDecline` と同じ考え方）。
+        押すとログアウトするので、**何が起きるかを言葉にしておく**
+      */}
+      <button type="button" onClick={onDecline} className="mt-3 w-full py-2 text-sm text-slate-500">
+        同意しない（ログアウトする）
+      </button>
+    </div>
+  )
+}
+
+function Point({ children }: { children: React.ReactNode }) {
+  return (
+    <li className="rounded-lg bg-brand-soft px-3 py-3 text-sm leading-6 text-slate-700">
+      {children}
+    </li>
+  )
+}

--- a/apps/web/src/client/App.tsx
+++ b/apps/web/src/client/App.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useState } from 'react'
 import { Link, Route, Switch, useLocation } from 'wouter'
 
+import { AgreementGate } from './AgreementGate'
+import { api } from './api'
 import { DiscoverPage } from './DiscoverPage'
 import { ExportPage } from './ExportPage'
 import { Layout } from './Layout'
@@ -21,8 +23,17 @@ import { signOutRequestInit, toSessionState, type SessionState } from './model'
  * `not_found_handling: single-page-application` が index.html を返すので、
  * **`/lists/xxx` を直接開いてもこの SPA が起動する。**
  */
+/**
+ * 同意の確認より先に開けるページ（#319）。
+ *
+ * 🔴 **規約とポリシーを塞がない。** ここを通さないと、
+ * **確認画面から全文を読みに行けない**（読ませるための画面なのに読めない）。
+ * 実際に一度そうなった。
+ */
+const LEGAL_PATHS = new Set(['/terms', '/privacy'])
+
 export function App() {
-  const [, navigate] = useLocation()
+  const [location, navigate] = useLocation()
   const [session, setSession] = useState<SessionState>({ status: 'loading' })
   const [signOutFailed, setSignOutFailed] = useState(false)
 
@@ -47,6 +58,46 @@ export function App() {
     void loadSession()
   }, [loadSession])
 
+  // --- 規約への同意（#319） ---
+
+  /**
+   * 同意が済んでいるか。**ログイン中のときだけ聞く。**
+   *
+   * 🔴 **確かめられなかったときは通す**（`agreed` のまま）。
+   * これは押させるための画面であって**認可ではない**ので、
+   * 通信の不調でリストが開けなくなる方が害が大きい。
+   */
+  const [agreement, setAgreement] = useState<'unknown' | 'agreed' | 'required'>('unknown')
+
+  useEffect(() => {
+    if (session.status !== 'authenticated') {
+      setAgreement('unknown')
+      return
+    }
+
+    void (async () => {
+      try {
+        const res = await api.api.account.$get()
+        if (!res.ok) {
+          setAgreement('agreed')
+          return
+        }
+
+        const body = await res.json()
+        setAgreement(body.agreed ? 'agreed' : 'required')
+      } catch {
+        setAgreement('agreed')
+      }
+    })()
+  }, [session.status])
+
+  const agree = useCallback(async () => {
+    const res = await api.api.account.agree.$post()
+    if (!res.ok) throw new Error('同意を記録できなかった')
+
+    setAgreement('agreed')
+  }, [])
+
   const signOut = useCallback(async () => {
     setSignOutFailed(false)
 
@@ -69,66 +120,81 @@ export function App() {
     <Layout showListsLink={session.status === 'authenticated'}>
       <SessionArea session={session} onRetry={() => void loadSession()} />
 
-      <Switch>
-        {/* トップは一覧ではなく**最後に更新したリスト**（PRODUCT_SPEC.md §4.3）。
+      {/*
+        規約の確認（#319）。**同意するまで先へ進ませない。**
+        ⚠️ **聞いている最中（`unknown`）は何も出さない。** 出すと、
+        同意が要る人に一瞬リストが見えてから画面が入れ替わる
+      */}
+      {session.status === 'authenticated' &&
+      agreement !== 'agreed' &&
+      !LEGAL_PATHS.has(location) ? (
+        agreement === 'required' ? (
+          <AgreementGate onAgree={agree} onDecline={() => void signOut()} />
+        ) : (
+          <p className="py-8 text-center text-slate-500">読み込み中</p>
+        )
+      ) : (
+        <Switch>
+          {/* トップは一覧ではなく**最後に更新したリスト**（PRODUCT_SPEC.md §4.3）。
             リストを1つしか持っていない人に無駄な1タップを作らない */}
-        <Route path="/">
-          <ListPage session={session} />
-        </Route>
+          <Route path="/">
+            <ListPage session={session} />
+          </Route>
 
-        {/*
+          {/*
           取り入れ面（#235 / 親 #10）。**ログインは要らない。**
           書き始める前の人こそ対象なので、ここで認証を求めない
         */}
-        <Route path="/discover">
-          <DiscoverPage session={session} />
-        </Route>
+          <Route path="/discover">
+            <DiscoverPage session={session} />
+          </Route>
 
-        <Route path="/lists">
-          {/* ログアウトはここに置く。日常的に押すものではないので、
+          <Route path="/lists">
+            {/* ログアウトはここに置く。日常的に押すものではないので、
               編集画面には出さない（#114） */}
-          <ListsPage
-            session={session}
-            signOutFailed={signOutFailed}
-            onSignOut={() => void signOut()}
-          />
-        </Route>
+            <ListsPage
+              session={session}
+              signOutFailed={signOutFailed}
+              onSignOut={() => void signOut()}
+            />
+          </Route>
 
-        {/* :listId より先に置かなくても段数が違うので当たらないが、
+          {/* :listId より先に置かなくても段数が違うので当たらないが、
             関係のある経路を近くに並べておく */}
-        <Route path="/lists/:listId/export">
-          {(params) => <ExportPage session={session} listId={params.listId} />}
-        </Route>
+          <Route path="/lists/:listId/export">
+            {(params) => <ExportPage session={session} listId={params.listId} />}
+          </Route>
 
-        <Route path="/lists/:listId/share">
-          {(params) => <SharePage session={session} listId={params.listId} />}
-        </Route>
+          <Route path="/lists/:listId/share">
+            {(params) => <SharePage session={session} listId={params.listId} />}
+          </Route>
 
-        <Route path="/lists/:listId">
-          {(params) => <ListPage session={session} listId={params.listId} />}
-        </Route>
+          <Route path="/lists/:listId">
+            {(params) => <ListPage session={session} listId={params.listId} />}
+          </Route>
 
-        {/*
+          {/*
           規約とポリシー（#304）。**ログインの有無で出し分けない。**
           読むのに何も要らない
         */}
-        <Route path="/terms">
-          <TermsPage />
-        </Route>
+          <Route path="/terms">
+            <TermsPage />
+          </Route>
 
-        <Route path="/privacy">
-          <PrivacyPage />
-        </Route>
+          <Route path="/privacy">
+            <PrivacyPage />
+          </Route>
 
-        <Route>
-          <Notice tone="warn">
-            このページはありません。
-            <Link href="/" className="underline">
-              トップへ戻る
-            </Link>
-          </Notice>
-        </Route>
-      </Switch>
+          <Route>
+            <Notice tone="warn">
+              このページはありません。
+              <Link href="/" className="underline">
+                トップへ戻る
+              </Link>
+            </Notice>
+          </Route>
+        </Switch>
+      )}
     </Layout>
   )
 }

--- a/apps/web/src/client/LegalPage.tsx
+++ b/apps/web/src/client/LegalPage.tsx
@@ -1,4 +1,4 @@
-import { LEGAL_EFFECTIVE_DATE } from '@yaritai100list/shared'
+import { formatLegalDate, LEGAL_EFFECTIVE_DATE } from '@yaritai100list/shared'
 
 /**
  * 利用規約とプライバシーポリシーの枠（#304）。
@@ -69,7 +69,9 @@ export function LegalPage({ title, children }: { title: string; children: React.
       {children}
 
       {/* 🔴 **いつからのものかを出す。**「掲載した時点から適用する」と書く以上、必須 */}
-      <p className="mt-10 text-xs text-slate-500">制定日: {LEGAL_EFFECTIVE_DATE}</p>
+      <p className="mt-10 text-xs text-slate-500">
+        制定日: {formatLegalDate(LEGAL_EFFECTIVE_DATE)}
+      </p>
     </div>
   )
 }

--- a/apps/web/src/client/PrivacyPage.tsx
+++ b/apps/web/src/client/PrivacyPage.tsx
@@ -80,6 +80,13 @@ export function PrivacyPage() {
             ],
           },
           {
+            term: '同意の記録',
+            rows: [
+              { label: '項目', value: '同意した規約の版と、同意した日時' },
+              { label: '取得の方法', value: '確認画面で「同意して始める」を押した際に記録します' },
+            ],
+          },
+          {
             term: 'お問い合わせ',
             rows: [
               { label: '項目', value: '種別、内容、返信先として記入された連絡先' },

--- a/apps/web/src/db/schema/agreements.ts
+++ b/apps/web/src/db/schema/agreements.ts
@@ -1,0 +1,51 @@
+import { sql } from 'drizzle-orm'
+import { index, integer, sqliteTable, text } from 'drizzle-orm/sqlite-core'
+
+import { users } from './auth'
+
+/**
+ * 規約とポリシーへの同意の記録（#319）。
+ *
+ * 🔴 **`users` の列にしない**（2026-09-01 の利用者の指示）。理由は2つ。
+ *
+ * - **版ごとに1行ずつ積む。** 規約を改定したときに、
+ *   **どの版にいつ同意したか**が全部残る。列だと最後の1つしか持てない
+ * - **`users` は Better Auth のアダプタが読み書きする表**（`auth.ts` の注意書き）。
+ *   こちらの都合で列を足さない
+ *
+ * ⚠️ **同意していないことは「行が無い」で表す。**
+ * 「同意しなかった」を記録しない（断った人はログアウトするので、次に来たらまた聞く）。
+ */
+export const agreements = sqliteTable(
+  'agreements',
+  {
+    /** 推測不可能な値。**連番にしない**（`CLAUDE.md` の不変条件）。 */
+    id: text('id').primaryKey(),
+
+    /**
+     * 同意した人。
+     *
+     * 🔴 **アカウントを消したら同意の記録も消える**（`on delete cascade`）。
+     * これも本人に紐づく情報なので、`lists` と同じ扱いにする（#308）。
+     */
+    userId: text('user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+
+    /**
+     * 同意した規約の版。**`LEGAL_EFFECTIVE_DATE`（ISO の日付）と同じ形。**
+     *
+     * 🔴 **突き合わせるので ISO で持つ。**「いまの版の行があるか」だけを見る
+     * （`2026年8月21日` のような表示用の文字列だと比べられない）。
+     */
+    effectiveOn: text('effective_on').notNull(),
+
+    agreedAt: integer('agreed_at', { mode: 'timestamp_ms' })
+      .notNull()
+      .default(sql`(unixepoch('subsec') * 1000)`),
+  },
+  (t) => [
+    // 引くのは必ず「この人が、この版に同意しているか」
+    index('agreements_user_id_effective_on_idx').on(t.userId, t.effectiveOn),
+  ],
+)

--- a/apps/web/src/db/schema/index.ts
+++ b/apps/web/src/db/schema/index.ts
@@ -5,6 +5,7 @@
  * `./src/db/schema/*.ts` を見るので、置き忘れてもマイグレーションには入るが、
  * アプリ側から import できなくなる。
  */
+export * from './agreements'
 export * from './auth'
 export * from './items'
 export * from './lists'

--- a/apps/web/src/index.ts
+++ b/apps/web/src/index.ts
@@ -16,6 +16,7 @@ import {
   isFutureCompletedAt,
   parseCompletedOn,
   ITEMS_PER_LIST_MAX,
+  LEGAL_EFFECTIVE_DATE,
   LISTS_PER_USER_MAX,
   SHARE_HIDDEN_ITEM_LABEL,
   SHARED_VISIBILITIES,
@@ -34,7 +35,7 @@ import { z } from 'zod'
 import { createAuth } from './auth'
 import { requireOwnedItem, requireOwnedList, requireUser } from './authorization'
 import { createDb, type Db } from './db'
-import { items, lists, pool, users, wishTexts } from './db/schema'
+import { agreements, items, lists, pool, users, wishTexts } from './db/schema'
 import type { AppEnv } from './env'
 import { newId, newShareId } from './id'
 import { buildExportImagePayload, EXPORT_IMAGE_FILE_NAME, exportImageRequest } from './export-image'
@@ -633,6 +634,53 @@ const app = new Hono<AppEnv>()
       .where(eq(lists.id, c.get('list').id))
 
     return c.json({ deleted: true } as const)
+  })
+
+  /**
+   * 同意が済んでいるか（#319）。**ログイン後に1回だけ聞く。**
+   *
+   * 🔴 **「いまの版の行があるか」で見る。** 規約を改定して
+   * `LEGAL_EFFECTIVE_DATE` を動かすと、**全員がまた未同意になる**（それが目的）。
+   */
+  .get('/api/account', requireUser, async (c) => {
+    const [agreed] = await createDb(c.env.DB)
+      .select({ id: agreements.id })
+      .from(agreements)
+      .where(
+        and(
+          eq(agreements.userId, c.get('userId')),
+          eq(agreements.effectiveOn, LEGAL_EFFECTIVE_DATE),
+        ),
+      )
+      .limit(1)
+
+    return c.json({ agreed: agreed !== undefined } as const)
+  })
+
+  /**
+   * 同意を記録する（#319）。
+   *
+   * 🔴 **どの版に同意したかはサーバーが決める。** 画面から版を受け取らない。
+   * 受け取ると、**古い版に同意したことにして確認画面を飛ばせる。**
+   *
+   * ⚠️ **2回押されても1行のまま。** 先に見てから入れる
+   * （**同意は数えるものではない**ので、行が増えても害は無いが、揃えておく）。
+   */
+  .post('/api/account/agree', requireUser, async (c) => {
+    const db = createDb(c.env.DB)
+    const userId = c.get('userId')
+
+    const [already] = await db
+      .select({ id: agreements.id })
+      .from(agreements)
+      .where(and(eq(agreements.userId, userId), eq(agreements.effectiveOn, LEGAL_EFFECTIVE_DATE)))
+      .limit(1)
+
+    if (already === undefined) {
+      await db.insert(agreements).values({ id: newId(), userId, effectiveOn: LEGAL_EFFECTIVE_DATE })
+    }
+
+    return c.json({ agreed: true } as const)
   })
 
   /**

--- a/apps/web/test/agreement-api.test.ts
+++ b/apps/web/test/agreement-api.test.ts
@@ -1,0 +1,123 @@
+import { exports } from 'cloudflare:workers'
+import { LEGAL_EFFECTIVE_DATE } from '@yaritai100list/shared'
+import { eq } from 'drizzle-orm'
+import { describe, expect, it } from 'vitest'
+
+import { agreements } from '../src/db/schema'
+import { signIn, testBaseUrl, testDb } from './helpers'
+
+/**
+ * 規約への同意（#319）。
+ *
+ * 🔴 見るのは3つ。
+ *
+ * - **記録が無ければ「要る」と返すこと**（これが確認画面を出す条件）
+ * - **同意した版をサーバーが決めること**（画面から受け取ると、古い版に同意したことにできる）
+ * - **アカウントを消したら記録も消えること**（本人に紐づく情報。#308 と同じ扱い）
+ */
+
+const request = (path: string, init?: RequestInit) =>
+  exports.default.fetch(new Request(`${testBaseUrl()}${path}`, init))
+
+const readAgreement = (headers?: Headers) =>
+  request(
+    '/api/account',
+    headers === undefined ? undefined : { headers: Object.fromEntries(headers) },
+  )
+
+const agree = (headers: Headers) =>
+  request('/api/account/agree', { method: 'POST', headers: Object.fromEntries(headers) })
+
+const rowsOf = (userId: string) =>
+  testDb().select().from(agreements).where(eq(agreements.userId, userId))
+
+describe('GET /api/account', () => {
+  it('🔴 未ログインでは聞けない', async () => {
+    expect((await readAgreement()).status).toBe(401)
+  })
+
+  /**
+   * 🔴 **既存の利用者にも出す**（2026-09-01 の利用者の判断）。
+   * マイグレーションで同意済みの行を入れていないので、**記録が無い人は全員ここを通る。**
+   */
+  it('🔴 記録が無ければ「同意が要る」と返す', async () => {
+    const me = await signIn('me@example.com')
+
+    const body = await (await readAgreement(me.headers)).json<{ agreed: boolean }>()
+
+    expect(body.agreed).toBe(false)
+  })
+
+  it('同意したあとは「済んでいる」と返す', async () => {
+    const me = await signIn('me@example.com')
+    await agree(me.headers)
+
+    const body = await (await readAgreement(me.headers)).json<{ agreed: boolean }>()
+
+    expect(body.agreed).toBe(true)
+  })
+
+  /**
+   * 🔴 **版が変わったら、また聞く。**
+   * 規約を改定して `LEGAL_EFFECTIVE_DATE` を動かしたときに、全員がもう一度通る仕組み。
+   */
+  it('🔴 別の版にしか同意していなければ、また聞く', async () => {
+    const me = await signIn('me@example.com')
+
+    await testDb()
+      .insert(agreements)
+      .values({ id: 'old', userId: me.userId, effectiveOn: '2020-01-01' })
+
+    const body = await (await readAgreement(me.headers)).json<{ agreed: boolean }>()
+
+    expect(body.agreed).toBe(false)
+  })
+})
+
+describe('POST /api/account/agree', () => {
+  it('🔴 未ログインでは記録できない', async () => {
+    const res = await request('/api/account/agree', { method: 'POST' })
+
+    expect(res.status).toBe(401)
+  })
+
+  it('🔴 いまの版で記録される（版はサーバーが決める）', async () => {
+    const me = await signIn('me@example.com')
+
+    expect((await agree(me.headers)).status).toBe(200)
+
+    const rows = await rowsOf(me.userId)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.effectiveOn).toBe(LEGAL_EFFECTIVE_DATE)
+  })
+
+  it('🔴 2回押しても1行のまま', async () => {
+    const me = await signIn('me@example.com')
+
+    await agree(me.headers)
+    await agree(me.headers)
+
+    expect(await rowsOf(me.userId)).toHaveLength(1)
+  })
+
+  it('🔴 他人の記録にはならない', async () => {
+    const me = await signIn('me@example.com')
+    const other = await signIn('other@example.com')
+
+    await agree(me.headers)
+
+    expect(await rowsOf(other.userId)).toHaveLength(0)
+  })
+
+  it('🔴 アカウントを消すと同意の記録も消える', async () => {
+    const me = await signIn('me@example.com')
+    await agree(me.headers)
+
+    await request('/api/account', {
+      method: 'DELETE',
+      headers: Object.fromEntries(me.headers),
+    })
+
+    expect(await testDb().select().from(agreements)).toHaveLength(0)
+  })
+})

--- a/packages/shared/src/service.ts
+++ b/packages/shared/src/service.ts
@@ -52,12 +52,30 @@ export const OPERATOR_URL = 'https://x.com/aiandrox'
 export const CONTACT_FORM_URL = 'https://forms.gle/B4ZPTdQife4LfHJt5'
 
 /**
- * 規約・ポリシーの制定日（#304）。**画面に出す。**
+ * 規約・ポリシーの版（#304 / #319）。**制定日そのものを版として使う。**
  *
- * ⚠️ **中身を変えたら日付も変える。** 変えた事実が利用者から見えないと、
- * 「掲載した時点から適用する」と書いてある意味が無い。
+ * 🔴 **ISO で持つ。** 同意の記録（`agreements.effective_on`）と突き合わせるので、
+ * **機械で比べられる形**でなければならない（#319）。
+ * 画面に出す文字列は `formatLegalDate` が作る。
+ * **表示用と判定用を別々に持たない**（2つあると必ずずれる）。
+ *
+ * ⚠️ **中身を変えたら日付も変える。** 変えると
+ * **同意の記録が古い版のものになり、全員にもう一度確認画面が出る。**
+ * それがこの仕組みの目的なので、**軽い直しで動かさないこと**
+ * （誤字の修正で全員に同意を求め直すのは筋が悪い）。
  */
-export const LEGAL_EFFECTIVE_DATE = '2026年8月21日'
+export const LEGAL_EFFECTIVE_DATE = '2026-08-21'
+
+/** `2026-08-21` → `2026年8月21日`。**画面に出すのはこちら。** */
+export function formatLegalDate(value: string): string {
+  const parsed = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value)
+  const [, year, month, day] = parsed ?? []
+
+  // 読めない形はそのまま返す。**黙って別の日付にしない**
+  if (year === undefined || month === undefined || day === undefined) return value
+
+  return `${year}年${String(Number(month))}月${String(Number(day))}日`
+}
 
 /**
  * サービスを一言で言ったもの。**OGP 画像に載せる**（#229）。


### PR DESCRIPTION
Closes #319

## やったこと

**同意の記録が無い人**に確認画面を出す。押すまで先へ進ませない。

<img src="https://raw.githubusercontent.com/aiandrox/yaritai100list/previews/319-gate.png" width="330">

## 🔴 同意は履歴テーブルで持つ

`users` に列を足すのではなく、`agreements` 表に**版ごとに1行ずつ積む**。

| なぜ | |
|---|---|
| 版ごとに残る | 規約を改定したときに、**どの版にいつ同意したか**が全部残る |
| Better Auth の表を触らない | `users` はアダプタが読み書きする表 |

**規約を改定して `LEGAL_EFFECTIVE_DATE` を動かすと、全員がまた未同意になる。** それが目的。
⚠️ 裏を返すと、**誤字の修正で動かすと全員に聞き直す**ことになる。定数のコメントに書いた。

## 🔴 既存の利用者にも一度見せる

**マイグレーションで同意済みの行を入れていない**（2026-09-01 の判断）。
規約もポリシーもこれが初版で、**既に使っている人もまだ読んでいない**ため。

⚠️ **本番に出ると、次に開いた全員に確認画面が出る。** 想定どおりの動き。

## 制定日を ISO にした

`'2026年8月21日'` は**機械で比べられない**。同意の記録と突き合わせるので `'2026-08-21'` にし、
**表示は `formatLegalDate` が作る。** 表示用と判定用を別々に持たない。

## 踏んだこと

🔴 **確認画面から規約を読みに行けなかった。**
ゲートで `<Switch>` ごと覆ったので、`/terms` と `/privacy` まで塞いでいた。
**読ませるための画面なのに読めない。** 実物で辿って気づいた（`LEGAL_PATHS` で通す）。

```
直す前: 「利用規約」を押す → h1 は「はじめる前に」のまま
直した後: 「利用規約」を押す → h1 が「利用規約」
```

## 判断したこと

- **確かめられなかったときは通す**（ゲートを出さない）。これは**認可ではない**ので、
  通信の不調でリストが開けなくなる方が害が大きい。守るのは `requireUser` 側
- 🔴 **同意した版はサーバーが決める。** 画面から受け取ると、
  **古い版に同意したことにして確認画面を飛ばせる**
- **聞いている最中は何も出さない。** 出すと、同意が要る人に一瞬リストが見えてから入れ替わる
- ⚠️ **プライバシーポリシーの「取得する情報」に同意の記録を足した**（新しく持つ情報なので）

## テスト

686 件中 686 件が緑（30 ファイル。+9）。typecheck / lint / format:check も緑。

- 記録が無ければ「要る」／同意後は「済んでいる」
- 🔴 **別の版にしか同意していなければ、また聞く**
- 🔴 **版はサーバーが決める**（いまの版で記録される）
- 2回押しても1行のまま／他人の記録にならない
- 🔴 **アカウントを消すと同意の記録も消える**

## 確認したこと

ローカルで通した。**確認画面 → 規約を読む → 同意 → リスト → 開き直しても出ない。**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
