### PR TITLE
同意の確認で全文を出し、チェックしてから進めるようにする

### DIFF
--- a/apps/web/src/client/AgreementGate.tsx
+++ b/apps/web/src/client/AgreementGate.tsx
@@ -1,12 +1,17 @@
 import { useState } from 'react'
-import { Link } from 'wouter'
+
+import { PrivacyPage } from './PrivacyPage'
+import { TermsPage } from './TermsPage'
 
 /**
- * 規約とポリシーの確認（#319）。**同意の記録が無い人にだけ出す。**
+ * 規約とポリシーの確認（#319 / #322）。**同意の記録が無い人にだけ出す。**
  *
- * 🔴 **全文を出さない。** 出しても読まれない。
- * **知らずに使うと困ることだけ**を並べて、全文はリンクにする。
- * 一番効くのは「**全体に公開すると、他の人に取り入れられる**」。
+ * 🔴 **要約を置かない**（2026-09-01 の利用者の判断）。
+ * 最初は要点3つを並べていたが、**中身を更新したときに要約だけ古くなる。**
+ * ずれても気づける仕組みが無い以上、**全文をそのまま出す**方が安全。
+ *
+ * 🔴 **同じ本文を2箇所に書かない。** `/terms` と `/privacy` の中身を
+ * **そのまま読み込んで**枠の中に出す。片方だけ直す事故が起きない。
  *
  * 🔴 **「同意しない」の出口を必ず置く。** ログアウトしてトップへ戻る。
  * **このアプリは未ログインでも書ける**ので、断っても何も失わない。
@@ -21,6 +26,7 @@ export function AgreementGate({
   onAgree: () => Promise<void>
   onDecline: () => void
 }) {
+  const [checked, setChecked] = useState(false)
   const [sending, setSending] = useState(false)
   const [failed, setFailed] = useState(false)
 
@@ -42,29 +48,36 @@ export function AgreementGate({
       <h1 className="text-lg font-bold text-slate-900">はじめる前に</h1>
 
       <p className="mt-3 text-sm leading-6 text-slate-600">
-        利用規約とプライバシーポリシーを用意しました。要点は次の3つです。
+        利用規約とプライバシーポリシーを確認してください。
       </p>
 
-      <ul className="mt-4 flex flex-col gap-2">
-        <Point>書いたものは、あなたのものです</Point>
-        <Point>
-          <strong className="font-bold text-slate-900">「全体に公開」にしたやりたいこと</strong>
-          は、作者を伏せた形で「さがす」に並び、ほかの人が自分のリストに取り入れられます
-        </Point>
-        <Point>アカウントはいつでも削除できます。書いたものもすべて消えます</Point>
-      </ul>
+      {/*
+        🔴 **枠の中だけを流す。** 画面ごと長くすると、
+        **同意のチェックとボタンが下に押し出されて見えなくなる。**
 
-      <p className="mt-4 text-sm leading-6 text-slate-600">
-        全文は
-        <Link href="/terms" className="font-bold text-brand-deep underline">
-          利用規約
-        </Link>
-        と
-        <Link href="/privacy" className="font-bold text-brand-deep underline">
-          プライバシーポリシー
-        </Link>
-        をご覧ください。
-      </p>
+        ⚠️ 高さは `50dvh`。電話の縦幅の半分で、**枠の下に何があるかが見えている**
+        （チェックとボタンが同時に視界に入る）
+      */}
+      <div className="mt-4 max-h-[50dvh] overflow-y-auto rounded border border-brand bg-brand-soft px-4 py-2">
+        <TermsPage heading="h2" />
+        <PrivacyPage heading="h2" />
+      </div>
+
+      {/*
+        🔴 **押させる前に、押した意味を明示する。**
+        ボタンだけだと「読んだ」のか「同意した」のかが曖昧になる
+      */}
+      <label className="mt-4 flex cursor-pointer items-start gap-2 text-sm leading-6 text-slate-700">
+        <input
+          type="checkbox"
+          checked={checked}
+          onChange={(event) => {
+            setChecked(event.target.checked)
+          }}
+          className="mt-1.5 shrink-0"
+        />
+        <span>利用規約とプライバシーポリシーに同意します</span>
+      </label>
 
       {failed && (
         <p role="alert" className="mt-3 text-sm text-brand-deep">
@@ -72,11 +85,15 @@ export function AgreementGate({
         </p>
       )}
 
+      {/*
+        ⚠️ **チェックするまで押せない。**
+        `disabled` にしているので、押しても何も起きない状態は作らない
+      */}
       <button
         type="button"
-        disabled={sending}
+        disabled={!checked || sending}
         onClick={agree}
-        className="mt-5 w-full rounded-lg bg-brand-deep px-3 py-3 font-bold text-white disabled:opacity-50"
+        className="mt-4 w-full rounded-lg bg-brand-deep px-3 py-3 font-bold text-white disabled:opacity-50"
       >
         同意して始める
       </button>
@@ -89,13 +106,5 @@ export function AgreementGate({
         同意しない（ログアウトする）
       </button>
     </div>
-  )
-}
-
-function Point({ children }: { children: React.ReactNode }) {
-  return (
-    <li className="rounded-lg bg-brand-soft px-3 py-3 text-sm leading-6 text-slate-700">
-      {children}
-    </li>
   )
 }

--- a/apps/web/src/client/LegalPage.tsx
+++ b/apps/web/src/client/LegalPage.tsx
@@ -61,10 +61,26 @@ export function LegalRecords({
   )
 }
 
-export function LegalPage({ title, children }: { title: string; children: React.ReactNode }) {
+export function LegalPage({
+  title,
+  heading = 'h1',
+  children,
+}: {
+  title: string
+  /**
+   * 見出しの段（#322）。
+   *
+   * 🔴 **同意の確認画面（`AgreementGate`）の中にも同じ本文を出す。**
+   * あちらでは画面の見出しが別にあるので、**`h1` が2つにならないよう `h2` にする。**
+   */
+  heading?: 'h1' | 'h2'
+  children: React.ReactNode
+}) {
+  const Heading = heading
+
   return (
     <div className="pb-8">
-      <h1 className="text-xl font-bold text-slate-900">{title}</h1>
+      <Heading className="text-xl font-bold text-slate-900">{title}</Heading>
 
       {children}
 

--- a/apps/web/src/client/PrivacyPage.tsx
+++ b/apps/web/src/client/PrivacyPage.tsx
@@ -24,9 +24,9 @@ import { LegalHeading, LegalList, LegalPage, LegalRecords, LegalText } from './L
  * 委託先の名前は求めに応じて開示する形にしているが、
  * **自動で判定していること**と**第三者の閲覧で本文が外に出ること**は書く。
  */
-export function PrivacyPage() {
+export function PrivacyPage({ heading }: { heading?: 'h1' | 'h2' } = {}) {
   return (
-    <LegalPage title="プライバシーポリシー">
+    <LegalPage title="プライバシーポリシー" heading={heading ?? 'h1'}>
       <LegalText>
         「やりたいことリスト100」（以下「本サービス」）における個人情報の取り扱いについて定めます。
       </LegalText>

--- a/apps/web/src/client/TermsPage.tsx
+++ b/apps/web/src/client/TermsPage.tsx
@@ -19,9 +19,9 @@ import { LegalHeading, LegalList, LegalPage, LegalText } from './LegalPage'
  * 「一切の責任を負わない」と書くと**無効になりうる**ので、
  * 故意・重過失を除く形にしてある。**軽くしようとして書き換えないこと。**
  */
-export function TermsPage() {
+export function TermsPage({ heading }: { heading?: 'h1' | 'h2' } = {}) {
   return (
-    <LegalPage title="利用規約">
+    <LegalPage title="利用規約" heading={heading ?? 'h1'}>
       <LegalText>
         この規約は「やりたいことリスト100」（以下「本サービス」）の利用条件を定めるものです。
         本サービスを利用した時点で、この規約に同意したものとみなします。


### PR DESCRIPTION
関連: #319

2026-09-01 の利用者の指示。**要約をやめて全文を出し、同意のチェックを挟む。**

| 全文をスクロール | チェックすると押せる |
|---|---|
| <img src="https://raw.githubusercontent.com/aiandrox/yaritai100list/previews/324-gate.png" width="300"> | <img src="https://raw.githubusercontent.com/aiandrox/yaritai100list/previews/324-checked.png" width="300"> |

## 🔴 要約を置かない

最初は要点3つを並べていたが、やめた。

**中身を更新したときに、要約だけ古くなる。** ずれても気づける仕組みが無い以上、
**全文をそのまま出す**方が安全（利用者の判断）。

## 🔴 同じ本文を2箇所に書かない

`/terms` と `/privacy` の中身を**そのまま読み込んで**枠に出す。
片方だけ直す事故が起きない。

見出しの段だけ差し替えられるようにした（`heading="h2"`）。
**画面の見出しと合わせて `h1` が2つにならないように。**

## 判断したこと

- **枠の中だけを流す**（`max-h-[50dvh]`）。画面ごと長くすると、
  **チェックとボタンが下に押し出されて見えなくなる**
- **チェックするまでボタンを `disabled` に。** 押しても何も起きない状態は作らない
- **文言を「確認してください」に。** 「用意しました」だと、読む必要があると伝わらない

## テスト

686 件中 686 件が緑。typecheck / lint / format:check も緑。
**画面の組み立てなので、増やしたテストは無い**（判断を1つも足していない）。

## 確認したこと

ローカルで通した。

| | 結果 |
|---|---|
| 見出し | `h1` は「はじめる前に」の1つだけ（枠の中は `h2`） |
| 枠 | スクロールする（`scrollHeight > clientHeight`） |
| 中身 | 利用規約の全9条＋プライバシーポリシーの全10条が入っている |
| チェック前 | ボタンは押せない |
| チェック後 | 押せる → 同意が記録され、リストへ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
