### PR TITLE
規約の制定日を 2026-09-01 にする

### DIFF
--- a/packages/shared/src/service.ts
+++ b/packages/shared/src/service.ts
@@ -64,7 +64,7 @@ export const CONTACT_FORM_URL = 'https://forms.gle/B4ZPTdQife4LfHJt5'
  * それがこの仕組みの目的なので、**軽い直しで動かさないこと**
  * （誤字の修正で全員に同意を求め直すのは筋が悪い）。
  */
-export const LEGAL_EFFECTIVE_DATE = '2026-08-21'
+export const LEGAL_EFFECTIVE_DATE = '2026-09-01'
 
 /** `2026-08-21` → `2026年8月21日`。**画面に出すのはこちら。** */
 export function formatLegalDate(value: string): string {


### PR DESCRIPTION
関連: #304 / #319

## やったこと

`LEGAL_EFFECTIVE_DATE` を `2026-08-21` → **`2026-09-01`** に。
**ページが本番に出たのは 9/1** なので、そちらに合わせる。

## 🔴 いま変えるのが一番安い

この定数を動かすと、**その版に同意していない人全員に確認画面が出る**（#319 の仕組み）。

本番の `agreements` を数えたところ **0 件**だったので、**聞き直しになる人はいない。**

```
select count(*) as agreed from agreements  →  0
```

⚠️ **同意が貯まってから動かすと、全員がもう一度通る。**
定数のコメントに書いてあるとおり、**誤字の修正では動かさないこと。**

## テスト

686 件中 686 件が緑。typecheck / lint / format:check も緑。
**表示（`2026年9月1日`）は定数から作っている**ので、直す場所は1箇所だけ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
