### PR TITLE
同意の確認を閉じられないモーダルにし、未同意の新規は残さない

### DIFF
--- a/apps/web/src/client/AgreementGate.tsx
+++ b/apps/web/src/client/AgreementGate.tsx
@@ -1,20 +1,20 @@
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import { PrivacyPage } from './PrivacyPage'
 import { TermsPage } from './TermsPage'
 
 /**
- * 規約とポリシーの確認（#319 / #322）。**同意の記録が無い人にだけ出す。**
+ * 規約とポリシーの確認（#319 / #325）。**同意の記録が無い人にだけ出す。**
  *
- * 🔴 **要約を置かない**（2026-09-01 の利用者の判断）。
- * 最初は要点3つを並べていたが、**中身を更新したときに要約だけ古くなる。**
- * ずれても気づける仕組みが無い以上、**全文をそのまま出す**方が安全。
+ * 🔴 **閉じられないモーダルにする**（2026-09-01 の利用者の指示）。
+ * 画面の一番手前に出し、**背景を押しても Esc でも閉じない。**
+ * どの画面を直接開いても、同意するまでこれが手前にある。
+ *
+ * 🔴 **要約を置かない。** 中身を更新したときに**要約だけ古くなる。**
+ * ずれても気づける仕組みが無い以上、全文をそのまま出す。
  *
  * 🔴 **同じ本文を2箇所に書かない。** `/terms` と `/privacy` の中身を
- * **そのまま読み込んで**枠の中に出す。片方だけ直す事故が起きない。
- *
- * 🔴 **「同意しない」の出口を必ず置く。** ログアウトしてトップへ戻る。
- * **このアプリは未ログインでも書ける**ので、断っても何も失わない。
+ * **そのまま読み込んで**枠に出す。片方だけ直す事故が起きない。
  *
  * ⚠️ **これは認可の仕組みではない。** 押させるための画面であって、
  * API を守るものではない（守るのは `requireUser` と `requireOwnedList`）。
@@ -22,13 +22,25 @@ import { TermsPage } from './TermsPage'
 export function AgreementGate({
   onAgree,
   onDecline,
+  declineLabel,
 }: {
   onAgree: () => Promise<void>
   onDecline: () => void
+  /** 断ったときに何が起きるかは、新規か既存かで変わる（`App` が文言を決める） */
+  declineLabel: string
 }) {
+  const dialog = useRef<HTMLDialogElement>(null)
   const [checked, setChecked] = useState(false)
   const [sending, setSending] = useState(false)
   const [failed, setFailed] = useState(false)
+
+  // 出したら開きっぱなし。**閉じる経路を作らない**
+  useEffect(() => {
+    if (!dialog.current?.open) dialog.current?.showModal()
+  }, [])
+
+  // 開いている間は背景を動かさない（`Modal.tsx` と同じ）
+  useEffect(() => () => void (document.body.style.overflow = ''), [])
 
   const agree = () => {
     setSending(true)
@@ -44,67 +56,108 @@ export function AgreementGate({
   }
 
   return (
-    <div className="mx-auto max-w-md rounded-lg bg-white px-5 py-6">
-      <h1 className="text-lg font-bold text-slate-900">はじめる前に</h1>
+    <dialog
+      ref={dialog}
+      aria-labelledby="agreement-title"
+      /*
+       * 🔴 **閉じさせない。**
+       * - `onCancel` を止めると **Esc で閉じない**
+       * - 背景を押しても閉じる処理を**書かない**（`Modal.tsx` とはここが違う）
+       * - × も「あとで」も置かない。**決めるまで進めない**
+       */
+      onCancel={(event) => {
+        event.preventDefault()
+      }}
+      onToggle={(event) => {
+        document.body.style.overflow = event.currentTarget.open ? 'hidden' : ''
+      }}
+      className="m-auto w-[calc(100%-1.5rem)] max-w-(--page-max-width) rounded-xl bg-white p-0 text-slate-900 backdrop:bg-slate-900/60"
+    >
+      <div className="max-h-[92dvh] overflow-y-auto px-4 py-5">
+        <h1 id="agreement-title" className="text-lg font-bold text-slate-900">
+          はじめる前に
+        </h1>
 
-      <p className="mt-3 text-sm leading-6 text-slate-600">
-        利用規約とプライバシーポリシーを確認してください。
-      </p>
-
-      {/*
-        🔴 **枠の中だけを流す。** 画面ごと長くすると、
-        **同意のチェックとボタンが下に押し出されて見えなくなる。**
-
-        ⚠️ 高さは `50dvh`。電話の縦幅の半分で、**枠の下に何があるかが見えている**
-        （チェックとボタンが同時に視界に入る）
-      */}
-      <div className="mt-4 max-h-[50dvh] overflow-y-auto rounded border border-brand bg-brand-soft px-4 py-2">
-        <TermsPage heading="h2" />
-        <PrivacyPage heading="h2" />
-      </div>
-
-      {/*
-        🔴 **押させる前に、押した意味を明示する。**
-        ボタンだけだと「読んだ」のか「同意した」のかが曖昧になる
-      */}
-      <label className="mt-4 flex cursor-pointer items-start gap-2 text-sm leading-6 text-slate-700">
-        <input
-          type="checkbox"
-          checked={checked}
-          onChange={(event) => {
-            setChecked(event.target.checked)
-          }}
-          className="mt-1.5 shrink-0"
-        />
-        <span>利用規約とプライバシーポリシーに同意します</span>
-      </label>
-
-      {failed && (
-        <p role="alert" className="mt-3 text-sm text-brand-deep">
-          記録できませんでした。通信を確かめて、もう一度お試しください
+        <p className="mt-2 text-sm leading-6 text-slate-600">
+          利用規約とプライバシーポリシーを確認してください。
         </p>
-      )}
 
-      {/*
-        ⚠️ **チェックするまで押せない。**
-        `disabled` にしているので、押しても何も起きない状態は作らない
-      */}
-      <button
-        type="button"
-        disabled={!checked || sending}
-        onClick={agree}
-        className="mt-4 w-full rounded-lg bg-brand-deep px-3 py-3 font-bold text-white disabled:opacity-50"
-      >
-        同意して始める
-      </button>
+        {/*
+          🔴 **2つの文書を1つの枠に入れない**（2026-09-01 の利用者の指示）。
+          別々の枠にして、**見出しは枠の外**に置く。
+          1つにまとめると、スクロールしている間**いま何を読んでいるのか分からなくなる。**
+        */}
+        <Document title="利用規約">
+          <TermsPage heading="none" />
+        </Document>
 
-      {/*
-        断る側。**主のボタンと同じ強さにしない**（`ModalDecline` と同じ考え方）。
-        押すとログアウトするので、**何が起きるかを言葉にしておく**
-      */}
-      <button type="button" onClick={onDecline} className="mt-3 w-full py-2 text-sm text-slate-500">
-        同意しない（ログアウトする）
-      </button>
-    </div>
+        <Document title="プライバシーポリシー">
+          <PrivacyPage heading="none" />
+        </Document>
+
+        {/*
+          🔴 **押させる前に、押した意味を明示する。**
+          ボタンだけだと「読んだ」のか「同意した」のかが曖昧になる
+        */}
+        <label className="mt-4 flex cursor-pointer items-start gap-2 text-sm leading-6 text-slate-700">
+          <input
+            type="checkbox"
+            checked={checked}
+            onChange={(event) => {
+              setChecked(event.target.checked)
+            }}
+            className="mt-1.5 shrink-0"
+          />
+          <span>利用規約とプライバシーポリシーに同意します</span>
+        </label>
+
+        {failed && (
+          <p role="alert" className="mt-3 text-sm text-brand-deep">
+            記録できませんでした。通信を確かめて、もう一度お試しください
+          </p>
+        )}
+
+        {/* ⚠️ **チェックするまで押せない。** 押しても何も起きない状態は作らない */}
+        <button
+          type="button"
+          disabled={!checked || sending}
+          onClick={agree}
+          className="mt-4 w-full rounded-lg bg-brand-deep px-3 py-3 font-bold text-white disabled:opacity-50"
+        >
+          同意して始める
+        </button>
+
+        {/*
+          断る側。**主のボタンと同じ強さにしない。**
+          🔴 **何が起きるかを言葉にする。** 新規はアカウントごと消えるので、
+          既存（ログアウトするだけ）と同じ文言にしてはいけない
+        */}
+        <button
+          type="button"
+          onClick={onDecline}
+          className="mt-3 w-full py-2 text-sm text-slate-500"
+        >
+          {declineLabel}
+        </button>
+      </div>
+    </dialog>
+  )
+}
+
+/**
+ * 1つの文書。**見出しは枠の外、本文だけが枠の中で流れる。**
+ *
+ * ⚠️ 高さは `30dvh`。**2つ並ぶ**ので、
+ * **チェックとボタンが画面の下に押し出されない**大きさにしてある。
+ */
+function Document({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="mt-4">
+      <h2 className="text-sm font-bold text-slate-900">{title}</h2>
+
+      <div className="mt-1 max-h-[30dvh] overflow-y-auto rounded border border-brand bg-brand-soft px-3 py-2">
+        {children}
+      </div>
+    </section>
   )
 }

--- a/apps/web/src/client/App.tsx
+++ b/apps/web/src/client/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { Link, Route, Switch, useLocation } from 'wouter'
 
 import { AgreementGate } from './AgreementGate'
@@ -24,16 +24,15 @@ import { signOutRequestInit, toSessionState, type SessionState } from './model'
  * **`/lists/xxx` を直接開いてもこの SPA が起動する。**
  */
 /**
- * 同意の確認より先に開けるページ（#319）。
+ * ログイン直後の読み込みに付く印（#325）。**`/api/login/google` が付ける。**
  *
- * 🔴 **規約とポリシーを塞がない。** ここを通さないと、
- * **確認画面から全文を読みに行けない**（読ませるための画面なのに読めない）。
- * 実際に一度そうなった。
+ * 🔴 **読んだらすぐ URL から消す。** 消さないとリロードでも残ってしまい、
+ * 「**リロードしたら初回ではない**」という判定が効かなくなる。
  */
-const LEGAL_PATHS = new Set(['/terms', '/privacy'])
+const WELCOME_PARAM = 'welcome'
 
 export function App() {
-  const [location, navigate] = useLocation()
+  const [, navigate] = useLocation()
   const [session, setSession] = useState<SessionState>({ status: 'loading' })
   const [signOutFailed, setSignOutFailed] = useState(false)
 
@@ -69,6 +68,45 @@ export function App() {
    */
   const [agreement, setAgreement] = useState<'unknown' | 'agreed' | 'required'>('unknown')
 
+  /**
+   * 断ったときにアカウントごと捨てるか（#325）。
+   *
+   * 🔴 **規約ができた後に登録した人だけ捨てる。** まだ何も書いていないため。
+   * **前から居る人は捨てない**（データがある）。断ってもログアウトするだけ。
+   */
+  const [discardable, setDiscardable] = useState(false)
+
+  /**
+   * この読み込みがログイン直後か（#325）。
+   *
+   * 🔴 **すぐ URL から消す。** 残すとリロードでも「初回」に見えてしまう。
+   * **消した後の状態が「リロードした後」と同じ**になるのが要点。
+   */
+  const justSignedIn = useRef(false)
+
+  useEffect(() => {
+    const url = new URL(window.location.href)
+    if (!url.searchParams.has(WELCOME_PARAM)) return
+
+    justSignedIn.current = true
+    url.searchParams.delete(WELCOME_PARAM)
+    window.history.replaceState(null, '', `${url.pathname}${url.search}${url.hash}`)
+  }, [])
+
+  /**
+   * アカウントごと捨てて、未ログインの状態に戻す（#325）。
+   *
+   * ⚠️ **画面を開き直す。** セッションごと消えているので、
+   * React の state を1つずつ戻すより確実（アカウント削除と同じ）。
+   */
+  const discardAccount = useCallback(async () => {
+    try {
+      await api.api.account.$delete()
+    } finally {
+      window.location.href = '/'
+    }
+  }, [])
+
   useEffect(() => {
     if (session.status !== 'authenticated') {
       setAgreement('unknown')
@@ -84,12 +122,29 @@ export function App() {
         }
 
         const body = await res.json()
-        setAgreement(body.agreed ? 'agreed' : 'required')
+        if (body.agreed) {
+          setAgreement('agreed')
+          return
+        }
+
+        setDiscardable(body.joinedAfterTerms)
+
+        /*
+         * 🔴 **同意しないまま読み込み直したら、アカウントごと捨てる**（#325）。
+         * 対象は規約ができた後に登録した人で、**まだ何も書いていない。**
+         * ログイン直後の1回だけモーダルを出し、そこで決めてもらう。
+         */
+        if (body.joinedAfterTerms && !justSignedIn.current) {
+          await discardAccount()
+          return
+        }
+
+        setAgreement('required')
       } catch {
         setAgreement('agreed')
       }
     })()
-  }, [session.status])
+  }, [session.status, discardAccount])
 
   const agree = useCallback(async () => {
     const res = await api.api.account.agree.$post()
@@ -121,80 +176,78 @@ export function App() {
       <SessionArea session={session} onRetry={() => void loadSession()} />
 
       {/*
-        規約の確認（#319）。**同意するまで先へ進ませない。**
-        ⚠️ **聞いている最中（`unknown`）は何も出さない。** 出すと、
-        同意が要る人に一瞬リストが見えてから画面が入れ替わる
+        規約の確認（#319 / #325）。**画面の一番手前に出す。**
+        🔴 **下の画面を差し替えない。** モーダルなので、どの経路を直接開いても
+        同意するまでこれが手前にある（既存の利用者はログイン状態のまま）
       */}
-      {session.status === 'authenticated' &&
-      agreement !== 'agreed' &&
-      !LEGAL_PATHS.has(location) ? (
-        agreement === 'required' ? (
-          <AgreementGate onAgree={agree} onDecline={() => void signOut()} />
-        ) : (
-          <p className="py-8 text-center text-slate-500">読み込み中</p>
-        )
-      ) : (
-        <Switch>
-          {/* トップは一覧ではなく**最後に更新したリスト**（PRODUCT_SPEC.md §4.3）。
-            リストを1つしか持っていない人に無駄な1タップを作らない */}
-          <Route path="/">
-            <ListPage session={session} />
-          </Route>
+      {session.status === 'authenticated' && agreement === 'required' && (
+        <AgreementGate
+          onAgree={agree}
+          onDecline={() => (discardable ? void discardAccount() : void signOut())}
+          declineLabel={discardable ? '同意しない（登録をやめる）' : '同意しない（ログアウトする）'}
+        />
+      )}
 
-          {/*
+      <Switch>
+        {/* トップは一覧ではなく**最後に更新したリスト**（PRODUCT_SPEC.md §4.3）。
+            リストを1つしか持っていない人に無駄な1タップを作らない */}
+        <Route path="/">
+          <ListPage session={session} />
+        </Route>
+
+        {/*
           取り入れ面（#235 / 親 #10）。**ログインは要らない。**
           書き始める前の人こそ対象なので、ここで認証を求めない
         */}
-          <Route path="/discover">
-            <DiscoverPage session={session} />
-          </Route>
+        <Route path="/discover">
+          <DiscoverPage session={session} />
+        </Route>
 
-          <Route path="/lists">
-            {/* ログアウトはここに置く。日常的に押すものではないので、
+        <Route path="/lists">
+          {/* ログアウトはここに置く。日常的に押すものではないので、
               編集画面には出さない（#114） */}
-            <ListsPage
-              session={session}
-              signOutFailed={signOutFailed}
-              onSignOut={() => void signOut()}
-            />
-          </Route>
+          <ListsPage
+            session={session}
+            signOutFailed={signOutFailed}
+            onSignOut={() => void signOut()}
+          />
+        </Route>
 
-          {/* :listId より先に置かなくても段数が違うので当たらないが、
+        {/* :listId より先に置かなくても段数が違うので当たらないが、
             関係のある経路を近くに並べておく */}
-          <Route path="/lists/:listId/export">
-            {(params) => <ExportPage session={session} listId={params.listId} />}
-          </Route>
+        <Route path="/lists/:listId/export">
+          {(params) => <ExportPage session={session} listId={params.listId} />}
+        </Route>
 
-          <Route path="/lists/:listId/share">
-            {(params) => <SharePage session={session} listId={params.listId} />}
-          </Route>
+        <Route path="/lists/:listId/share">
+          {(params) => <SharePage session={session} listId={params.listId} />}
+        </Route>
 
-          <Route path="/lists/:listId">
-            {(params) => <ListPage session={session} listId={params.listId} />}
-          </Route>
+        <Route path="/lists/:listId">
+          {(params) => <ListPage session={session} listId={params.listId} />}
+        </Route>
 
-          {/*
+        {/*
           規約とポリシー（#304）。**ログインの有無で出し分けない。**
           読むのに何も要らない
         */}
-          <Route path="/terms">
-            <TermsPage />
-          </Route>
+        <Route path="/terms">
+          <TermsPage />
+        </Route>
 
-          <Route path="/privacy">
-            <PrivacyPage />
-          </Route>
+        <Route path="/privacy">
+          <PrivacyPage />
+        </Route>
 
-          <Route>
-            <Notice tone="warn">
-              このページはありません。
-              <Link href="/" className="underline">
-                トップへ戻る
-              </Link>
-            </Notice>
-          </Route>
-        </Switch>
-      )}
+        <Route>
+          <Notice tone="warn">
+            このページはありません。
+            <Link href="/" className="underline">
+              トップへ戻る
+            </Link>
+          </Notice>
+        </Route>
+      </Switch>
     </Layout>
   )
 }

--- a/apps/web/src/client/LegalPage.tsx
+++ b/apps/web/src/client/LegalPage.tsx
@@ -68,19 +68,23 @@ export function LegalPage({
 }: {
   title: string
   /**
-   * 見出しの段（#322）。
+   * 見出しの段（#322 / #325）。
    *
    * 🔴 **同意の確認画面（`AgreementGate`）の中にも同じ本文を出す。**
-   * あちらでは画面の見出しが別にあるので、**`h1` が2つにならないよう `h2` にする。**
+   * あちらは**見出しを枠の外に置く**ので `'none'` を渡す
+   * （枠の中に入れると、スクロールで見出しが流れて何の文書か分からなくなる）。
    */
-  heading?: 'h1' | 'h2'
+  heading?: 'h1' | 'h2' | 'none'
   children: React.ReactNode
 }) {
-  const Heading = heading
-
   return (
     <div className="pb-8">
-      <Heading className="text-xl font-bold text-slate-900">{title}</Heading>
+      {heading !== 'none' &&
+        (heading === 'h1' ? (
+          <h1 className="text-xl font-bold text-slate-900">{title}</h1>
+        ) : (
+          <h2 className="text-xl font-bold text-slate-900">{title}</h2>
+        ))}
 
       {children}
 

--- a/apps/web/src/client/PrivacyPage.tsx
+++ b/apps/web/src/client/PrivacyPage.tsx
@@ -24,7 +24,7 @@ import { LegalHeading, LegalList, LegalPage, LegalRecords, LegalText } from './L
  * 委託先の名前は求めに応じて開示する形にしているが、
  * **自動で判定していること**と**第三者の閲覧で本文が外に出ること**は書く。
  */
-export function PrivacyPage({ heading }: { heading?: 'h1' | 'h2' } = {}) {
+export function PrivacyPage({ heading }: { heading?: 'h1' | 'h2' | 'none' } = {}) {
   return (
     <LegalPage title="プライバシーポリシー" heading={heading ?? 'h1'}>
       <LegalText>

--- a/apps/web/src/client/TermsPage.tsx
+++ b/apps/web/src/client/TermsPage.tsx
@@ -19,7 +19,7 @@ import { LegalHeading, LegalList, LegalPage, LegalText } from './LegalPage'
  * 「一切の責任を負わない」と書くと**無効になりうる**ので、
  * 故意・重過失を除く形にしてある。**軽くしようとして書き換えないこと。**
  */
-export function TermsPage({ heading }: { heading?: 'h1' | 'h2' } = {}) {
+export function TermsPage({ heading }: { heading?: 'h1' | 'h2' | 'none' } = {}) {
   return (
     <LegalPage title="利用規約" heading={heading ?? 'h1'}>
       <LegalText>

--- a/apps/web/src/index.ts
+++ b/apps/web/src/index.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/cloudflare'
 import {
   BROWSABLE_GENRES,
   buildExportFile,
+  COMPLETED_ON_TIME_ZONE_OFFSET_MS,
   type CompletedPrecision,
   completedOnSchema,
   completedPrecisionOf,
@@ -276,7 +277,13 @@ const app = new Hono<AppEnv>()
     const auth = createAuth(createDb(c.env.DB), c.env)
 
     const res = await auth.api.signInSocial({
-      body: { provider: 'google', callbackURL: '/' },
+      /*
+       * 🔴 **ログイン直後かどうかを、戻り先の印で見分ける**（#325）。
+       * 新規の人が同意しないままリロードしたら**アカウントごと捨てる**が、
+       * **初回の読み込みだけはモーダルを出す**必要がある。
+       * 画面側がこの印を読んで、すぐ URL から消す（リロードすると印が無い）。
+       */
+      body: { provider: 'google', callbackURL: '/?welcome=1' },
       asResponse: true,
     })
 
@@ -654,7 +661,27 @@ const app = new Hono<AppEnv>()
       )
       .limit(1)
 
-    return c.json({ agreed: agreed !== undefined } as const)
+    /*
+     * 🔴 **規約ができた後に登録した人か**（#325）。
+     * この人が同意しないなら**アカウントを残さない**（まだ何も書いていない）。
+     * 規約より前から居る人は**消さない**（データがある）。
+     *
+     * ⚠️ **境目は日本時間の 0 時。** 完了日と同じ扱いにする（`COMPLETED_ON_TIME_ZONE_OFFSET_MS`）。
+     */
+    const [user] = await createDb(c.env.DB)
+      .select({ createdAt: users.createdAt })
+      .from(users)
+      .where(eq(users.id, c.get('userId')))
+      .limit(1)
+
+    const termsSince = new Date(
+      Date.parse(`${LEGAL_EFFECTIVE_DATE}T00:00:00.000Z`) - COMPLETED_ON_TIME_ZONE_OFFSET_MS,
+    )
+
+    return c.json({
+      agreed: agreed !== undefined,
+      joinedAfterTerms: user !== undefined && user.createdAt >= termsSince,
+    } as const)
   })
 
   /**

--- a/apps/web/test/agreement-new-user.test.ts
+++ b/apps/web/test/agreement-new-user.test.ts
@@ -1,0 +1,59 @@
+import { exports } from 'cloudflare:workers'
+import { LEGAL_EFFECTIVE_DATE } from '@yaritai100list/shared'
+import { eq } from 'drizzle-orm'
+import { describe, expect, it } from 'vitest'
+
+import { users } from '../src/db/schema'
+import { signIn, testBaseUrl, testDb } from './helpers'
+
+/**
+ * 「規約ができた後に登録した人か」の判定（#325）。
+ *
+ * 🔴 **これで «断ったらアカウントごと捨てる» 相手を決めている。**
+ * 間違えると、**前から使っている人のデータを消しかねない。**
+ *
+ * ⚠️ **境目は日本時間の 0 時**（完了日と同じ扱い）。
+ */
+
+const readAccount = (headers: Headers) =>
+  exports.default.fetch(
+    new Request(`${testBaseUrl()}/api/account`, { headers: Object.fromEntries(headers) }),
+  )
+
+/** 規約の制定日（日本時間の 0 時）の前後1秒 */
+const TERMS_AT = Date.parse(`${LEGAL_EFFECTIVE_DATE}T00:00:00.000Z`) - 9 * 60 * 60 * 1000
+
+const setCreatedAt = (userId: string, at: number) =>
+  testDb()
+    .update(users)
+    .set({ createdAt: new Date(at) })
+    .where(eq(users.id, userId))
+
+describe('joinedAfterTerms', () => {
+  it('🔴 規約より後に登録した人は true（断ったら捨てる相手）', async () => {
+    const me = await signIn('new@example.com')
+    await setCreatedAt(me.userId, TERMS_AT + 1000)
+
+    const body = await (await readAccount(me.headers)).json<{ joinedAfterTerms: boolean }>()
+
+    expect(body.joinedAfterTerms).toBe(true)
+  })
+
+  it('🔴 規約より前から居る人は false（消してはいけない）', async () => {
+    const me = await signIn('old@example.com')
+    await setCreatedAt(me.userId, TERMS_AT - 1000)
+
+    const body = await (await readAccount(me.headers)).json<{ joinedAfterTerms: boolean }>()
+
+    expect(body.joinedAfterTerms).toBe(false)
+  })
+
+  it('🔴 ちょうど境目は「後」に入れる（同じ瞬間を両方に入れない）', async () => {
+    const me = await signIn('edge@example.com')
+    await setCreatedAt(me.userId, TERMS_AT)
+
+    const body = await (await readAccount(me.headers)).json<{ joinedAfterTerms: boolean }>()
+
+    expect(body.joinedAfterTerms).toBe(true)
+  })
+})


### PR DESCRIPTION
関連: #319

2026-09-01 の利用者の指示。

<img src="https://raw.githubusercontent.com/aiandrox/yaritai100list/previews/325-gate.png" width="320">

## 🔴 前提の訂正: 「同意まで保存しない」はできない

**Better Auth が Google のコールバックの時点でユーザー行とセッションを作る。**
`databaseHooks.user.create.before` は**データを書き換えるか、作成を中止するか**だけで、
**後回しにする口が無い**（仮登録の概念も無い）。中止すると**セッションも作られない**ので、
そもそも同意画面を誰に出すのか分からなくなる。

自前でコールバックを受ければ実現できるが、**Better Auth を選んだ理由を捨てる変更**になる
（`TECH_STACK.md` §8「認証を手で書かない」／`CLAUDE.md` のセッションの不変条件）。

**なので「作ってから捨てる」にした。** 観測される動きは指示どおり。

| | 未同意のとき |
|---|---|
| **新規**（規約より後に登録） | モーダル。**断る／リロードでアカウントごと削除**してログアウト |
| **既存**（規約より前から居る） | モーダル。**捨てない**（データがある）。断ればログアウトのみ |

## リロードをどう見分けるか

ログイン後の戻り先に印を付ける（`/?welcome=1`）。
🔴 **画面側が読んだ直後に URL から消す**ので、**リロードすると印が無い** = 初回ではない。

## 閉じられないモーダル

- `onCancel` を止めて **Esc で閉じない**
- 背景を押しても閉じる処理を**書かない**（`Modal.tsx` とはここが違う）
- × も「あとで」も置かない
- 🔴 **下の画面を差し替えない。** どの経路を直接開いても手前に出る（既存はログイン状態のまま）

## 見た目

- **規約とポリシーを別々の枠**にし、**見出しは枠の外**（スクロール中に何の文書か分かる）
- **幅を絞らない**（画面いっぱい）
- 断るボタンの文言を分けた: **「登録をやめる」**（新規）と「ログアウトする」（既存）

## テスト

689 件中 689 件が緑（31 ファイル。+3）。typecheck / lint / format:check も緑。

🔴 **「捨てる相手」を決める判定にテストを置いた。** 間違えると
**前から使っている人のデータを消しかねない**ところなので、境目を固定した。

- 規約より後に登録 → `true` ／ 前から居る → `false` ／ **ちょうど境目は「後」**

## 実物で確認したこと

| | 結果 |
|---|---|
| 新規・ログイン直後 | モーダルが出る／URL から `welcome` が消える |
| **Esc / 背景を押す** | **閉じない** |
| **同意せずリロード** | **ログアウト状態**（アカウントごと削除） |
| 既存が `/lists` を直接開く | モーダルが出る（ログイン状態は保持） |
| 既存がリロード | モーダルのまま、**ログイン状態も保持** |
| 同意した後 | モーダルが消えて進める |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
