### PR TITLE
編集画面でメモを書けるようにする（#297）

### DIFF
--- a/apps/web/src/client/ListEditor.tsx
+++ b/apps/web/src/client/ListEditor.tsx
@@ -5,6 +5,7 @@ import {
   daysInMonth,
   formatCompletedOn,
   isCompleted,
+  ITEM_MEMO_MAX_LENGTH,
   ITEM_TEXT_MAX_LENGTH,
   ITEMS_PER_LIST_MAX,
   LIST_TITLE_MAX_LENGTH,
@@ -55,6 +56,8 @@ interface ListEditorProps {
   onRenameList: (title: string) => Promise<boolean>
   onAddItem: (text: string) => Promise<boolean>
   onUpdateItemText: (id: string, text: string) => Promise<boolean>
+  /** メモを書き換える（#294）。`null` で消す */
+  onChangeMemo: (id: string, memo: string | null) => Promise<boolean>
   onToggleItem: (item: Item) => Promise<boolean>
   /**
    * 完了日を入れる・直す・消す（#207 / #279）。**完了済みの項目にしか使わない。**
@@ -73,6 +76,7 @@ export function ListEditor({
   onRenameList,
   onAddItem,
   onUpdateItemText,
+  onChangeMemo,
   onToggleItem,
   onChangeCompletedOn,
   onRemoveItem,
@@ -97,6 +101,15 @@ export function ListEditor({
    * 「押せない」と「完了済み」が両方成り立つ項目は存在しない。
    */
   const [promptedId, setPromptedId] = useState<string | null>(null)
+
+  /**
+   * メモ欄が開いている行（#294）。**`promptedId` とは別に持つ。**
+   *
+   * 🔴 **こちらは外側を押しても閉じない。** 書いている途中に閉じると、
+   * **書いたものが消えたように見える**（完了の案内は読むだけなので閉じてよい）。
+   * 同じ状態にまとめると、この違いを表せない。
+   */
+  const [memoId, setMemoId] = useState<string | null>(null)
 
   /**
    * 案内の**外側を押したら閉じる**（#83）。閉じ方が「同じ ✓ をもう一度押す」しか
@@ -221,6 +234,12 @@ export function ListEditor({
                   item={slot.item}
                   completion={completion}
                   prompted={promptedId === slot.item.id}
+                  memoOpen={memoId === slot.item.id}
+                  onToggleMemo={() => {
+                    const id = slot.item?.id ?? null
+                    setMemoId((current) => (current === id ? null : id))
+                  }}
+                  onChangeMemo={onChangeMemo}
                   onCommit={onUpdateItemText}
                   onToggle={(item) => {
                     // **できないことを黙って無効化しない。** 無効化だけだと、
@@ -425,6 +444,9 @@ function ItemRow({
   item,
   completion,
   prompted,
+  memoOpen,
+  onToggleMemo,
+  onChangeMemo,
   onCommit,
   onToggle,
   onUncomplete,
@@ -435,6 +457,10 @@ function ItemRow({
   item: Item
   completion: CompletionPermission
   prompted: boolean
+  /** メモ欄が開いているか（#294）。**完了の案内とは別の状態** */
+  memoOpen: boolean
+  onToggleMemo: () => void
+  onChangeMemo: (id: string, memo: string | null) => Promise<boolean>
   onCommit: (id: string, text: string) => Promise<boolean>
   onToggle: (item: Item) => void
   onUncomplete: (item: Item) => void
@@ -442,6 +468,7 @@ function ItemRow({
   onRemove: (id: string) => void
 }) {
   const [draft, setDraft] = useState(item.text)
+  const hasMemo = item.memo !== null
   // 🔴 **完了は粒度で判定する**（#279）。日付なしの完了も「済み」の見た目にする
   const done = isCompleted(item.completedPrecision)
 
@@ -560,6 +587,21 @@ function ItemRow({
         )}
 
         {/*
+          メモ（#294）。**✓ と同じ考え方で、無くてもうっすら出す**（#208）。
+          🔴 **書いてある行だけに出すと、書き足す入口が無くなる。**
+          書いてあるときは濃くして、**どこに書いたかが一覧で分かる**ようにする。
+        */}
+        <button
+          type="button"
+          aria-label={`${number} 番目のメモ${hasMemo ? '（あり）' : ''}`}
+          aria-expanded={memoOpen}
+          onClick={onToggleMemo}
+          className={`shrink-0 px-1 text-sm ${hasMemo ? 'text-brand-deep' : 'text-brand'}`}
+        >
+          ✎
+        </button>
+
+        {/*
           掴む場所（#166）。**行全体を掴めるようにしない。**
           本文を選ぼうとしただけでドラッグが始まってしまう。
 
@@ -590,6 +632,19 @@ function ItemRow({
           ×
         </button>
       </div>
+
+      {/*
+        メモ（#294）。**行の下に開く。**
+        🔴 **閉じている行の高さは変えない**（`PRODUCT_SPEC.md` §4.5）。
+        開いた行だけ背が伸びる
+      */}
+      {memoOpen && (
+        <MemoField
+          value={item.memo}
+          onSave={(memo) => onChangeMemo(item.id, memo)}
+          onClose={onToggleMemo}
+        />
+      )}
 
       {/*
         浮かぶものは2つあるが**同時には出ない**（ListEditor の promptedId の注意書き）。
@@ -943,5 +998,62 @@ function EmptyRow({ number }: { number: string }) {
       <span className="size-6 shrink-0 rounded-full border-2 border-dashed border-brand/50" />
       <span className="flex-1" />
     </li>
+  )
+}
+
+/**
+ * メモの入力欄（#294）。**行の下に開く。**
+ *
+ * 🔴 **離れたときに保存する**（本文の入力欄と同じ）。
+ * 「保存」を押させると、押し忘れて消える。
+ *
+ * ⚠️ **外側を押しただけでは閉じない**（完了の案内とはここが違う）。
+ * 書いている途中に閉じると、**書いたものが消えたように見える。**
+ * 閉じるのは ✎ をもう一度押すか、この中の「閉じる」から。
+ */
+function MemoField({
+  value,
+  onSave,
+  onClose,
+}: {
+  value: string | null
+  onSave: (memo: string | null) => Promise<boolean>
+  onClose: () => void
+}) {
+  const [draft, setDraft] = useState(value ?? '')
+
+  const save = async () => {
+    const next = draft.trim() === '' ? null : draft
+    if (next === value) return
+
+    if (!(await onSave(next))) setDraft(value ?? '')
+  }
+
+  return (
+    <div className="pb-3 pl-8">
+      <textarea
+        value={draft}
+        autoFocus
+        aria-label="メモ"
+        maxLength={ITEM_MEMO_MAX_LENGTH}
+        rows={3}
+        placeholder="なぜやりたいか、叶えたときのことなど"
+        onChange={(event) => {
+          setDraft(event.target.value)
+        }}
+        onBlur={() => void save()}
+        className="w-full rounded border border-brand bg-white px-2 py-1.5 text-sm leading-6 text-slate-900 focus:outline-2 focus:outline-brand-deep"
+      />
+
+      <button
+        type="button"
+        onClick={() => {
+          void save().then(onClose)
+        }}
+        className="mt-1 text-xs text-slate-500 underline"
+      >
+        閉じる
+      </button>
+    </div>
   )
 }

--- a/apps/web/src/client/ListPage.tsx
+++ b/apps/web/src/client/ListPage.tsx
@@ -245,6 +245,7 @@ function ListPageBody({
             onRenameList={controller.renameList}
             onAddItem={controller.addItem}
             onUpdateItemText={controller.updateItemText}
+            onChangeMemo={controller.changeMemo}
             onToggleItem={controller.toggleItem}
             onChangeCompletedOn={controller.changeCompletedOn}
             onRemoveItem={controller.removeItem}

--- a/apps/web/src/client/model.ts
+++ b/apps/web/src/client/model.ts
@@ -17,6 +17,7 @@ import {
   isCompleted,
   ITEM_TEXT_MAX_LENGTH,
   ITEMS_PER_LIST_MAX,
+  itemMemoSchema,
   itemTextSchema,
   LIST_TITLE_MAX_LENGTH,
   listTitleSchema,
@@ -155,6 +156,14 @@ export interface Item {
    * 未ログインのリストでは常に `null`（未ログインでは印を付けられない。#77）。
    */
   completedPrecision: CompletedPrecision | null
+
+  /**
+   * 自分だけが読むメモ（#294）。書いていなければ `null`。
+   *
+   * 🔴 **空文字を持たない。**「書いていない」は `null` 1つで表す
+   * （サーバー側の `itemMemoSchema` が空を `null` に寄せているのと揃える）。
+   */
+  memo: string | null
 }
 
 /**
@@ -227,7 +236,7 @@ export function addItem(list: LocalList, item: { id: string; text: string }): Li
       ...list,
       items: [
         ...list.items,
-        { id: item.id, text: text.data, completedAt: null, completedPrecision: null },
+        { id: item.id, text: text.data, completedAt: null, completedPrecision: null, memo: null },
       ],
     },
   }
@@ -263,6 +272,22 @@ export function setItemCompletion(
   if (!list.items.some((item) => item.id === id)) return { ok: false, reason: 'not-found' }
 
   return { ok: true, list: mapItem(list, id, (item) => ({ ...item, ...completion })) }
+}
+
+/**
+ * メモを書き換える（#294）。**`null` で消す。**
+ *
+ * 🔴 **上限はここで効かせる**（`itemMemoSchema`）。画面側に別の上限を書かない。
+ * ⚠️ **空文字は `null` に寄る**（スキーマがそうしている）。
+ * 「書いていない」の表し方を1つにする。
+ */
+export function setItemMemo(list: LocalList, id: string, memo: string | null): ListResult {
+  if (!list.items.some((item) => item.id === id)) return { ok: false, reason: 'not-found' }
+
+  const parsed = itemMemoSchema.safeParse(memo)
+  if (!parsed.success) return { ok: false, reason: 'text-too-long' }
+
+  return { ok: true, list: mapItem(list, id, (item) => ({ ...item, memo: parsed.data })) }
 }
 
 /**
@@ -647,6 +672,14 @@ const storedListSchema = z.object({
       id: z.string(),
       text: z.string(),
       completedAt: z.number().nullable(),
+
+      /**
+       * メモ（#294）。**古い保存には無いので省略できる。**
+       *
+       * 必須にすると、#294 より前に書いた人の保存が丸ごと `broken` に落ちる
+       * （完了日の粒度と同じ扱い）。
+       */
+      memo: z.string().nullable().optional(),
       /**
        * 完了日の粒度（#279）。**古い保存には無いので省略できる。**
        *
@@ -684,6 +717,8 @@ export function parseStoredList(raw: string | null): StoredListResult {
       items: parsed.data.items.map((item) => ({
         ...item,
         completedPrecision: item.completedPrecision ?? (item.completedAt === null ? null : 'day'),
+        // 🔴 **古い保存にはメモが無い**（#294）。無いだけで壊れていない
+        memo: item.memo ?? null,
       })),
     },
   }
@@ -712,6 +747,8 @@ export interface RemoteItem {
   completedAt: string | null
   /** 完了日の粒度（#279）。**`null` は未完了** */
   completedPrecision: CompletedPrecision | null
+  /** メモ（#294）。書いていなければ `null` */
+  memo: string | null
 }
 
 /**
@@ -762,6 +799,7 @@ export function toLocalList(list: { title: string }, items: RemoteItem[]): Local
       text: item.text,
       completedAt: item.completedAt === null ? null : Date.parse(item.completedAt),
       completedPrecision: item.completedPrecision,
+      memo: item.memo,
     })),
   }
 }

--- a/apps/web/src/client/useList.ts
+++ b/apps/web/src/client/useList.ts
@@ -16,6 +16,7 @@ import {
   NOT_COMPLETED,
   serializeList,
   setItemCompletion,
+  setItemMemo,
   toImportBody,
   toLocalList,
   updateItemText,
@@ -106,6 +107,8 @@ export interface ListController {
   renameList: (title: string) => Promise<boolean>
   addItem: (text: string) => Promise<boolean>
   updateItemText: (id: string, text: string) => Promise<boolean>
+  /** メモを書き換える（#294）。**`null` で消す** */
+  changeMemo: (id: string, memo: string | null) => Promise<boolean>
   toggleItem: (item: Item) => Promise<boolean>
   /**
    * 完了日を入れる・直す・消す（#207 / #279）。**完了済みの項目にしか使えない。**
@@ -477,6 +480,27 @@ export function useList(
         await loadFromServer()
         return false
       }
+    },
+
+    /**
+     * メモを書き換える（#294）。
+     *
+     * ⚠️ **未ログインでも書ける。** 完了（#77）とは違い、ログインの動機にしない。
+     * 保存先が localStorage になるだけで、画面の作りは同じ。
+     */
+    changeMemo: async (itemId, memo) => {
+      if (list === null) return false
+
+      const next = setItemMemo(list, itemId, memo)
+
+      return onServer
+        ? applyOptimistic(next, (id) =>
+            api.api.lists[':listId'].items[':itemId'].$patch({
+              param: { listId: id, itemId },
+              json: { memo },
+            }),
+          )
+        : applyLocal(next)
     },
 
     updateItemText: async (itemId, text) => {

--- a/apps/web/test/client-model.test.ts
+++ b/apps/web/test/client-model.test.ts
@@ -1,5 +1,6 @@
 import {
   DEFAULT_LIST_TITLE,
+  ITEM_MEMO_MAX_LENGTH,
   ITEM_TEXT_MAX_LENGTH,
   ITEMS_PER_LIST_MAX,
   LIST_TITLE_MAX_LENGTH,
@@ -40,6 +41,7 @@ import {
   COMPLETION_WITHOUT_DATE,
   NOT_COMPLETED,
   setItemCompletion,
+  setItemMemo,
   toCompletionPermission,
   toImportBody,
   toLocalList,
@@ -153,7 +155,7 @@ describe('addItem', () => {
     const list = expectOk(addItem(createEmptyList(), { id: 'i1', text: '南極に行く' }))
 
     expect(list.items).toEqual([
-      { id: 'i1', text: '南極に行く', completedAt: null, completedPrecision: null },
+      { id: 'i1', text: '南極に行く', completedAt: null, completedPrecision: null, memo: null },
     ])
   })
 
@@ -230,6 +232,7 @@ describe('updateItemText', () => {
       text: '北極に行く',
       completedAt: 1_700_000_000_000,
       completedPrecision: 'day',
+      memo: null,
     })
   })
 
@@ -394,7 +397,13 @@ describe('toSlots / formatItemNumber / filledCount', () => {
 
     expect(slots[0]).toEqual({
       number: '001',
-      item: { id: 'i1', text: '南極に行く', completedAt: null, completedPrecision: null },
+      item: {
+        id: 'i1',
+        text: '南極に行く',
+        completedAt: null,
+        completedPrecision: null,
+        memo: null,
+      },
     })
     expect(slots[1]).toEqual({ number: '002', item: null })
   })
@@ -456,6 +465,59 @@ describe('pickCurrentListId', () => {
 
   it('1つも無ければ null（呼び出し側が作る）', () => {
     expect(pickCurrentListId([])).toBeNull()
+  })
+})
+
+/**
+ * メモ（#294）。**上限と「空の表し方」をここで固定する。**
+ *
+ * 🔴 **空文字を持たない。**「書いていない」は `null` 1つ。
+ * 2通りあると、画面もサーバーも両方を気にすることになる。
+ */
+describe('setItemMemo', () => {
+  it('メモを書ける', () => {
+    const list = expectOk(setItemMemo(listOf('南極に行く'), 'i1', '寒そう'))
+
+    expect(list.items[0]?.memo).toBe('寒そう')
+  })
+
+  it('null で消せる', () => {
+    const written = expectOk(setItemMemo(listOf('南極に行く'), 'i1', '寒そう'))
+
+    expect(expectOk(setItemMemo(written, 'i1', null)).items[0]?.memo).toBeNull()
+  })
+
+  it('🔴 空白だけなら null に寄る', () => {
+    const list = expectOk(setItemMemo(listOf('南極に行く'), 'i1', '\u3000 '))
+
+    expect(list.items[0]?.memo).toBeNull()
+  })
+
+  it('🔴 上限を超えたら断る（画面側に別の上限を書かない）', () => {
+    const justFits = 'あ'.repeat(ITEM_MEMO_MAX_LENGTH)
+    const tooLong = 'あ'.repeat(ITEM_MEMO_MAX_LENGTH + 1)
+
+    expect(expectOk(setItemMemo(listOf('南極に行く'), 'i1', justFits)).items[0]?.memo).toBe(
+      justFits,
+    )
+    expect(setItemMemo(listOf('南極に行く'), 'i1', tooLong)).toEqual({
+      ok: false,
+      reason: 'text-too-long',
+    })
+  })
+
+  it('無い ID なら not-found', () => {
+    expect(setItemMemo(listOf('南極に行く'), 'nope', 'x')).toEqual({
+      ok: false,
+      reason: 'not-found',
+    })
+  })
+
+  it('元のリストを書き換えない', () => {
+    const before = listOf('南極に行く')
+    setItemMemo(before, 'i1', '寒そう')
+
+    expect(before.items[0]?.memo).toBeNull()
   })
 })
 
@@ -724,10 +786,17 @@ describe('toLocalList', () => {
         text: '南極に行く',
         completedAt: '2026-08-07T00:00:00.000Z',
         completedPrecision: 'day',
+        memo: null,
       },
-      { id: 'i2', text: 'オーロラを見る', completedAt: null, completedPrecision: null },
+      { id: 'i2', text: 'オーロラを見る', completedAt: null, completedPrecision: null, memo: null },
       // 日付なしの完了（#279）。**日時が無いまま完了として渡ってくる**
-      { id: 'i3', text: '富士山に登る', completedAt: null, completedPrecision: 'unknown' },
+      {
+        id: 'i3',
+        text: '富士山に登る',
+        completedAt: null,
+        completedPrecision: 'unknown',
+        memo: null,
+      },
     ])
 
     expect(list).toEqual({
@@ -738,17 +807,42 @@ describe('toLocalList', () => {
           text: '南極に行く',
           completedAt: Date.parse('2026-08-07T00:00:00.000Z'),
           completedPrecision: 'day',
+          memo: null,
         },
-        { id: 'i2', text: 'オーロラを見る', completedAt: null, completedPrecision: null },
-        { id: 'i3', text: '富士山に登る', completedAt: null, completedPrecision: 'unknown' },
+        {
+          id: 'i2',
+          text: 'オーロラを見る',
+          completedAt: null,
+          completedPrecision: null,
+          memo: null,
+        },
+        {
+          id: 'i3',
+          text: '富士山に登る',
+          completedAt: null,
+          completedPrecision: 'unknown',
+          memo: null,
+        },
       ],
     })
   })
 
   it('🔴 並べ替えない（並び順の情報源をサーバーに1本化する）', () => {
     const list = toLocalList({ title: 'x' }, [
-      { id: 'i2', text: '2番目に入っている', completedAt: null, completedPrecision: null },
-      { id: 'i1', text: '1番目に入っている', completedAt: null, completedPrecision: null },
+      {
+        id: 'i2',
+        text: '2番目に入っている',
+        completedAt: null,
+        completedPrecision: null,
+        memo: null,
+      },
+      {
+        id: 'i1',
+        text: '1番目に入っている',
+        completedAt: null,
+        completedPrecision: null,
+        memo: null,
+      },
     ])
 
     expect(list.items.map((item) => item.id)).toEqual(['i2', 'i1'])


### PR DESCRIPTION
Closes #297

親: #294。データと API（#296）は本番にあるが、**書く画面が無かった。**

| 閉じているとき | 開いたとき |
|---|---|
| <img src="https://raw.githubusercontent.com/aiandrox/yaritai100list/previews/297-closed.png" width="320"> | <img src="https://raw.githubusercontent.com/aiandrox/yaritai100list/previews/297-open.png" width="320"> |

## やったこと

- 行の **✎** から下に開く
- 🔴 **閉じている行の高さは変えない**（`PRODUCT_SPEC.md` §4.5。100 の枠を崩さない）
- **書いてある行は印を濃くする。** どこに書いたか一覧で分かる
- **未ログインでも書ける**（完了 #77 とは違い、ログインの動機にしない）

## 判断したこと

- 🔴 **✎ は書いていない行にも出す**（`text-brand` でうっすら）。
  **書いてある行だけに出すと、書き足す入口が無くなる。**
  未完了でも ✓ をうっすら出す（#208）のと同じ考え方
- 🔴 **メモ欄は「外側を押しただけ」では閉じない。**
  完了の案内（`promptedId`）は読むだけなので外側で閉じてよいが、
  **書いている途中に閉じると、書いたものが消えたように見える。**
  状態を分けたのはこの違いを表すため
- **離れたときに保存する**（本文の入力欄と同じ）。「保存」を押させると押し忘れる
- **上限は `itemMemoSchema`。** 画面側に別の上限を書かない

## localStorage

`storedListSchema` に足したが、**省略できる**ようにした。
必須にすると **#294 より前に書いた人の保存が丸ごと `broken` に落ちる**（粒度 #279 と同じ扱い）。

## テスト

695 件中 695 件が緑（31 ファイル。+6）。typecheck / lint / format:check も緑。

`setItemMemo` に置いた判断:

- 書ける／`null` で消せる
- 🔴 **空白だけなら `null` に寄る**（「書いていない」の表し方を1つにする）
- 🔴 上限を超えたら断る／無い ID は `not-found`／元のリストを書き換えない

## 実物で確認したこと

未ログイン（localStorage）で通した。

| | 結果 |
|---|---|
| ✎ で開く | メモ欄が出る |
| 閉じる | 印が濃くなる（メモあり） |
| 🔴 閉じている行の高さ | **書く前と同じ** |
| リロード | **書いた内容が残っている** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
