### PR TITLE
共有ページのテストを、項目の一覧だけ見るようにする（#322）

### DIFF
--- a/apps/web/test/share-page.test.ts
+++ b/apps/web/test/share-page.test.ts
@@ -16,6 +16,21 @@ import { createTestUser, testBaseUrl, testDb } from './helpers'
 const request = (path: string) => exports.default.fetch(new Request(`${testBaseUrl()}${path}`))
 
 /** 公開範囲を指定してリストを1つ作る。 */
+/**
+ * 項目の一覧の部分だけを取り出す（#322）。
+ *
+ * 🔴 **ページ全体から年を探さない。** 共有ページには **OGP 画像の URL** が入っていて、
+ * そこに**更新日時がミリ秒で載っている**（`ogImageUrl`。キャッシュ破棄のため）。
+ * エポックミリ秒の数字の並びに**偶然 `2026` が含まれる瞬間**があり、
+ * **時刻によってだけ落ちるテスト**になっていた。
+ *
+ * 見たいのは「**伏せた項目の行に、いつ叶えたかが出ていないこと**」なので、
+ * 一覧の中だけを見る。
+ */
+function itemsHtml(body: string): string {
+  return body.slice(body.indexOf('<ol'), body.indexOf('</ol>'))
+}
+
 async function createList(options: {
   visibility: 'private' | 'unlisted' | 'public'
   title?: string
@@ -468,9 +483,9 @@ describe('見えてはいけないもの', () => {
         },
       ])
 
-      const body = await (await request(`/share/${list.shareId}`)).text()
-
-      expect(body).not.toContain('2026')
+      expect(itemsHtml(await (await request(`/share/${list.shareId}`)).text())).not.toContain(
+        '2026',
+      )
     })
 
     // 🔴 粒度も伏せる（#279）。「2026年」だけでも「いつ」の情報
@@ -488,7 +503,7 @@ describe('見えてはいけないもの', () => {
       const body = await (await request(`/share/${list.shareId}`)).text()
 
       expect(body).toContain('1 / 1 達成')
-      expect(body).not.toContain('2026')
+      expect(itemsHtml(body)).not.toContain('2026')
     })
 
     it('隠していない項目は今までどおり本文と完了日時が出る（回帰確認）', async () => {


### PR DESCRIPTION
Closes #322

## やったこと

**時刻によってだけ落ちるテスト**を直した（#300 と同じ種類）。**私の変更とは無関係に `main` にあったもの。**

```ts
const body = await (await request(`/share/${list.shareId}`)).text()
expect(body).not.toContain('2026')   // ← ページ全体を見ていた
```

共有ページには **OGP 画像の URL** が入っていて、そこに**更新日時がミリ秒**で載っている
（`ogImageUrl`。キャッシュ破棄のため）。

```
/og/<shareId>?v=1788228572026
                      ^^^^ ここに 2026 が並ぶ
```

エポックミリ秒の数字に**偶然 `2026` が含まれる瞬間**に落ちる。
`shareId`（ランダムな16進32文字）も同じ理由で踏みうる。

🔴 **本番の挙動は正しい。** 直したのはテストの見方。

## 直し方

見たいのは「**伏せた項目の行に、いつ叶えたかが出ていないこと**」なので、
**項目の一覧の中だけ**を見る（`itemsHtml`）。同じ節の「年だけの完了」も揃えた。

## 🔴 緩めすぎていないことを確かめた

伏せる処理を外すと、**両方ちゃんと落ちる。**

```
completedAt の伏せを外す
  → × 隠した項目の完了日時は出ない
  → × 隠した項目は、年だけの完了でも年が出ない
```

⚠️ **1回目は落ちなかった。** `completedPrecision` だけ外しても、
**日付は `completedAt` から描いている**ので漏れない。**両方外して初めて漏れる。**
伏せる処理が2つあることの確認にもなった。

## テスト

686 件中 686 件が緑。typecheck / lint / format:check も緑。**テストだけの変更。**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
